### PR TITLE
fix: Resolve web manifest console error

### DIFF
--- a/.changeset/wicked-llamas-explain.md
+++ b/.changeset/wicked-llamas-explain.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix web manifest console error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Create release pull request
+      - name: Create release pull request or bump version tag
         uses: changesets/action@v1
         with:
           title: 'ci: Release'

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="manifest" crossorigin="use-credentials" href="/manifest.webmanifest" />
     <title>Namesake</title>
   </head>
   <body>


### PR DESCRIPTION
## What changed?
Add `crossorigin="use-credentials"` for the webmanifest to resolve a console error.