### PR TITLE
chore: Use `@changesets/changelog-github` config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.3/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "@changesets/changelog-github",
   "commit": false,
-  "fixed": [],
-  "linked": [],
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [],
   "privatePackages": {
     "version": true,
     "tag": true


### PR DESCRIPTION
## What changed?
Modify the config file for generating changelogs so that our changelog links to PRs and mentions individuals.

## Why?
Better integration with GitHub than the standard changelog generator!