### PR TITLE
feat: Add quest detail routes

### DIFF
--- a/.changeset/thirty-cups-burn.md
+++ b/.changeset/thirty-cups-burn.md
@@ -2,4 +2,4 @@
 "namesake": minor
 ---
 
-Add quest detail routes
+Add quest detail routes, add the ability to mark quests complete/incomplete, add a "new quest" modal for users to select from quests they haven't already added

--- a/.changeset/thirty-cups-burn.md
+++ b/.changeset/thirty-cups-burn.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Add quest detail routes

--- a/.changeset/thirty-cups-burn.md
+++ b/.changeset/thirty-cups-burn.md
@@ -2,4 +2,4 @@
 "namesake": minor
 ---
 
-Add quest detail routes, add the ability to mark quests complete/incomplete, add a "new quest" modal for users to select from quests they haven't already added
+Add quest detail routes, add the ability to mark quests complete/incomplete, and support adding new quests from the global quest list

--- a/convex/usersQuests.ts
+++ b/convex/usersQuests.ts
@@ -70,3 +70,38 @@ export const create = userMutation({
     });
   },
 });
+
+export const getUserQuestByQuestId = userQuery({
+  args: { questId: v.id("quests") },
+  handler: async (ctx, args) => {
+    const userQuest = await ctx.db
+      .query("usersQuests")
+      .withIndex("userId", (q) => q.eq("userId", ctx.userId))
+      .filter((q) => q.eq(q.field("questId"), args.questId))
+      .first();
+
+    return userQuest;
+  },
+});
+
+export const markComplete = userMutation({
+  args: { questId: v.id("quests") },
+  handler: async (ctx, args) => {
+    const userQuest = await getUserQuestByQuestId(ctx, {
+      questId: args.questId,
+    });
+    if (userQuest === null) throw new Error("Quest not found");
+    await ctx.db.patch(userQuest._id, { completionTime: Date.now() });
+  },
+});
+
+export const markIncomplete = userMutation({
+  args: { questId: v.id("quests") },
+  handler: async (ctx, args) => {
+    const userQuest = await getUserQuestByQuestId(ctx, {
+      questId: args.questId,
+    });
+    if (userQuest === null) throw new Error("Quest not found");
+    await ctx.db.patch(userQuest._id, { completionTime: undefined });
+  },
+});

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,10 +12,12 @@
 
 import { Route as rootRoute } from './routes/__root'
 import { Route as SigninImport } from './routes/signin'
+import { Route as QuestsRouteImport } from './routes/quests/route'
 import { Route as AdminRouteImport } from './routes/admin/route'
 import { Route as IndexImport } from './routes/index'
 import { Route as SettingsIndexImport } from './routes/settings/index'
 import { Route as AdminIndexImport } from './routes/admin/index'
+import { Route as QuestsQuestIdImport } from './routes/quests/$questId'
 import { Route as AdminQuestsIndexImport } from './routes/admin/quests/index'
 import { Route as AdminFormsIndexImport } from './routes/admin/forms/index'
 import { Route as AdminQuestsQuestIdImport } from './routes/admin/quests/$questId'
