### PR TITLE
feat: Display closed signup notice while in beta

### DIFF
--- a/.changeset/afraid-kids-agree.md
+++ b/.changeset/afraid-kids-agree.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Display support, system status, and home links on signin

--- a/.changeset/brave-dodos-marry.md
+++ b/.changeset/brave-dodos-marry.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Display closed signup notice while in beta

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -10,7 +10,7 @@ export function Card({ children, className }: CardProps) {
     <div
       className={twMerge(
         className,
-        "p-4 bg-gray-subtle border border-gray-dim rounded-xl",
+        "p-6 bg-gray-subtle border border-gray-dim rounded-xl",
       )}
     >
       {children}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,12 @@
-import { AppHeader, Button, Form, Logo, TextField } from "@/components";
+import {
+  AppHeader,
+  Button,
+  Card,
+  Form,
+  Link,
+  Logo,
+  TextField,
+} from "@/components";
 import { useAuthActions } from "@convex-dev/auth/react";
 import {
   type NavigateOptions,
@@ -32,6 +40,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 function RootRoute() {
   const router = useRouter();
   const { isAuthenticated } = useConvexAuth();
+  const isProd = process.env.NODE_ENV === "production";
 
   const SignInWithMagicLink = ({
     handleLinkSent,
@@ -78,29 +87,57 @@ function RootRoute() {
     const [step, setStep] = useState<"signIn" | "linkSent">("signIn");
 
     return (
-      <div className="flex flex-col w-screen h-screen place-content-center gap-12">
-        <Logo />
-        <div className="p-6 rounded-lg bg-gray-subtle border border-gray-dim w-96 max-w-full mx-auto">
-          {step === "signIn" ? (
-            <SignInWithMagicLink handleLinkSent={() => setStep("linkSent")} />
-          ) : (
-            <div>
-              <p>Check your email.</p>
-              <p>A sign-in link has been sent to your email address.</p>
-              <Button onPress={() => setStep("signIn")}>Cancel</Button>
-            </div>
-          )}
-        </div>
-      </div>
+      <Card>
+        {step === "signIn" ? (
+          <SignInWithMagicLink handleLinkSent={() => setStep("linkSent")} />
+        ) : (
+          <div>
+            <p>Check your email.</p>
+            <p>A sign-in link has been sent to your email address.</p>
+            <Button onPress={() => setStep("signIn")}>Cancel</Button>
+          </div>
+        )}
+      </Card>
     );
   };
 
-  const App = () => (
-    <main className="flex flex-col flex-1 min-h-screen text-gray-normal">
-      <AppHeader />
-      <Outlet />
-    </main>
+  const ClosedSignups = () => (
+    <Card>
+      <p>
+        Namesake is in active development and currently closed to signups. For
+        name change support, join us on{" "}
+        <Link href="https://namesake.fyi/chat">Discord</Link>.
+      </p>
+    </Card>
   );
+
+  type AppProps = {
+    isAuthenticated: boolean;
+    isClosed: boolean;
+  };
+
+  const App = ({ isAuthenticated, isClosed }: AppProps) => {
+    if (isClosed || !isAuthenticated) {
+      return (
+        <div className="flex flex-col w-96 max-w-full mx-auto h-screen place-content-center gap-8">
+          <Logo className="mb-4" />
+          {isClosed ? <ClosedSignups /> : <SignIn />}
+          <div className="flex gap-4 justify-center">
+            <Link href="https://namesake.fyi">Namesake.fyi</Link>
+            <Link href="https://namesake.fyi/chat">Support</Link>
+            <Link href="https://status.namesake.fyi">System Status</Link>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <main className="flex flex-col flex-1 min-h-screen text-gray-normal">
+        <AppHeader />
+        <Outlet />
+      </main>
+    );
+  };
 
   return (
     // TODO: Improve this API
@@ -115,7 +152,7 @@ function RootRoute() {
         typeof path === "string" ? path : router.buildLocation(path).href
       }
     >
-      {!isAuthenticated ? <SignIn /> : <App />}
+      <App isAuthenticated={isAuthenticated} isClosed={isProd} />
     </RouterProvider>
   );
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -123,7 +123,7 @@ function RootRoute() {
           <Logo className="mb-4" />
           {isClosed ? <ClosedSignups /> : <SignIn />}
           <div className="flex gap-4 justify-center">
-            <Link href="https://namesake.fyi">Namesake.fyi</Link>
+            <Link href="https://namesake.fyi">Namesake</Link>
             <Link href="https://namesake.fyi/chat">Support</Link>
             <Link href="https://status.namesake.fyi">System Status</Link>
           </div>


### PR DESCRIPTION
## What changed?
- Check and display a notice that the app is closed to signups
- Display links to home, support, and status

![CleanShot 2024-09-21 at 11 26 15@2x](https://github.com/user-attachments/assets/7df8f574-958d-4ad9-8e83-7e47dcee8cb9)

## Why?
Removed the Cloudflare Zero Trust login, replacing with in-app logic.

## How was this tested?
Manual testing

## Anything else?
Changes the padding size for the `Card` component