### PR TITLE
chore: Refactor mutations to use helper queries and add validators file

### DIFF
--- a/convex/formFields.ts
+++ b/convex/formFields.ts
@@ -5,9 +5,7 @@ import { query } from "./_generated/server";
 // https://docs.convex.dev/functions/validation
 
 export const getAllFieldsForForm = query({
-  args: {
-    formId: v.id("forms"),
-  },
+  args: { formId: v.id("forms") },
   handler: async (ctx, args) => {
     return await ctx.db
       .query("formFields")

--- a/convex/helpers.ts
+++ b/convex/helpers.ts
@@ -15,7 +15,6 @@ export const userQuery = customQuery(
   }),
 );
 
-// Use `apiMutation` instead of `mutation` to apply this behavior.
 export const userMutation = customMutation(mutation, {
   args: {},
   input: async (ctx) => {

--- a/convex/helpers.ts
+++ b/convex/helpers.ts
@@ -1,0 +1,26 @@
+import { getAuthUserId } from "@convex-dev/auth/server";
+import {
+  customCtx,
+  customMutation,
+  customQuery,
+} from "convex-helpers/server/customFunctions";
+import { mutation, query } from "./_generated/server";
+
+export const userQuery = customQuery(
+  query,
+  customCtx(async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) throw new Error("Not authenticated");
+    return { userId, ctx };
+  }),
+);
+
+// Use `apiMutation` instead of `mutation` to apply this behavior.
+export const userMutation = customMutation(mutation, {
+  args: {},
+  input: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) throw new Error("Not authenticated");
+    return { ctx: { userId }, args: {} };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,17 +1,7 @@
 import { authTables } from "@convex-dev/auth/server";
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-import { JURISDICTIONS } from "./constants";
-
-export const jurisdictions = v.union(
-  ...Object.keys(JURISDICTIONS).map((jurisdiction) => v.literal(jurisdiction)),
-);
-
-export const themes = v.union(
-  v.literal("system"),
-  v.literal("light"),
-  v.literal("dark"),
-);
+import { jurisdiction, theme } from "./validators";
 
 export default defineSchema({
   ...authTables,
@@ -30,7 +20,7 @@ export default defineSchema({
     formCode: v.optional(v.string()),
     creationUser: v.id("users"),
     file: v.optional(v.id("_storage")),
-    jurisdiction: jurisdictions,
+    jurisdiction: jurisdiction,
     deletionTime: v.optional(v.number()),
   }),
 
@@ -82,7 +72,7 @@ export default defineSchema({
   quests: defineTable({
     title: v.string(),
     creationUser: v.id("users"),
-    jurisdiction: v.optional(jurisdictions),
+    jurisdiction: v.optional(jurisdiction),
     deletionTime: v.optional(v.number()),
     steps: v.optional(
       v.array(
@@ -111,7 +101,7 @@ export default defineSchema({
     emailVerificationTime: v.optional(v.number()),
     isAnonymous: v.optional(v.boolean()),
     isMinor: v.optional(v.boolean()),
-    theme: v.optional(themes),
+    theme: v.optional(theme),
   }).index("email", ["email"]),
 
   /**

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,7 +1,7 @@
-import { getAuthUserId } from "@convex-dev/auth/server";
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server";
-import { themes } from "./schema";
+import { query } from "./_generated/server";
+import { userMutation, userQuery } from "./helpers";
+import { theme } from "./validators";
 
 // TODO: Add `returns` value validation
 // https://docs.convex.dev/functions/validation
@@ -13,72 +13,59 @@ export const getAllUsers = query({
   },
 });
 
-export const getCurrentUser = query({
+export const getCurrentUser = userQuery({
   args: {},
   handler: async (ctx) => {
-    const userId = await getAuthUserId(ctx);
-    if (userId === null) return null;
-    return await ctx.db.get(userId);
+    return await ctx.db.get(ctx.userId);
   },
 });
 
-export const setCurrentUserName = mutation({
+export const setCurrentUserName = userMutation({
   args: { name: v.optional(v.string()) },
   handler: async (ctx, args) => {
-    const userId = await getAuthUserId(ctx);
-    if (userId === null) throw new Error("Not authenticated");
-    await ctx.db.patch(userId, { name: args.name });
+    await ctx.db.patch(ctx.userId, { name: args.name });
   },
 });
 
-export const setCurrentUserIsMinor = mutation({
+export const setCurrentUserIsMinor = userMutation({
   args: { isMinor: v.boolean() },
   handler: async (ctx, args) => {
-    const userId = await getAuthUserId(ctx);
-    if (userId === null) throw new Error("Not authenticated");
-    await ctx.db.patch(userId, { isMinor: args.isMinor });
+    await ctx.db.patch(ctx.userId, { isMinor: args.isMinor });
   },
 });
 
-export const setUserTheme = mutation({
-  args: {
-    theme: themes,
-  },
+export const setUserTheme = userMutation({
+  args: { theme: theme },
   handler: async (ctx, args) => {
-    const userId = await getAuthUserId(ctx);
-    if (userId === null) throw new Error("Not authenticated");
-    await ctx.db.patch(userId, { theme: args.theme });
+    await ctx.db.patch(ctx.userId, { theme: args.theme });
   },
 });
 
-export const deleteCurrentUser = mutation({
+export const deleteCurrentUser = userMutation({
   args: {},
   handler: async (ctx) => {
-    const userId = await getAuthUserId(ctx);
-    if (userId === null) throw new Error("Not authenticated");
-
     // Delete userQuests
     const userQuests = await ctx.db
       .query("usersQuests")
-      .withIndex("userId", (q) => q.eq("userId", userId))
+      .withIndex("userId", (q) => q.eq("userId", ctx.userId))
       .collect();
     for (const userQuest of userQuests) await ctx.db.delete(userQuest._id);
 
     // Delete authAccounts
     const authAccounts = await ctx.db
       .query("authAccounts")
-      .withIndex("userIdAndProvider", (q) => q.eq("userId", userId))
+      .withIndex("userIdAndProvider", (q) => q.eq("userId", ctx.userId))
       .collect();
     for (const account of authAccounts) await ctx.db.delete(account._id);
 
     // Delete authSessions
     const authSessions = await ctx.db
       .query("authSessions")
-      .withIndex("userId", (q) => q.eq("userId", userId))
+      .withIndex("userId", (q) => q.eq("userId", ctx.userId))
       .collect();
     for (const session of authSessions) await ctx.db.delete(session._id);
 
     // Finally, delete the user
-    await ctx.db.delete(userId);
+    await ctx.db.delete(ctx.userId);
   },
 });

--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -1,0 +1,12 @@
+import { v } from "convex/values";
+import { JURISDICTIONS } from "./constants";
+
+export const jurisdiction = v.union(
+  ...Object.keys(JURISDICTIONS).map((jurisdiction) => v.literal(jurisdiction)),
+);
+
+export const theme = v.union(
+  v.literal("system"),
+  v.literal("light"),
+  v.literal("dark"),
+);


### PR DESCRIPTION
## What changed?
- Abstract authenticated queries and mutations https://stack.convex.dev/custom-functions
- Move validators to new `validators.ts` file
- Resolves #69 

## Why?
Less duplication, easier reusability and consistency.