@@ -25,6 +27,11 @@ import { Route as AdminFormsFormIdImport } from './routes/admin/forms/$formId'
 
 const SigninRoute = SigninImport.update({
   path: '/signin',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const QuestsRouteRoute = QuestsRouteImport.update({
+  path: '/quests',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -46,6 +53,11 @@ const SettingsIndexRoute = SettingsIndexImport.update({
 const AdminIndexRoute = AdminIndexImport.update({
   path: '/',
   getParentRoute: () => AdminRouteRoute,
+} as any)
+
+const QuestsQuestIdRoute = QuestsQuestIdImport.update({
+  path: '/$questId',
+  getParentRoute: () => QuestsRouteRoute,
 } as any)
 
 const AdminQuestsIndexRoute = AdminQuestsIndexImport.update({
@@ -86,12 +98,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminRouteImport
       parentRoute: typeof rootRoute
     }
+    '/quests': {
+      id: '/quests'
+      path: '/quests'
+      fullPath: '/quests'
+      preLoaderRoute: typeof QuestsRouteImport
+      parentRoute: typeof rootRoute
+    }
     '/signin': {
       id: '/signin'
       path: '/signin'
       fullPath: '/signin'
       preLoaderRoute: typeof SigninImport
       parentRoute: typeof rootRoute
+    }
+    '/quests/$questId': {
+      id: '/quests/$questId'
+      path: '/$questId'
+      fullPath: '/quests/$questId'
+      preLoaderRoute: typeof QuestsQuestIdImport
+      parentRoute: typeof QuestsRouteImport
     }
     '/admin/': {
       id: '/admin/'
@@ -160,10 +186,24 @@ const AdminRouteRouteWithChildren = AdminRouteRoute._addFileChildren(
   AdminRouteRouteChildren,
 )
 
+interface QuestsRouteRouteChildren {
+  QuestsQuestIdRoute: typeof QuestsQuestIdRoute
+}
+
+const QuestsRouteRouteChildren: QuestsRouteRouteChildren = {
+  QuestsQuestIdRoute: QuestsQuestIdRoute,
+}
+
+const QuestsRouteRouteWithChildren = QuestsRouteRoute._addFileChildren(
+  QuestsRouteRouteChildren,
+)
+
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/admin': typeof AdminRouteRouteWithChildren
+  '/quests': typeof QuestsRouteRouteWithChildren
   '/signin': typeof SigninRoute
+  '/quests/$questId': typeof QuestsQuestIdRoute
   '/admin/': typeof AdminIndexRoute
   '/settings': typeof SettingsIndexRoute
   '/admin/forms/$formId': typeof AdminFormsFormIdRoute
@@ -174,7 +214,9 @@ export interface FileRoutesByFullPath {
 
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/quests': typeof QuestsRouteRouteWithChildren
   '/signin': typeof SigninRoute
+  '/quests/$questId': typeof QuestsQuestIdRoute
   '/admin': typeof AdminIndexRoute
   '/settings': typeof SettingsIndexRoute
   '/admin/forms/$formId': typeof AdminFormsFormIdRoute
@@ -187,7 +229,9 @@ export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexRoute
   '/admin': typeof AdminRouteRouteWithChildren
+  '/quests': typeof QuestsRouteRouteWithChildren
   '/signin': typeof SigninRoute
+  '/quests/$questId': typeof QuestsQuestIdRoute
   '/admin/': typeof AdminIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/admin/forms/$formId': typeof AdminFormsFormIdRoute
@@ -201,7 +245,9 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/admin'
+    | '/quests'
     | '/signin'
+    | '/quests/$questId'
     | '/admin/'
     | '/settings'
     | '/admin/forms/$formId'
@@ -211,7 +257,9 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/quests'
     | '/signin'
+    | '/quests/$questId'
     | '/admin'
     | '/settings'
     | '/admin/forms/$formId'
@@ -222,7 +270,9 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/admin'
+    | '/quests'
     | '/signin'
+    | '/quests/$questId'
     | '/admin/'
     | '/settings/'
     | '/admin/forms/$formId'
@@ -235,6 +285,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AdminRouteRoute: typeof AdminRouteRouteWithChildren
+  QuestsRouteRoute: typeof QuestsRouteRouteWithChildren
   SigninRoute: typeof SigninRoute
   SettingsIndexRoute: typeof SettingsIndexRoute
 }
@@ -242,6 +293,7 @@ export interface RootRouteChildren {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AdminRouteRoute: AdminRouteRouteWithChildren,
+  QuestsRouteRoute: QuestsRouteRouteWithChildren,
   SigninRoute: SigninRoute,
   SettingsIndexRoute: SettingsIndexRoute,
 }
@@ -260,6 +312,7 @@ export const routeTree = rootRoute
       "children": [
         "/",
         "/admin",
+        "/quests",
         "/signin",
         "/settings/"
       ]
@@ -277,8 +330,18 @@ export const routeTree = rootRoute
         "/admin/quests/"
       ]
     },
+    "/quests": {
+      "filePath": "quests/route.tsx",
+      "children": [
+        "/quests/$questId"
+      ]
+    },
     "/signin": {
       "filePath": "signin.tsx"
+    },
+    "/quests/$questId": {
+      "filePath": "quests/$questId.tsx",
+      "parent": "/quests"
     },
     "/admin/": {
       "filePath": "admin/index.tsx",

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,56 +1,9 @@
-import { RiSignpostLine } from "@remixicon/react";
-import { createFileRoute } from "@tanstack/react-router";
-import { Authenticated, Unauthenticated, useQuery } from "convex/react";
-import { api } from "../../convex/_generated/api";
-import {
-  Badge,
-  Container,
-  Empty,
-  GridList,
-  GridListItem,
-  PageHeader,
-} from "../components";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/")({
-  component: IndexRoute,
+  beforeLoad: () => {
+    throw redirect({
+      to: "/quests",
+    });
+  },
 });
-
-function IndexRoute() {
-  const MyQuests = () => {
-    const myQuests = useQuery(api.usersQuests.getQuestsForCurrentUser);
-
-    if (myQuests === undefined) return;
-
-    if (myQuests === null || myQuests.length === 0)
-      return <Empty title="No quests" icon={RiSignpostLine} />;
-
-    return (
-      <GridList aria-label="My quests">
-        {myQuests.map((quest) => {
-          if (quest === null) return null;
-
-          return (
-            <GridListItem textValue={quest.title} key={quest._id}>
-              <div className="flex items-baseline gap-2">
-                <p className="font-bold text-lg">{quest.title}</p>
-                {quest.jurisdiction && <Badge>{quest.jurisdiction}</Badge>}
-              </div>
-            </GridListItem>
-          );
-        })}
-      </GridList>
-    );
-  };
-
-  return (
-    <Container>
-      <Authenticated>
-        <PageHeader title="My Quests" />
-        <MyQuests />
-      </Authenticated>
-      <Unauthenticated>
-        <h1>Please log in</h1>
-      </Unauthenticated>
-    </Container>
-  );
-}

--- a/src/routes/quests/$questId.tsx
+++ b/src/routes/quests/$questId.tsx
@@ -1,0 +1,87 @@
+import { RiMoreLine } from "@remixicon/react";
+import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery } from "convex/react";
+import Markdown from "react-markdown";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import {
+  Badge,
+  Button,
+  Menu,
+  MenuItem,
+  MenuTrigger,
+  PageHeader,
+} from "../../components";
+
+export const Route = createFileRoute("/quests/$questId")({
+  component: QuestDetailRoute,
+});
+
+function QuestDetailRoute() {
+  const { questId } = Route.useParams();
+  // TODO: Opportunity to combine the `quest` and `userQuest` queries
+  const quest = useQuery(api.quests.getQuest, {
+    questId: questId as Id<"quests">,
+  });
+  const userQuest = useQuery(api.usersQuests.getUserQuestByQuestId, {
+    questId: questId as Id<"quests">,
+  });
+  const markComplete = useMutation(api.usersQuests.markComplete);
+  const markIncomplete = useMutation(api.usersQuests.markIncomplete);
+
+  const handleMarkComplete = (questId: Id<"quests">) =>
+    markComplete({ questId });
+  const handleMarkIncomplete = (questId: Id<"quests">) =>
+    markIncomplete({ questId });
+
+  if (quest === undefined || userQuest === undefined) return;
+  if (quest === null || userQuest === null) return "Quest not found";
+
+  return (
+    <main>
+      <PageHeader
+        title={quest.title}
+        badge={
+          <div className="flex gap-1">
+            <Badge>{quest.jurisdiction}</Badge>
+            {userQuest?.completionTime ? (
+              <Badge variant="success">Complete</Badge>
+            ) : (
+              <Badge variant="info">In progress</Badge>
+            )}
+          </div>
+        }
+      >
+        <MenuTrigger>
+          <Button aria-label="Quest settings" variant="icon">
+            <RiMoreLine />
+          </Button>
+          <Menu>
+            {!userQuest.completionTime && (
+              <MenuItem onAction={() => handleMarkComplete(quest._id)}>
+                Mark complete
+              </MenuItem>
+            )}
+            {userQuest.completionTime && (
+              <MenuItem onAction={() => handleMarkIncomplete(quest._id)}>
+                Mark as in progress
+              </MenuItem>
+            )}
+          </Menu>
+        </MenuTrigger>
+      </PageHeader>
+      {quest.steps ? (
+        <ol className="flex flex-col gap-4">
+          {quest.steps.map((step, i) => (
+            <li key={`${quest.title}-step-${i}`}>
+              <h2>{step.title}</h2>
+              <Markdown>{step.body}</Markdown>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p>This quest has no steps yet.</p>
+      )}
+    </main>
+  );
+}

--- a/src/routes/quests/route.tsx
+++ b/src/routes/quests/route.tsx
@@ -1,0 +1,173 @@
+import { RiAddLine, RiSignpostLine } from "@remixicon/react";
+import { Outlet, createFileRoute } from "@tanstack/react-router";
+import {
+  Authenticated,
+  Unauthenticated,
+  useMutation,
+  useQuery,
+} from "convex/react";
+import { useState } from "react";
+import type { Selection } from "react-aria-components";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import {
+  Badge,
+  Button,
+  Container,
+  Empty,
+  Form,
+  GridList,
+  GridListItem,
+  Modal,
+} from "../../components";
+
+export const Route = createFileRoute("/quests")({
+  component: IndexRoute,
+});
+
+const NewQuestModal = ({
+  isOpen,
+  onOpenChange,
+  onSubmit,
+}: {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onSubmit: () => void;
+}) => {
+  const [selectedQuests, setSelectedQuests] = useState<Selection>(new Set());
+  const availableQuests = useQuery(api.usersQuests.getAvailableQuestsForUser);
+  const hasAvailableQuests = availableQuests && availableQuests.length > 0;
+  const addQuest = useMutation(api.usersQuests.create);
+
+  const clearForm = () => {
+    setSelectedQuests(new Set());
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    for (const questId of selectedQuests) {
+      addQuest({ questId: questId as Id<"quests"> });
+    }
+
+    clearForm();
+    onSubmit();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+      <Form className="w-full" onSubmit={handleSubmit}>
+        {hasAvailableQuests ? (
+          <GridList
+            aria-label="Available quests"
+            items={availableQuests}
+            selectionMode="multiple"
+            selectedKeys={selectedQuests}
+            onSelectionChange={setSelectedQuests}
+          >
+            {availableQuests.map((quest) => (
+              <GridListItem
+                key={quest._id}
+                id={quest._id}
+                textValue={quest.title}
+              >
+                {quest.title}
+                {quest.jurisdiction && <Badge>{quest.jurisdiction}</Badge>}
+                {quest.steps &&
+                  quest.steps.length > 0 &&
+                  `${quest.steps?.length} steps`}
+              </GridListItem>
+            ))}
+          </GridList>
+        ) : (
+          <Empty title="No more quests" icon={RiSignpostLine} />
+        )}
+        <div className="flex gap-2 justify-end">
+          <Button type="button" onPress={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="primary"
+            isDisabled={!hasAvailableQuests}
+          >
+            {selectedQuests === "all"
+              ? "Add all quests"
+              : selectedQuests.size > 1
+                ? `Add ${selectedQuests.size} quests`
+                : "Add quest"}
+          </Button>
+        </div>
+      </Form>
+    </Modal>
+  );
+};
+
+function IndexRoute() {
+  const [isNewQuestModalOpen, setIsNewQuestModalOpen] = useState(false);
+
+  const MyQuests = () => {
+    const myQuests = useQuery(api.usersQuests.getQuestsForCurrentUser);
+
+    if (myQuests === undefined) return;
+
+    if (myQuests === null || myQuests.length === 0)
+      return (
+        <Empty
+          title="No quests"
+          icon={RiSignpostLine}
+          button={{
+            children: "Add quest",
+            variant: "primary",
+            onPress: () => setIsNewQuestModalOpen(true),
+          }}
+        />
+      );
+
+    return (
+      <GridList aria-label="My quests">
+        {myQuests.map((quest) => {
+          if (quest === null) return null;
+
+          return (
+            <GridListItem
+              textValue={quest.title}
+              key={quest._id}
+              href={{ to: "/quests/$questId", params: { questId: quest._id } }}
+            >
+              <div className="flex items-baseline gap-2">
+                <p className="font-bold text-lg">{quest.title}</p>
+                {quest.jurisdiction && <Badge>{quest.jurisdiction}</Badge>}
+              </div>
+            </GridListItem>
+          );
+        })}
+        <GridListItem
+          textValue="Add quest"
+          onAction={() => setIsNewQuestModalOpen(true)}
+        >
+          <RiAddLine /> Add quest
+        </GridListItem>
+      </GridList>
+    );
+  };
+
+  return (
+    <Container>
+      <Authenticated>
+        <div className="grid grid-cols-2 items-start gap-4">
+          <MyQuests />
+          <Outlet />
+        </div>
+        <NewQuestModal
+          isOpen={isNewQuestModalOpen}
+          onOpenChange={setIsNewQuestModalOpen}
+          onSubmit={() => setIsNewQuestModalOpen(false)}
+        />
+      </Authenticated>
+      <Unauthenticated>
+        <h1>Please log in</h1>
+      </Unauthenticated>
+    </Container>
+  );
+}


### PR DESCRIPTION
## What changed?
- Add routes to display quest details
- Add the ability to mark a quest as complete and then mark it as incomplete
- Add the ability for users to add quests to their profile that they haven't added already
- It's not pretty but it works!

![CleanShot 2024-09-18 at 17 51 04@2x](https://github.com/user-attachments/assets/bd35cfb5-7169-401f-a44f-5009ffe9a00f)

## Why?
Ongoing core functionality work.

## How was this change made?
- Added 3 new `usersQuests` functions: `getUserQuestByQuestId`, `markComplete`, and `markIncomplete`
- Changed the default route from `/` to `/quests` and added an automatic redirect
- Added `/quests/$questId` detail routes to display within an `<Outlet />` beside the navigation
- Added a `NewQuestModal` which displays all quests not already added by a user, and allows them to select one or more quests and add them to their profile

## How was this tested?
Manual testing.

## Anything else?
Filed a ticket: https://github.com/namesakefyi/namesake/issues/84