### PR TITLE
chore: Use permissions `write-all` for release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
+    permissions: write-all
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
## What changed?
More permissions changes for the release CI.

## Why?
Still failing.