### PR TITLE
chore: Rename states to jurisdictions

### DIFF
--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -1,4 +1,4 @@
-export enum US_STATES {
+export enum JURISDICTIONS {
   AK = "Alaska",
   AL = "Alabama",
   AR = "Arkansas",
@@ -8,6 +8,7 @@ export enum US_STATES {
   CT = "Connecticut",
   DC = "District of Columbia",
   DE = "Delaware",
+  FED = "Federal",
   FL = "Florida",
   GA = "Georgia",
   HI = "Hawaii",
@@ -38,6 +39,7 @@ export enum US_STATES {
   OK = "Oklahoma",
   OR = "Oregon",
   PA = "Pennsylvania",
+  PR = "Puerto Rico",
   RI = "Rhode Island",
   SC = "South Carolina",
   SD = "South Dakota",

--- a/convex/forms.ts
+++ b/convex/forms.ts
@@ -1,7 +1,7 @@
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
-import { usState } from "./schema";
+import { jurisdictions } from "./schema";
 
 // TODO: Add `returns` value validation
 // https://docs.convex.dev/functions/validation
@@ -63,7 +63,7 @@ export const uploadPDF = mutation({
 export const createForm = mutation({
   args: {
     title: v.string(),
-    state: usState,
+    jurisdiction: jurisdictions,
     formCode: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
@@ -71,7 +71,7 @@ export const createForm = mutation({
     if (userId === null) throw new Error("Not authenticated");
     return await ctx.db.insert("forms", {
       title: args.title,
-      state: args.state,
+      jurisdiction: args.jurisdiction,
       formCode: args.formCode,
       creationUser: userId,
     });

--- a/convex/quests.ts
+++ b/convex/quests.ts
@@ -1,7 +1,7 @@
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
-import { usState } from "./schema";
+import { jurisdictions } from "./schema";
 
 // TODO: Add `returns` value validation
 // https://docs.convex.dev/functions/validation
@@ -31,13 +31,13 @@ export const getQuest = query({
 });
 
 export const createQuest = mutation({
-  args: { title: v.string(), state: v.optional(usState) },
+  args: { title: v.string(), jurisdiction: v.optional(jurisdictions) },
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
     if (userId === null) throw new Error("Not authenticated");
     return await ctx.db.insert("quests", {
       title: args.title,
-      state: args.state,
+      jurisdiction: args.jurisdiction,
       creationUser: userId,
     });
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,10 +1,10 @@
 import { authTables } from "@convex-dev/auth/server";
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-import { US_STATES } from "./constants";
+import { JURISDICTIONS } from "./constants";
 
-export const usState = v.union(
-  ...Object.keys(US_STATES).map((state) => v.literal(state)),
+export const jurisdictions = v.union(
+  ...Object.keys(JURISDICTIONS).map((jurisdiction) => v.literal(jurisdiction)),
 );
 
 export default defineSchema({
@@ -24,7 +24,7 @@ export default defineSchema({
     formCode: v.optional(v.string()),
     creationUser: v.id("users"),
     file: v.optional(v.id("_storage")),
-    state: usState,
+    jurisdiction: jurisdictions,
     deletionTime: v.optional(v.number()),
   }),
 
@@ -76,7 +76,7 @@ export default defineSchema({
   quests: defineTable({
     title: v.string(),
     creationUser: v.id("users"),
-    state: v.optional(usState),
+    jurisdiction: v.optional(jurisdictions),
     deletionTime: v.optional(v.number()),
     steps: v.optional(
       v.array(

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -153,19 +153,123 @@ declare module '@tanstack/react-router' {
 
 // Create and export the route tree
 
-export const routeTree = rootRoute.addChildren({
-  IndexRoute,
-  AdminRouteRoute: AdminRouteRoute.addChildren({
-    AdminIndexRoute,
-    AdminFormsFormIdRoute,
-    AdminQuestsQuestIdRoute,
-    AdminFormsIndexRoute,
-    AdminQuestsIndexRoute,
-  }),
-  SigninRoute,
-  QuestsIndexRoute,
-  SettingsIndexRoute,
-})
+interface AdminRouteRouteChildren {
+  AdminIndexRoute: typeof AdminIndexRoute
+  AdminFormsFormIdRoute: typeof AdminFormsFormIdRoute
+  AdminQuestsQuestIdRoute: typeof AdminQuestsQuestIdRoute
+  AdminFormsIndexRoute: typeof AdminFormsIndexRoute
+  AdminQuestsIndexRoute: typeof AdminQuestsIndexRoute
+}
+
+const AdminRouteRouteChildren: AdminRouteRouteChildren = {
+  AdminIndexRoute: AdminIndexRoute,
+  AdminFormsFormIdRoute: AdminFormsFormIdRoute,
+  AdminQuestsQuestIdRoute: AdminQuestsQuestIdRoute,
+  AdminFormsIndexRoute: AdminFormsIndexRoute,
+  AdminQuestsIndexRoute: AdminQuestsIndexRoute,
+}
+
+const AdminRouteRouteWithChildren = AdminRouteRoute._addFileChildren(
+  AdminRouteRouteChildren,
+)
+
+export interface FileRoutesByFullPath {
+  '/': typeof IndexRoute
+  '/admin': typeof AdminRouteRouteWithChildren
+  '/signin': typeof SigninRoute
+  '/admin/': typeof AdminIndexRoute
+  '/quests': typeof QuestsIndexRoute
+  '/settings': typeof SettingsIndexRoute
+  '/admin/forms/$formId': typeof AdminFormsFormIdRoute
+  '/admin/quests/$questId': typeof AdminQuestsQuestIdRoute
+  '/admin/forms': typeof AdminFormsIndexRoute
+  '/admin/quests': typeof AdminQuestsIndexRoute
+}
+
+export interface FileRoutesByTo {
+  '/': typeof IndexRoute
+  '/signin': typeof SigninRoute
+  '/admin': typeof AdminIndexRoute
+  '/quests': typeof QuestsIndexRoute
+  '/settings': typeof SettingsIndexRoute
+  '/admin/forms/$formId': typeof AdminFormsFormIdRoute
+  '/admin/quests/$questId': typeof AdminQuestsQuestIdRoute
+  '/admin/forms': typeof AdminFormsIndexRoute
+  '/admin/quests': typeof AdminQuestsIndexRoute
+}
+
+export interface FileRoutesById {
+  __root__: typeof rootRoute
+  '/': typeof IndexRoute
+  '/admin': typeof AdminRouteRouteWithChildren
+  '/signin': typeof SigninRoute
+  '/admin/': typeof AdminIndexRoute
+  '/quests/': typeof QuestsIndexRoute
+  '/settings/': typeof SettingsIndexRoute
+  '/admin/forms/$formId': typeof AdminFormsFormIdRoute
+  '/admin/quests/$questId': typeof AdminQuestsQuestIdRoute
+  '/admin/forms/': typeof AdminFormsIndexRoute
+  '/admin/quests/': typeof AdminQuestsIndexRoute
+}
+
+export interface FileRouteTypes {
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/admin'
+    | '/signin'
+    | '/admin/'
+    | '/quests'
+    | '/settings'
+    | '/admin/forms/$formId'
+    | '/admin/quests/$questId'
+    | '/admin/forms'
+    | '/admin/quests'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/signin'
+    | '/admin'
+    | '/quests'
+    | '/settings'
+    | '/admin/forms/$formId'
+    | '/admin/quests/$questId'
+    | '/admin/forms'
+    | '/admin/quests'
+  id:
+    | '__root__'
+    | '/'
+    | '/admin'
+    | '/signin'
+    | '/admin/'
+    | '/quests/'
+    | '/settings/'
+    | '/admin/forms/$formId'
+    | '/admin/quests/$questId'
+    | '/admin/forms/'
+    | '/admin/quests/'
+  fileRoutesById: FileRoutesById
+}
+
+export interface RootRouteChildren {
+  IndexRoute: typeof IndexRoute
+  AdminRouteRoute: typeof AdminRouteRouteWithChildren
+  SigninRoute: typeof SigninRoute
+  QuestsIndexRoute: typeof QuestsIndexRoute
+  SettingsIndexRoute: typeof SettingsIndexRoute
+}
+
+const rootRouteChildren: RootRouteChildren = {
+  IndexRoute: IndexRoute,
+  AdminRouteRoute: AdminRouteRouteWithChildren,
+  SigninRoute: SigninRoute,
+  QuestsIndexRoute: QuestsIndexRoute,
+  SettingsIndexRoute: SettingsIndexRoute,
+}
+
+export const routeTree = rootRoute
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()
 
 /* prettier-ignore-end */
 

--- a/src/routes/admin/forms/$formId.tsx
+++ b/src/routes/admin/forms/$formId.tsx
@@ -27,7 +27,7 @@ function AdminFormDetailRoute() {
     <div>
       <PageHeader
         title={form.title}
-        badge={<Badge size="lg">{form.state}</Badge>}
+        badge={<Badge size="lg">{form.jurisdiction}</Badge>}
         subtitle={form.formCode}
       />
       {formFields?.map((field) => (

--- a/src/routes/admin/forms/index.tsx
+++ b/src/routes/admin/forms/index.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery } from "convex/react";
 import { useState } from "react";
 import { api } from "../../../../convex/_generated/api";
 import type { DataModel } from "../../../../convex/_generated/dataModel";
-import { US_STATES } from "../../../../convex/constants";
+import { JURISDICTIONS } from "../../../../convex/constants";
 import {
   Badge,
   Button,
@@ -46,23 +46,23 @@ const NewFormModal = ({
   const [file, setFile] = useState<File | null>(null);
   const [title, setTitle] = useState("");
   const [formCode, setFormCode] = useState("");
-  const [state, setState] = useState<US_STATES | null>(null);
+  const [jurisdiction, setJurisdiction] = useState<JURISDICTIONS | null>(null);
 
   const clearForm = () => {
     setFile(null);
     setTitle("");
     setFormCode("");
-    setState(null);
+    setJurisdiction(null);
   };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (state === null) throw new Error("State is required");
+    if (jurisdiction === null) throw new Error("Jurisdiction is required");
     if (file === null) throw new Error("File is required");
 
     setIsSubmitting(true);
-    const formId = await createForm({ title, state, formCode });
+    const formId = await createForm({ title, jurisdiction, formCode });
 
     const postUrl = await generateUploadUrl();
     const result = await fetch(postUrl, {
@@ -111,14 +111,14 @@ const NewFormModal = ({
           description="Legal reference codes like “CJP 27”. Optional."
         />
         <Select
-          label="State"
-          name="state"
-          selectedKey={state}
-          onSelectionChange={(key) => setState(key as US_STATES)}
-          placeholder="Select a state"
+          label="Jurisdiction"
+          name="jurisdiction"
+          selectedKey={jurisdiction}
+          onSelectionChange={(key) => setJurisdiction(key as JURISDICTIONS)}
+          placeholder="Select a jurisdiction"
           isRequired
         >
-          {Object.entries(US_STATES).map(([value, label]) => (
+          {Object.entries(JURISDICTIONS).map(([value, label]) => (
             <SelectItem key={value} id={value}>
               {label}
             </SelectItem>
@@ -158,7 +158,9 @@ const FormTableRow = ({ form }: { form: DataModel["forms"]["document"] }) => {
           </span>
         )}
       </TableCell>
-      <TableCell>{form.state && <Badge>{form.state}</Badge>}</TableCell>
+      <TableCell>
+        {form.jurisdiction && <Badge>{form.jurisdiction}</Badge>}
+      </TableCell>
       <TableCell>{new Date(form._creationTime).toLocaleString()}</TableCell>
       <TableCell>
         <MenuTrigger>
@@ -214,7 +216,7 @@ function FormsRoute() {
       <Table aria-label="Forms">
         <TableHeader>
           <TableColumn isRowHeader>Title</TableColumn>
-          <TableColumn>State</TableColumn>
+          <TableColumn>Jurisdiction</TableColumn>
           <TableColumn>Created</TableColumn>
           <TableColumn />
         </TableHeader>

--- a/src/routes/admin/quests/$questId.tsx
+++ b/src/routes/admin/quests/$questId.tsx
@@ -48,7 +48,7 @@ function AdminQuestDetailRoute() {
     <div>
       <PageHeader
         title={quest.title}
-        badge={<Badge size="lg">{quest.state}</Badge>}
+        badge={<Badge size="lg">{quest.jurisdiction}</Badge>}
       />
       <div className="flex flex-col gap-6">
         {quest.steps ? (

--- a/src/routes/admin/quests/index.tsx
+++ b/src/routes/admin/quests/index.tsx
@@ -172,7 +172,7 @@ function QuestsRoute() {
       <Table aria-label="Quests">
         <TableHeader>
           <TableColumn isRowHeader>Quest</TableColumn>
-          <TableColumn>State</TableColumn>
+          <TableColumn>Jurisdiction</TableColumn>
           <TableColumn>Used By</TableColumn>
           <TableColumn>Created</TableColumn>
           <TableColumn />

--- a/src/routes/admin/quests/index.tsx
+++ b/src/routes/admin/quests/index.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery } from "convex/react";
 import { useState } from "react";
 import { api } from "../../../../convex/_generated/api";
 import type { DataModel } from "../../../../convex/_generated/dataModel";
-import { US_STATES } from "../../../../convex/constants";
+import { JURISDICTIONS } from "../../../../convex/constants";
 import {
   Badge,
   Button,
@@ -40,16 +40,16 @@ const NewQuestModal = ({
 }) => {
   const createQuest = useMutation(api.quests.createQuest);
   const [title, setTitle] = useState("");
-  const [state, setState] = useState<US_STATES | null>(null);
+  const [jurisdiction, setJurisdiction] = useState<JURISDICTIONS | null>(null);
 
   const clearForm = () => {
     setTitle("");
-    setState(null);
+    setJurisdiction(null);
   };
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    createQuest({ title, state: state ?? undefined });
+    createQuest({ title, jurisdiction: jurisdiction ?? undefined });
 
     clearForm();
     onSubmit();
@@ -67,13 +67,13 @@ const NewQuestModal = ({
           onChange={(value) => setTitle(value)}
         />
         <Select
-          label="State"
-          name="state"
-          selectedKey={state}
-          onSelectionChange={(key) => setState(key as US_STATES)}
-          placeholder="Select a state"
+          label="Jurisdiction"
+          name="jurisdiction"
+          selectedKey={jurisdiction}
+          onSelectionChange={(key) => setJurisdiction(key as JURISDICTIONS)}
+          placeholder="Select a jurisdiction"
         >
-          {Object.entries(US_STATES).map(([value, label]) => (
+          {Object.entries(JURISDICTIONS).map(([value, label]) => (
             <SelectItem key={value} id={value}>
               {label}
             </SelectItem>
@@ -117,8 +117,8 @@ const QuestTableRow = ({
         )}
       </TableCell>
       <TableCell>
-        {quest.state ? (
-          <Badge>{quest.state}</Badge>
+        {quest.jurisdiction ? (
+          <Badge>{quest.jurisdiction}</Badge>
         ) : (
           <span className="text-gray-dim opacity-50">—</span>
         )}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -30,7 +30,7 @@ function IndexRoute() {
             <GridListItem textValue={quest.title} key={quest._id}>
               <div className="flex items-baseline gap-2">
                 <p className="font-bold text-lg">{quest.title}</p>
-                {quest.state && <Badge>{quest.state}</Badge>}
+                {quest.jurisdiction && <Badge>{quest.jurisdiction}</Badge>}
               </div>
             </GridListItem>
           );

--- a/src/routes/quests/index.tsx
+++ b/src/routes/quests/index.tsx
@@ -27,10 +27,10 @@ function QuestsRoute() {
         items={allQuests}
         renderEmptyState={() => "No quests found"}
       >
-        {allQuests.map(({ _id, title, state }) => (
+        {allQuests.map(({ _id, title, jurisdiction }) => (
           <GridListItem textValue={title} key={_id}>
             {title}
-            {state && <Badge>{state}</Badge>}
+            {jurisdiction && <Badge>{jurisdiction}</Badge>}
           </GridListItem>
         ))}
       </GridList>


### PR DESCRIPTION
## What changed?
Rename `US_STATES`, `usStates`, `state`, etc. to `JURISDICTIONS`, `jurisdictions`, and `jurisdiction`.

## Why?
"State" is unclear in an application that uses the word "state" for lots of other things. OpenLaws API uses "jurisdictions"—let's adopt that, too.

## How was this change made?
Find/replace.

## How was this tested?
Pre-commit type-checking.