### PR TITLE
chore: Restrict CI tests to relevant directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,13 @@ name: CI
 on:
   pull_request:
     branches: main
+    paths:
+      - "convex/**"
+      - "e2e/**"
+      - "src/**"
   push:
     branches: main
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,8 +2,11 @@ name: Coverage
 
 on: 
   pull_request:
-    branches:
-      - main
+    branches: main
+    paths:
+      - "convex/**"
+      - "e2e/**"
+      - "src/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
+    branches: main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
## What changed?
Only run CI tests when changing files within `/convex`, `/e2e` or `/src`.

## Why?
Prevent unnecessary test runs when updating READMEs and other things.