### PR TITLE
ci: Update deploy pipeline for Cloudflare

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,14 @@ jobs:
           publish: pnpm changeset tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to Cloudflare Pages
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: 'namesake'
+          directory: 'dist'
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          branch: main


### PR DESCRIPTION
## What changed?
- Disable automatic deployments from `main` from the Cloudflare admin
- Extend the release workflow to deploy to Cloudflare using `pages-action` when `changesets` succeeds
- Resolves #52 

## Why?
Since we are versioning the app only the latest versioned changes should be deployed. This gives us greater control over what users have access to.