### PR TITLE
chore: Use `release` instead of `tag` when triggering deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,8 @@ name: Deploy
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-    - '*'
+  release:
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
## What changed?
Deploys were not running automatically; this updates the workflow to trigger based off the `release` change instead of `tag`.