### PR TITLE
feat: Add support link to dropdown menu and settings

### DIFF
--- a/.changeset/hot-kangaroos-whisper.md
+++ b/.changeset/hot-kangaroos-whisper.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Add support link to user dropdown menu and settings page

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -1,3 +1,5 @@
+/* prettier-ignore-start */
+
 /* eslint-disable */
 /**
  * Generated `api` utility.
@@ -17,10 +19,12 @@ import type * as auth from "../auth.js";
 import type * as constants from "../constants.js";
 import type * as formFields from "../formFields.js";
 import type * as forms from "../forms.js";
+import type * as helpers from "../helpers.js";
 import type * as http from "../http.js";
 import type * as quests from "../quests.js";
 import type * as users from "../users.js";
 import type * as usersQuests from "../usersQuests.js";
+import type * as validators from "../validators.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -35,10 +39,12 @@ declare const fullApi: ApiFromModules<{
   constants: typeof constants;
   formFields: typeof formFields;
   forms: typeof forms;
+  helpers: typeof helpers;
   http: typeof http;
   quests: typeof quests;
   users: typeof users;
   usersQuests: typeof usersQuests;
+  validators: typeof validators;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,
@@ -48,3 +54,5 @@ export declare const internal: FilterApi<
   typeof fullApi,
   FunctionReference<any, "internal">
 >;
+
+/* prettier-ignore-end */

--- a/convex/_generated/api.js
+++ b/convex/_generated/api.js
@@ -1,3 +1,5 @@
+/* prettier-ignore-start */
+
 /* eslint-disable */
 /**
  * Generated `api` utility.
@@ -20,3 +22,5 @@ import { anyApi } from "convex/server";
  */
 export const api = anyApi;
 export const internal = anyApi;
+
+/* prettier-ignore-end */

--- a/convex/_generated/dataModel.d.ts
+++ b/convex/_generated/dataModel.d.ts
@@ -1,3 +1,5 @@
+/* prettier-ignore-start */
+
 /* eslint-disable */
 /**
  * Generated data model types.
@@ -58,3 +60,5 @@ export type Id<TableName extends TableNames | SystemTableNames> =
  * `mutationGeneric` to make them type-safe.
  */
 export type DataModel = DataModelFromSchemaDefinition<typeof schema>;
+
+/* prettier-ignore-end */

--- a/convex/_generated/server.d.ts
+++ b/convex/_generated/server.d.ts
@@ -1,3 +1,5 @@
+/* prettier-ignore-start */
+
 /* eslint-disable */
 /**
  * Generated utilities for implementing server-side Convex query and mutation functions.
@@ -140,3 +142,5 @@ export type DatabaseReader = GenericDatabaseReader<DataModel>;
  * for the guarantees Convex provides your functions.
  */
 export type DatabaseWriter = GenericDatabaseWriter<DataModel>;
+
+/* prettier-ignore-end */

--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -1,3 +1,5 @@
+/* prettier-ignore-start */
+
 /* eslint-disable */
 /**
  * Generated utilities for implementing server-side Convex query and mutation functions.
@@ -87,3 +89,5 @@ export const internalAction = internalActionGeneric;
  * @returns The wrapped endpoint function. Route a URL path to this function in `convex/http.js`.
  */
 export const httpAction = httpActionGeneric;
+
+/* prettier-ignore-end */

--- a/src/components/shared/AppHeader.tsx
+++ b/src/components/shared/AppHeader.tsx
@@ -1,7 +1,7 @@
 import { useAuthActions } from "@convex-dev/auth/react";
 import { RiAccountCircleFill } from "@remixicon/react";
 import { Authenticated, Unauthenticated } from "convex/react";
-import { Button, Link, Menu, MenuItem, MenuTrigger } from "..";
+import { Button, Link, Menu, MenuItem, MenuSeparator, MenuTrigger } from "..";
 
 export const AppHeader = () => {
   const { signOut } = useAuthActions();
@@ -21,6 +21,15 @@ export const AppHeader = () => {
             </Button>
             <Menu>
               <MenuItem href={{ to: "/settings" }}>Settings</MenuItem>
+              <MenuSeparator />
+              <MenuItem
+                href="https://namesake.fyi/chat"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Support&hellip;
+              </MenuItem>
+              <MenuSeparator />
               <MenuItem onAction={signOut}>Sign Out</MenuItem>
             </Menu>
           </MenuTrigger>

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -169,6 +169,9 @@ function SettingsRoute() {
         >
           System Status
         </Link>
+        <Link href="https://namesake.fyi/chat" target="_blank" rel="noreferrer">
+          Support
+        </Link>
       </div>
     </Container>
   );


### PR DESCRIPTION
## What changed?
Adds a support link to Discord from the user dropdown menu and the settings page.

## Why?
Make it easy to join the Discord community from within the app.

## How was this change made?
Added the links.

## How was this tested?
Manual testing.