### PR TITLE
chore: Bump tag on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,5 +34,6 @@ jobs:
         uses: changesets/action@v1
         with:
           title: 'ci: Release'
+          publish: pnpm changeset tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed?
- Generate a new tag for the repo when published.

## Why?
- Display a nicer changelog for visitors.