### PR TITLE
feat: Display app version in settings page

### DIFF
--- a/.changeset/good-scissors-drum.md
+++ b/.changeset/good-scissors-drum.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Display version number on the settings page

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -8,6 +8,7 @@ import { api } from "../../../convex/_generated/api";
 import {
   Button,
   Container,
+  Link,
   Modal,
   PageHeader,
   Switch,
@@ -28,6 +29,7 @@ export const Route = createFileRoute("/settings/")({
 function SettingsRoute() {
   const { signOut } = useAuthActions();
   const user = useQuery(api.users.getCurrentUser);
+  const version = "APP_VERSION";
 
   // Name change field
   // TODO: Extract all this debounce logic + field as a component for reuse
@@ -132,6 +134,12 @@ function SettingsRoute() {
           </Modal>
         </div>
       )}
+      <a
+        href={`https://github.com/namesakefyi/namesake/releases/tag/v${APP_VERSION}`}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-block mt-4"
+      >{`Namesake v${APP_VERSION}`}</a>
     </Container>
   );
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const APP_VERSION: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,9 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [TanStackRouterVite(), react()],
+  define: {
+    APP_VERSION: JSON.stringify(process.env.npm_package_version),
+  },
   css: {
     postcss: {
       plugins: [autoprefixer(), tailwindcss(), cssnano()],


### PR DESCRIPTION
## What changed?
- Display the current release version of the Namesake app at the bottom of `/settings`
- Link to the repo changelog

## Why?
- This allows users to understand what version of the app is running and more easily debug issues