### PR TITLE
fix: Fix broken component styles, consolidate icon libraries

### DIFF
--- a/.changeset/happy-stingrays-look.md
+++ b/.changeset/happy-stingrays-look.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Consolidate icon libraries

--- a/.changeset/nice-rocks-refuse.md
+++ b/.changeset/nice-rocks-refuse.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix broken component styles

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@tanstack/react-router": "^1.57.15",
     "convex": "^1.16.0",
     "convex-helpers": "^0.1.58",
-    "lucide-react": "^0.441.0",
     "next-themes": "^0.3.0",
     "postcss": "^8.4.47",
     "pretty-bytes": "^6.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       convex-helpers:
         specifier: ^0.1.58
         version: 0.1.58(convex@1.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(zod@3.23.8)
-      lucide-react:
-        specifier: ^0.441.0
-        version: 0.441.0(react@18.3.1)
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4717,11 +4714,6 @@ packages:
 
   lucia@3.2.0:
     resolution: {integrity: sha512-eXMxXwk6hqtjRTj4W/x3EnTUtAztLPm0p2N2TEBMDEbakDLXiYnDQ9z/qahjPdPdhPguQc+vwO0/88zIWxlpuw==}
-
-  lucide-react@0.441.0:
-    resolution: {integrity: sha512-0vfExYtvSDhkC2lqg0zYVW1Uu9GsI4knuV9GP9by5z0Xhc4Zi5RejTxfz9LsjRmCyWVzHCJvxGKZWcRyvQCWVg==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -12540,10 +12532,6 @@ snapshots:
   lucia@3.2.0:
     dependencies:
       oslo: 1.2.0
-
-  lucide-react@0.441.0(react@18.3.1):
-    dependencies:
-      react: 18.3.1
 
   lz-string@1.5.0: {}
 

--- a/src/components/AlertDialog/AlertDialog.tsx
+++ b/src/components/AlertDialog/AlertDialog.tsx
@@ -1,9 +1,9 @@
-import { AlertCircleIcon, InfoIcon } from "lucide-react";
+import { RiAlertLine, RiInformationLine } from "@remixicon/react";
 import type { ReactNode } from "react";
 import { chain } from "react-aria";
-import { type DialogProps, Heading } from "react-aria-components";
+import { Heading } from "react-aria-components";
 import { Button } from "../Button";
-import { Dialog } from "../Dialog";
+import { Dialog, type DialogProps } from "../Dialog";
 
 interface AlertDialogProps extends Omit<DialogProps, "children"> {
   title: string;
@@ -29,7 +29,7 @@ export function AlertDialog({
         <>
           <Heading
             slot="title"
-            className="text-xl font-semibold leading-6 my-0"
+            className="text-xl font-medium text-gray-normal leading-6 my-0"
           >
             {title}
           </Heading>
@@ -37,9 +37,9 @@ export function AlertDialog({
             className={`w-6 h-6 absolute right-6 top-6 stroke-2 ${variant === "destructive" ? "text-red-9 dark:text-reddark-9" : "text-blue-9 dark:text-bluedark-9"}`}
           >
             {variant === "destructive" ? (
-              <AlertCircleIcon aria-hidden />
+              <RiAlertLine aria-hidden />
             ) : (
-              <InfoIcon aria-hidden />
+              <RiInformationLine aria-hidden />
             )}
           </div>
           <p className="mt-3 text-gray-dim">{children}</p>

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight } from "lucide-react";
+import { RiArrowRightWideLine } from "@remixicon/react";
 import {
   Breadcrumb as AriaBreadcrumb,
   Breadcrumbs as AriaBreadcrumbs,
@@ -31,7 +31,9 @@ export function Breadcrumb(
       )}
     >
       <Link variant="secondary" {...props} />
-      {props.href && <ChevronRight className="w-3 h-3 text-gray-dim" />}
+      {props.href && (
+        <RiArrowRightWideLine className="w-4 h-4 text-gray-8 dark:text-graydark-8" />
+      )}
     </AriaBreadcrumb>
   );
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -18,7 +18,7 @@ const button = tv({
       primary: "bg-purple-solid",
       secondary: "bg-gray-ghost text-gray-normal",
       destructive: "bg-red-solid",
-      icon: "bg-gray-ghost border-0 p-2 flex items-center justify-center rounded-full",
+      icon: "bg-gray-ghost text-gray-dim hover:text-gray-normal border-0 p-2 flex items-center justify-center rounded-full",
     },
     isDisabled: {
       true: "cursor-default text-gray-dim opacity-50 forced-colors:text-[GrayText]",

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,5 +1,4 @@
-import { ChevronLeft, ChevronRight } from "lucide-react";
-
+import { RiArrowLeftSLine, RiArrowRightSLine } from "@remixicon/react";
 import {
   Calendar as AriaCalendar,
   CalendarGridHeader as AriaCalendarGridHeader,
@@ -66,17 +65,17 @@ export function CalendarHeader() {
     <header className="flex items-center gap-1 pb-4 px-1 w-full">
       <Button variant="icon" slot="previous">
         {direction === "rtl" ? (
-          <ChevronRight aria-hidden />
+          <RiArrowRightSLine aria-hidden />
         ) : (
-          <ChevronLeft aria-hidden />
+          <RiArrowLeftSLine aria-hidden />
         )}
       </Button>
-      <Heading className="flex-1 font-semibold text-xl text-center mx-2 text-gray-12 dark:text-gray-2" />
+      <Heading className="flex-1 font-medium text-xl text-center mx-2 text-gray-normal" />
       <Button variant="icon" slot="next">
         {direction === "rtl" ? (
-          <ChevronLeft aria-hidden />
+          <RiArrowLeftSLine aria-hidden />
         ) : (
-          <ChevronRight aria-hidden />
+          <RiArrowRightSLine aria-hidden />
         )}
       </Button>
     </header>
@@ -87,7 +86,7 @@ export function CalendarGridHeader() {
   return (
     <AriaCalendarGridHeader>
       {(day) => (
-        <CalendarHeaderCell className="text-xs text-gray-5 dark:text-graydark-5 font-semibold">
+        <CalendarHeaderCell className="text-xs text-gray-9 dark:text-graydark-9 font-semibold">
           {day}
         </CalendarHeaderCell>
       )}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { Check, Minus } from "lucide-react";
+import { RiCheckLine, RiSubtractLine } from "@remixicon/react";
 import type { ReactNode } from "react";
 import {
   Checkbox as AriaCheckbox,
@@ -43,15 +43,15 @@ const checkboxStyles = tv({
   base: "flex gap-2 items-center group text-sm transition",
   variants: {
     isDisabled: {
-      false: "text-gray-10 dark:text-gray-2",
-      true: "text-gray-3 dark:text-gray-6 forced-colors:text-[GrayText]",
+      false: "text-gray-normal cursor-pointer",
+      true: "opacity-50 forced-colors:text-[GrayText] cursor-default",
     },
   },
 });
 
 const boxStyles = tv({
   extend: focusRing,
-  base: "w-5 h-5 flex-shrink-0 rounded flex items-center justify-center border-2 transition",
+  base: "w-6 h-6 flex-shrink-0 rounded flex items-center justify-center border-2 transition",
   variants: {
     isSelected: {
       false: "bg-white dark:bg-gray-12 border-gray-dim",
@@ -67,7 +67,7 @@ const boxStyles = tv({
 });
 
 const iconStyles =
-  "w-4 h-4 text-white group-disabled:text-gray-4 dark:group-disabled:text-gray-9 forced-colors:text-[HighlightText]";
+  "w-5 h-5 text-white group-disabled:text-gray-4 dark:group-disabled:text-gray-9 forced-colors:text-[HighlightText]";
 
 export function Checkbox(props: CheckboxProps) {
   return (
@@ -86,9 +86,9 @@ export function Checkbox(props: CheckboxProps) {
             })}
           >
             {isIndeterminate ? (
-              <Minus aria-hidden className={iconStyles} />
+              <RiSubtractLine aria-hidden className={iconStyles} />
             ) : isSelected ? (
-              <Check aria-hidden className={iconStyles} />
+              <RiCheckLine aria-hidden className={iconStyles} />
             ) : null}
           </div>
           {props.children}

--- a/src/components/ComboBox/ComboBox.tsx
+++ b/src/components/ComboBox/ComboBox.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from "lucide-react";
+import { RiArrowDownSLine } from "@remixicon/react";
 import type React from "react";
 import {
   ComboBox as AriaComboBox,
@@ -50,8 +50,8 @@ export function ComboBox<T extends object>({
       <Label>{label}</Label>
       <FieldGroup>
         <Input />
-        <Button variant="icon" className="w-6 mr-1 rounded outline-offset-0 ">
-          <ChevronDown aria-hidden className="w-4 h-4" />
+        <Button variant="icon" className="w-7 h-7 p-0 mr-1 outline-offset-0 ">
+          <RiArrowDownSLine aria-hidden className="w-4 h-4" />
         </Button>
       </FieldGroup>
       {description && <FieldDescription>{description}</FieldDescription>}

--- a/src/components/DateField/DateField.tsx
+++ b/src/components/DateField/DateField.tsx
@@ -46,16 +46,16 @@ export function DateField<T extends DateValue>({
 }
 
 const segmentStyles = tv({
-  base: "inline p-0.5 type-literal:px-0 rounded outline outline-0 forced-color-adjust-none caret-transparent text-gray-10 dark:text-gray-2 forced-colors:text-[ButtonText]",
+  base: "inline p-0.5 type-literal:px-0 rounded outline outline-0 forced-color-adjust-none caret-transparent text-gray-normal forced-colors:text-[ButtonText]",
   variants: {
     isPlaceholder: {
-      true: "text-gray-6 dark:text-gray-4 italic",
+      true: "text-gray-9 dark:text-graydark-9",
     },
     isDisabled: {
       true: "text-gray-2 dark:text-gray-6 forced-colors:text-[GrayText]",
     },
     isFocused: {
-      true: "bg-blue-9 text-white dark:text-white forced-colors:bg-[Highlight] forced-colors:text-[HighlightText]",
+      true: "bg-purple-9 text-white dark:text-white forced-colors:bg-[Highlight] forced-colors:text-[HighlightText]",
     },
   },
 });
@@ -66,7 +66,7 @@ export function DateInput(props: Omit<DateInputProps, "children">) {
       className={(renderProps) =>
         fieldGroupStyles({
           ...renderProps,
-          class: "block min-w-[150px] px-2 py-1.5 text-sm",
+          class: "block min-w-[150px] px-3 py-2",
         })
       }
       {...props}

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,5 +1,4 @@
-import { CalendarIcon } from "lucide-react";
-
+import { RiCalendarLine } from "@remixicon/react";
 import {
   DatePicker as AriaDatePicker,
   type DatePickerProps as AriaDatePickerProps,
@@ -37,9 +36,9 @@ export function DatePicker<T extends DateValue>({
     >
       {label && <Label>{label}</Label>}
       <FieldGroup className="min-w-[208px] w-auto">
-        <DateInput className="flex-1 min-w-[150px] px-2 py-1.5 text-sm" />
-        <Button variant="icon" className="w-6 mr-1 rounded outline-offset-0">
-          <CalendarIcon aria-hidden className="w-4 h-4" />
+        <DateInput className="flex-1 min-w-[150px] px-3 py-2" />
+        <Button variant="icon" className="w-7 h-7 p-0 mr-1 outline-offset-0">
+          <RiCalendarLine aria-hidden className="w-4 h-4" />
         </Button>
       </FieldGroup>
       {description && <FieldDescription>{description}</FieldDescription>}

--- a/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/DateRangePicker/DateRangePicker.tsx
@@ -1,5 +1,4 @@
-import { CalendarIcon } from "lucide-react";
-
+import { RiCalendarLine } from "@remixicon/react";
 import {
   DateRangePicker as AriaDateRangePicker,
   type DateRangePickerProps as AriaDateRangePickerProps,
@@ -37,16 +36,16 @@ export function DateRangePicker<T extends DateValue>({
     >
       {label && <Label>{label}</Label>}
       <FieldGroup className="min-w-[208px] w-auto">
-        <DateInput slot="start" className="px-2 py-1.5 text-sm" />
+        <DateInput slot="start" className="px-3 py-2" />
         <span
           aria-hidden="true"
           className="text-gray-10 dark:text-gray-2 forced-colors:text-[ButtonText] group-disabled:text-gray-2 group-disabled:dark:text-gray-6 group-disabled:forced-colors:text-[GrayText]"
         >
           –
         </span>
-        <DateInput slot="end" className="flex-1 px-2 py-1.5 text-sm" />
-        <Button variant="icon" className="w-6 mr-1 rounded outline-offset-0">
-          <CalendarIcon aria-hidden className="w-4 h-4" />
+        <DateInput slot="end" className="flex-1 px-3 py-2" />
+        <Button variant="icon" className="w-7 h-7 p-0 mr-1 outline-offset-0">
+          <RiCalendarLine aria-hidden className="w-4 h-4" />
         </Button>
       </FieldGroup>
       {description && <FieldDescription>{description}</FieldDescription>}

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,10 +1,12 @@
 import {
   Dialog as AriaDialog,
+  type DialogProps as AriaDialogProps,
   DialogTrigger as AriaDialogTrigger,
-  type DialogProps,
   type DialogTriggerProps,
 } from "react-aria-components";
 import { twMerge } from "tailwind-merge";
+
+export interface DialogProps extends AriaDialogProps {}
 
 export function Dialog(props: DialogProps) {
   return (

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -22,7 +22,7 @@ export function Label(props: LabelProps) {
     <AriaLabel
       {...props}
       className={twMerge(
-        "text-sm text-gray-normal font-medium cursor-default w-fit",
+        "text-sm text-gray-dim cursor-default w-fit",
         props.className,
       )}
     />
@@ -55,7 +55,7 @@ export const fieldBorderStyles = tv({
   variants: {
     isFocusWithin: {
       false: "border-gray-dim forced-colors:border-[ButtonBorder]",
-      true: "border-gray-dim forced-colors:border-[Highlight]",
+      true: "border-gray-normal forced-colors:border-[Highlight]",
     },
     isInvalid: {
       true: "border-red-normal bg-red-subtle forced-colors:border-[Mark]",
@@ -83,8 +83,8 @@ export function FieldGroup(props: GroupProps) {
   );
 }
 
-const inputStyles =
-  "px-3 py-2 flex-1 min-w-0 outline outline-0 bg-gray-subtle text-gray-normal disabled:text-gray-dim";
+export const inputStyles =
+  "px-3 py-2 flex-1 min-w-0 outline outline-0 bg-transparent text-gray-normal disabled:text-gray-dim";
 
 export function Input(props: InputProps) {
   return (

--- a/src/components/GridList/GridList.tsx
+++ b/src/components/GridList/GridList.tsx
@@ -28,14 +28,14 @@ export function GridList<T extends object>({
 
 const itemStyles = tv({
   extend: focusRing,
-  base: "relative flex items-center gap-3 cursor-default select-none py-2 px-3 text-sm border-y border-y-gray-6 dark:border-y-graydark-6 first:border-t-0 last:border-b-0 first:rounded-t-md last:rounded-b-md -mb-px last:mb-0 -outline-offset-2",
+  base: "relative text-gray-normal flex items-center gap-3 cursor-pointer select-none py-2 px-3 text-sm border-y border-gray-dim first:border-t-0 last:border-b-0 first:rounded-t-md last:rounded-b-md -mb-px last:mb-0 -outline-offset-2",
   variants: {
     isSelected: {
-      false: "hover:bg-gray-3 dark:hover:bg-graydark-3",
-      true: "bg-blue-1 dark:bg-blue-10/30 hover:bg-blue-2 dark:hover:bg-blue-10/40 border-y-blue-2 dark:border-y-blue-12 z-20",
+      false: "",
+      true: "bg-purple-subtle border-y border-purple-dim z-20",
     },
     isDisabled: {
-      true: "opacity-50 forced-colors:text-[GrayText] z-10",
+      true: "opacity-50 cursor-default forced-colors:text-[GrayText] z-10",
     },
   },
 });

--- a/src/components/ListBox/ListBox.tsx
+++ b/src/components/ListBox/ListBox.tsx
@@ -1,4 +1,4 @@
-import { Check } from "lucide-react";
+import { RiCheckLine } from "@remixicon/react";
 import {
   ListBox as AriaListBox,
   ListBoxItem as AriaListBoxItem,
@@ -24,7 +24,7 @@ export function ListBox<T extends object>({
       {...props}
       className={composeTailwindRenderProps(
         props.className,
-        "outline-0 p-1 border border-gray-3 dark:border-gray-6 rounded-lg",
+        "outline-0 p-1 border border-gray-dim rounded-lg",
       )}
     >
       {children}
@@ -34,15 +34,14 @@ export function ListBox<T extends object>({
 
 export const itemStyles = tv({
   extend: focusRing,
-  base: "group relative flex items-center gap-8 cursor-default select-none py-1.5 px-2.5 rounded-md will-change-transform text-sm forced-color-adjust-none",
+  base: "group relative flex items-center gap-8 cursor-pointer select-none py-1.5 px-2.5 rounded-md will-change-transform forced-color-adjust-none",
   variants: {
     isSelected: {
-      false:
-        "text-gray-10 dark:text-gray-3 hover:bg-gray-2 dark:hover:bg-gray-8 -outline-offset-2",
-      true: "bg-blue-9 text-white forced-colors:bg-[Highlight] forced-colors:text-[HighlightText] [&:has(+[data-selected])]:rounded-b-none [&+[data-selected]]:rounded-t-none -outline-offset-4 outline-white dark:outline-white forced-colors:outline-[HighlightText]",
+      false: "text-gray-normal -outline-offset-2",
+      true: "bg-purple-9 dark:bg-purpledark-9 text-white forced-colors:bg-[Highlight] forced-colors:text-[HighlightText] [&:has(+[data-selected])]:rounded-b-none [&+[data-selected]]:rounded-t-none -outline-offset-4 outline-white dark:outline-white forced-colors:outline-[HighlightText]",
     },
     isDisabled: {
-      true: "text-gray-7 dark:text-graydark-7 forced-colors:text-[GrayText]",
+      true: "text-gray-dim opacity-50 cursor-default forced-colors:text-[GrayText]",
     },
   },
 });
@@ -64,11 +63,11 @@ export function ListBoxItem(props: ListBoxItemProps) {
 }
 
 export const dropdownItemStyles = tv({
-  base: "group flex items-center gap-4 cursor-default select-none py-2 px-3 rounded-lg outline outline-0 text-sm forced-color-adjust-none",
+  base: "group flex items-center gap-4 cursor-pointer select-none py-2 px-3 rounded-lg outline outline-0 text-sm forced-color-adjust-none",
   variants: {
     isDisabled: {
       false: "text-gray-normal",
-      true: "text-gray-dim forced-colors:text-[GrayText]",
+      true: "text-gray-dim opacity-50 forced-colors:text-[GrayText] cursor-default",
     },
     isFocused: {
       true: "bg-purple-9 dark:bg-purpledark-9 text-white forced-colors:bg-[Highlight] forced-colors:text-[HighlightText]",
@@ -99,7 +98,7 @@ export function DropdownItem(props: ListBoxItemProps) {
             {children}
           </span>
           <span className="flex items-center w-5">
-            {isSelected && <Check className="w-4 h-4" />}
+            {isSelected && <RiCheckLine className="w-4 h-4" />}
           </span>
         </>
       ))}

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -1,5 +1,5 @@
+import { RiMoreLine } from "@remixicon/react";
 import type { Meta } from "@storybook/react";
-import { MoreHorizontal } from "lucide-react";
 import {
   Menu,
   MenuItem,
@@ -20,7 +20,7 @@ export default meta;
 export const Example = (args: any) => (
   <MenuTrigger>
     <Button variant="secondary" className="px-2">
-      <MoreHorizontal className="w-5 h-5" />
+      <RiMoreLine className="w-5 h-5" />
     </Button>
     <Menu {...args}>
       <MenuItem id="new">New…</MenuItem>
@@ -42,7 +42,7 @@ DisabledItems.args = {
 export const Sections = (args: any) => (
   <MenuTrigger>
     <Button variant="secondary" className="px-2">
-      <MoreHorizontal className="w-5 h-5" />
+      <RiMoreLine className="w-5 h-5" />
     </Button>
     <Menu {...args}>
       <MenuSection title="Your Content">
@@ -64,7 +64,7 @@ export const Sections = (args: any) => (
 export const Submenu = (args: any) => (
   <MenuTrigger>
     <Button variant="secondary" className="px-2">
-      <MoreHorizontal className="w-5 h-5" />
+      <RiMoreLine className="w-5 h-5" />
     </Button>
     <Menu {...args}>
       <MenuItem id="new">New…</MenuItem>

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronRight } from "lucide-react";
+import { RiArrowRightSLine, RiCheckLine } from "@remixicon/react";
 import {
   Menu as AriaMenu,
   MenuItem as AriaMenuItem,
@@ -47,14 +47,17 @@ export function MenuItem(props: MenuItemProps) {
           <>
             {selectionMode !== "none" && (
               <span className="flex items-center w-4">
-                {isSelected && <Check aria-hidden className="w-4 h-4" />}
+                {isSelected && <RiCheckLine aria-hidden className="w-4 h-4" />}
               </span>
             )}
             <span className="flex items-center cursor-pointer flex-1 gap-2 font-normal truncate group-selected:font-semibold">
               {children}
             </span>
             {hasSubmenu && (
-              <ChevronRight aria-hidden className="absolute w-4 h-4 right-2" />
+              <RiArrowRightSLine
+                aria-hidden
+                className="absolute w-4 h-4 right-2"
+              />
             )}
           </>
         ),

--- a/src/components/Meter/Meter.tsx
+++ b/src/components/Meter/Meter.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle } from "lucide-react";
+import { RiAlertLine } from "@remixicon/react";
 import {
   Meter as AriaMeter,
   type MeterProps as AriaMeterProps,
@@ -22,12 +22,12 @@ export function Meter({ label, ...props }: MeterProps) {
       {({ percentage, valueText }) => (
         <>
           <div className="flex justify-between gap-2">
-            <Label>{label}</Label>
+            <Label className="text-gray-normal">{label}</Label>
             <span
-              className={`text-sm ${percentage >= 80 ? "text-red-normal" : "text-gray-normal"}`}
+              className={`text-sm ${percentage >= 80 ? "text-red-dim" : "text-gray-dim"}`}
             >
               {percentage >= 80 && (
-                <AlertTriangle
+                <RiAlertLine
                   aria-label="Alert"
                   className="inline-block w-4 h-4 align-text-bottom"
                 />
@@ -35,7 +35,7 @@ export function Meter({ label, ...props }: MeterProps) {
               {valueText}
             </span>
           </div>
-          <div className="w-64 h-2 rounded-full bg-gray-3 dark:bg-gray-8 outline outline-1 -outline-offset-1 outline-transparent relative">
+          <div className="w-64 h-2 rounded-full bg-gray-4 dark:bg-graydark-4 outline outline-1 -outline-offset-1 outline-transparent relative">
             <div
               className={`absolute top-0 left-0 h-full rounded-full ${getColor(percentage)} forced-colors:bg-[Highlight]`}
               style={{ width: `${percentage}%` }}

--- a/src/components/NumberField/NumberField.tsx
+++ b/src/components/NumberField/NumberField.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { RiArrowDownSLine, RiArrowUpSLine } from "@remixicon/react";
 import {
   NumberField as AriaNumberField,
   type NumberFieldProps as AriaNumberFieldProps,
@@ -44,20 +44,20 @@ export function NumberField({
             <div
               className={fieldBorderStyles({
                 ...renderProps,
-                class: "flex flex-col border-s-2",
+                class: "flex flex-col border-s h-10",
               })}
             >
               <StepperButton slot="increment">
-                <ChevronUp aria-hidden className="w-4 h-4" />
+                <RiArrowUpSLine aria-hidden className="w-4 h-4" />
               </StepperButton>
               <div
                 className={fieldBorderStyles({
                   ...renderProps,
-                  class: "border-b-2",
+                  class: "border-b",
                 })}
               />
               <StepperButton slot="decrement">
-                <ChevronDown aria-hidden className="w-4 h-4" />
+                <RiArrowDownSLine aria-hidden className="w-4 h-4" />
               </StepperButton>
             </div>
           </>
@@ -73,7 +73,7 @@ function StepperButton(props: ButtonProps) {
   return (
     <Button
       {...props}
-      className="px-0.5 cursor-default text-gray-dim group-disabled:text-gray-2 dark:text-gray-4 dark:pressed:bg-gray-11 dark:group-disabled:text-gray-6 forced-colors:group-disabled:text-[GrayText]"
+      className="p-0.5 cursor-pointer text-gray-dim group-disabled:text-gray-2 dark:text-gray-4 dark:pressed:bg-gray-11 dark:group-disabled:text-gray-6 forced-colors:group-disabled:text-[GrayText]"
     />
   );
 }

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -1,5 +1,5 @@
+import { RiQuestionLine } from "@remixicon/react";
 import type { Meta } from "@storybook/react";
-import { HelpCircle } from "lucide-react";
 import { Heading } from "react-aria-components";
 import { Popover } from ".";
 import { Button } from "../Button";
@@ -7,10 +7,7 @@ import { Dialog, DialogTrigger } from "../Dialog";
 
 const meta: Meta<typeof Popover> = {
   component: Popover,
-
-  args: {
-    showArrow: true,
-  },
+  args: {},
 };
 
 export default meta;
@@ -18,7 +15,7 @@ export default meta;
 export const Example = (args: any) => (
   <DialogTrigger>
     <Button variant="icon" aria-label="Help">
-      <HelpCircle className="w-4 h-4" />
+      <RiQuestionLine />
     </Button>
     <Popover {...args} className="max-w-[250px]">
       <Dialog>

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -2,7 +2,6 @@ import type React from "react";
 import {
   Popover as AriaPopover,
   type PopoverProps as AriaPopoverProps,
-  OverlayArrow,
   PopoverContext,
   composeRenderProps,
   useSlottedContext,
@@ -10,12 +9,11 @@ import {
 import { tv } from "tailwind-variants";
 
 export interface PopoverProps extends Omit<AriaPopoverProps, "children"> {
-  showArrow?: boolean;
   children: React.ReactNode;
 }
 
 const styles = tv({
-  base: "bg-gray-subtle forced-colors:bg-[Canvas] shadow-2xl rounded-xl bg-clip-padding border border-black/10 dark:border-white/[15%] text-gray-normal",
+  base: "bg-gray-subtle forced-colors:bg-[Canvas] shadow-2xl rounded-xl bg-clip-padding border border-gray-dim text-gray-normal",
   variants: {
     isEntering: {
       true: "animate-in fade-in placement-bottom:slide-in-from-top-1 placement-top:slide-in-from-bottom-1 placement-left:slide-in-from-right-1 placement-right:slide-in-from-left-1 ease-out duration-2",
@@ -26,16 +24,11 @@ const styles = tv({
   },
 });
 
-export function Popover({
-  children,
-  showArrow,
-  className,
-  ...props
-}: PopoverProps) {
+export function Popover({ children, className, ...props }: PopoverProps) {
   const popoverContext = useSlottedContext(PopoverContext)!;
   const isSubmenu = popoverContext?.trigger === "SubmenuTrigger";
-  let offset = showArrow ? 12 : 8;
-  offset = isSubmenu ? offset - 6 : offset;
+  const offset = isSubmenu ? 2 : 8;
+
   return (
     <AriaPopover
       offset={offset}
@@ -44,18 +37,6 @@ export function Popover({
         styles({ ...renderProps, className }),
       )}
     >
-      {showArrow && (
-        <OverlayArrow className="group">
-          <svg
-            width={12}
-            height={12}
-            viewBox="0 0 12 12"
-            className="block fill-gray-2 dark:fill-graydark-2 forced-colors:fill-[Canvas] stroke-1 stroke-black/10 dark:stroke-gray-6 forced-colors:stroke-[ButtonBorder] group-placement-bottom:rotate-180 group-placement-left:-rotate-90 group-placement-right:rotate-90"
-          >
-            <path d="M0 0 L6 6 L12 0" />
-          </svg>
-        </OverlayArrow>
-      )}
       {children}
     </AriaPopover>
   );

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -21,14 +21,12 @@ export function ProgressBar({ label, ...props }: ProgressBarProps) {
       {({ percentage, valueText, isIndeterminate }) => (
         <>
           <div className="flex justify-between gap-2">
-            <Label>{label}</Label>
-            <span className="text-sm text-gray-6 dark:text-gray-4">
-              {valueText}
-            </span>
+            <Label className="text-gray-normal">{label}</Label>
+            <span className="text-sm text-gray-dim">{valueText}</span>
           </div>
-          <div className="w-64 h-2 rounded-full bg-gray-3 dark:bg-gray-8 outline outline-1 -outline-offset-1 outline-transparent relative overflow-hidden">
+          <div className="w-64 h-2 rounded-full bg-gray-4 dark:bg-graydark-4 outline outline-1 -outline-offset-1 outline-transparent relative overflow-hidden">
             <div
-              className={`absolute top-0 h-full rounded-full bg-blue-9 dark:bg-blue-5 forced-colors:bg-[Highlight] ${isIndeterminate ? "left-full animate-in duration-10 [--tw-enter-translate-x:calc(-16rem-1%)] slide-out-to-right-full repeat-infinite ease-out" : "left-0"}`}
+              className={`absolute top-0 h-full rounded-full bg-purple-9 dark:bg-purpledark-9 forced-colors:bg-[Highlight] ${isIndeterminate ? "left-full animate-in duration-10 [--tw-enter-translate-x:calc(-16rem-1%)] slide-out-to-right-full repeat-infinite ease-out" : "left-0"}`}
               style={{ width: `${isIndeterminate ? 40 : percentage}%` }}
             />
           </div>

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -43,9 +43,8 @@ const styles = tv({
   base: "w-5 h-5 rounded-full border bg-white dark:bg-gray-12 transition-all cursor-pointer",
   variants: {
     isSelected: {
-      false:
-        "border-gray-5 dark:border-graydark-5 group-pressed:border-gray-6 dark:group-pressed:border-graydark-6",
-      true: "border-[7px] dark:bg-white border-purple-9 dark:border-purpledark-9 forced-colors:!border-[Highlight] group-pressed:border-gray-10 dark:group-pressed:border-graydark-10",
+      false: "border-gray-normal",
+      true: "border-[7px] dark:bg-white border-purple-9 dark:border-purpledark-9 forced-colors:!border-[Highlight] group-pressed:border-purple-10 dark:group-pressed:border-purpledark-10",
     },
     isInvalid: {
       true: "border-red-9 dark:border-reddark-9 group-pressed:border-red-11 dark:group-pressed:border-reddark-11 forced-colors:!border-[Mark]",
@@ -62,7 +61,7 @@ export function Radio(props: RadioProps) {
       {...props}
       className={composeTailwindRenderProps(
         props.className,
-        "flex gap-2 items-center group text-gray-default disabled:opacity-50 forced-colors:disabled:text-[GrayText] text-sm transition",
+        "flex gap-2 items-center group text-gray-normal disabled:opacity-50 forced-colors:disabled:text-[GrayText] transition",
       )}
     >
       {(renderProps) => (

--- a/src/components/RangeCalendar/RangeCalendar.tsx
+++ b/src/components/RangeCalendar/RangeCalendar.tsx
@@ -18,20 +18,18 @@ export interface RangeCalendarProps<T extends DateValue>
 
 const cell = tv({
   extend: focusRing,
-  base: "w-full h-full flex items-center justify-center rounded-full forced-color-adjust-none text-gray-12 dark:text-gray-2",
+  base: "w-full h-full flex items-center justify-center rounded-full cursor-pointer forced-color-adjust-none text-gray-normal",
   variants: {
     selectionState: {
-      none: "group-hover:bg-gray-1 dark:group-hover:bg-gray-8 group-pressed:bg-gray-2 dark:group-pressed:bg-gray-6",
+      none: "group-hover:bg-gray-3 dark:group-hover:bg-graydark-3 group-pressed:bg-gray-2 dark:group-pressed:bg-gray-6",
       middle: [
-        "group-hover:bg-blue-2 dark:group-hover:bg-blue-12 forced-colors:group-hover:bg-[Highlight]",
-        "group-invalid:group-hover:bg-red-2 dark:group-invalid:group-hover:bg-red-12 forced-colors:group-invalid:group-hover:bg-[Mark]",
-        "group-pressed:bg-blue-3 dark:group-pressed:bg-blue-11 forced-colors:group-pressed:bg-[Highlight] forced-colors:text-[HighlightText]",
-        "group-invalid:group-pressed:bg-red-3 dark:group-invalid:group-pressed:bg-red-11 forced-colors:group-invalid:group-pressed:bg-[Mark]",
+        "group-hover:bg-purple-4 dark:group-hover:bg-purpledark-4 forced-colors:group-hover:bg-[Highlight]",
+        "group-invalid:group-hover:bg-red-4 dark:group-invalid:group-hover:bg-reddark-4 forced-colors:group-invalid:group-hover:bg-[Mark]",
       ],
-      cap: "bg-blue-9 group-invalid:bg-red-9 forced-colors:bg-[Highlight] forced-colors:group-invalid:bg-[Mark] text-white forced-colors:text-[HighlightText]",
+      cap: "bg-purple-9 dark:bg-purpledark-9 group-invalid:bg-red-9 dark:group-invalid:bg-reddark-9 forced-colors:bg-[Highlight] forced-colors:group-invalid:bg-[Mark] text-white forced-colors:text-[HighlightText]",
     },
     isDisabled: {
-      true: "text-gray-3 dark:text-gray-6 forced-colors:text-[GrayText]",
+      true: "text-gray-dim opacity-50 forced-colors:text-[GrayText] cursor-default",
     },
   },
 });
@@ -49,7 +47,7 @@ export function RangeCalendar<T extends DateValue>({
           {(date) => (
             <CalendarCell
               date={date}
-              className="group w-9 h-9 text-sm outline outline-0 cursor-default outside-month:text-gray-3 selected:bg-blue-1 dark:selected:bg-blue-10/30 forced-colors:selected:bg-[Highlight] invalid:selected:bg-red-1 dark:invalid:selected:bg-red-10/30 forced-colors:invalid:selected:bg-[Mark] [td:first-child_&]:rounded-s-full selection-start:rounded-s-full [td:last-child_&]:rounded-e-full selection-end:rounded-e-full"
+              className="group w-9 h-9 text-sm outline outline-0 cursor-default outside-month:text-gray-10 dark:outside-month:text-graydark-9 selected:bg-purple-3 selected:text-purple-12 dark:selected:bg-purpledark-3 dark:selected:text-purpledark-12 forced-colors:selected:bg-[Highlight] invalid:selected:bg-red-3 dark:invalid:selected:bg-reddark-3 forced-colors:invalid:selected:bg-[Mark] [td:first-child_&]:rounded-s-full selection-start:rounded-s-full [td:last-child_&]:rounded-e-full selection-end:rounded-e-full"
             >
               {({
                 formattedDate,

--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -1,4 +1,4 @@
-import { SearchIcon, XIcon } from "lucide-react";
+import { RiCloseLine, RiSearchLine } from "@remixicon/react";
 import {
   SearchField as AriaSearchField,
   type SearchFieldProps as AriaSearchFieldProps,
@@ -36,13 +36,16 @@ export function SearchField({
     >
       {label && <Label>{label}</Label>}
       <FieldGroup>
-        <SearchIcon
+        <RiSearchLine
           aria-hidden
-          className="w-4 h-4 ml-2 text-gray-dim forced-colors:text-[ButtonText] group-disabled:opacity-50 forced-colors:group-disabled:text-[GrayText]"
+          className="w-4 h-4 ml-3 text-gray-dim forced-colors:text-[ButtonText] group-disabled:opacity-50 forced-colors:group-disabled:text-[GrayText]"
         />
         <Input className="[&::-webkit-search-cancel-button]:hidden" />
-        <Button variant="icon" className="mr-1 w-6 group-empty:invisible">
-          <XIcon aria-hidden className="w-4 h-4" />
+        <Button
+          variant="icon"
+          className="mr-1 w-7 h-7 p-0 group-empty:invisible"
+        >
+          <RiCloseLine aria-hidden className="w-4 h-4" />
         </Button>
       </FieldGroup>
       {description && <FieldDescription>{description}</FieldDescription>}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from "lucide-react";
+import { RiArrowDownSLine } from "@remixicon/react";
 import type React from "react";
 import {
   Select as AriaSelect,
@@ -21,12 +21,12 @@ import { composeTailwindRenderProps, focusRing } from "../utils";
 
 const styles = tv({
   extend: focusRing,
-  base: "flex items-center text-start gap-4 w-full cursor-default border border-black/10 dark:border-white/10 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1)] dark:shadow-none rounded-lg pl-3 pr-2 py-2 min-w-[150px] transition bg-gray-ui",
+  base: "flex items-center text-start gap-4 w-full cursor-pointer border border-black/10 dark:border-white/10 rounded-lg pl-3 pr-2 py-2 min-w-[150px] transition bg-gray-ui",
   variants: {
     isDisabled: {
       false:
         "hover:bg-gray-1 pressed:bg-gray-2 dark:hover:bg-graydark-1 dark:pressed:bg-graydark-2 group-invalid:border-red- forced-colors:group-invalid:border-[Mark]",
-      true: "opacity-50 forced-colors:text-[GrayText] forced-colors:border-[GrayText]",
+      true: "opacity-50 forced-colors:text-[GrayText] forced-colors:border-[GrayText] cursor-default",
     },
   },
 });
@@ -58,8 +58,8 @@ export function Select<T extends object>({
     >
       {label && <Label>{label}</Label>}
       <Button className={styles}>
-        <SelectValue className="flex-1 placeholder-shown:italic" />
-        <ChevronDown
+        <SelectValue className="flex-1 text-gray-normal placeholder-shown:text-gray-9 dark:placeholder-shown:text-graydark-9" />
+        <RiArrowDownSLine
           aria-hidden
           className="w-4 h-4 text-gray-dim forced-colors:text-[ButtonText] group-disabled:opacity-50 forced-colors:group-disabled:text-[GrayText]"
         />

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -12,11 +12,11 @@ export interface SwitchProps extends Omit<AriaSwitchProps, "children"> {
 
 const track = tv({
   extend: focusRing,
-  base: "flex h-4 w-7 px-px items-center shrink-0 cursor-pointer rounded-full transition duration-2 ease-in-out shadow-inner border border-transparent",
+  base: "flex h-5 w-9 px-px items-center shrink-0 cursor-pointer rounded-full transition duration-2 ease-in-out border border-transparent",
   variants: {
     isSelected: {
       false:
-        "bg-gray-3 group-pressed:bg-gray-5 dark:bg-graydark-3 dark:group-pressed:bg-graydark-5",
+        "bg-gray-4 group-pressed:bg-gray-5 dark:bg-graydark-4 dark:group-pressed:bg-graydark-5",
       true: "bg-green-9 forced-colors:!bg-[Highlight] group-pressed:bg-green-10 dark:bg-greendark-9 dark:group-pressed:bg-greendark-10",
     },
     isDisabled: {
@@ -26,7 +26,7 @@ const track = tv({
 });
 
 const handle = tv({
-  base: "h-3 w-3 transform rounded-full bg-white outline outline-1 -outline-offset-1 outline-transparent shadow transition duration-2 ease-in-out",
+  base: "h-4 w-4 transform rounded-full bg-white outline outline-1 -outline-offset-1 outline-transparent shadow transition duration-2 ease-in-out",
   variants: {
     isSelected: {
       false: "translate-x-0",

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp } from "lucide-react";
+import { RiArrowUpSLine } from "@remixicon/react";
 import {
   Cell as AriaCell,
   Column as AriaColumn,
@@ -64,7 +64,7 @@ export function TableColumn(props: ColumnProps) {
                   }`}
                 >
                   {sortDirection && (
-                    <ArrowUp
+                    <RiArrowUpSLine
                       aria-hidden
                       className="w-4 h-4 text-gray-dim forced-colors:text-[ButtonText]"
                     />
@@ -96,8 +96,8 @@ export function TableHeader<T extends object>(props: TableHeaderProps<T>) {
       {allowsDragging && <TableColumn />}
       {selectionBehavior === "toggle" && (
         <AriaColumn
-          width={36}
-          minWidth={36}
+          width={40}
+          minWidth={40}
           className="text-start text-sm font-semibold cursor-default p-2"
         >
           {selectionMode === "multiple" && <Checkbox slot="selection" />}
@@ -110,7 +110,7 @@ export function TableHeader<T extends object>(props: TableHeaderProps<T>) {
 
 const rowStyles = tv({
   extend: focusRing,
-  base: "group/row relative cursor-default select-none -outline-offset-2 text-sm bg-gray-ghost selected:bg-purple-subtle",
+  base: "group/row relative cursor-default select-none -outline-offset-2 text-sm text-gray-normal selected:bg-purple-subtle",
 });
 
 export function TableRow<T extends object>({
@@ -140,8 +140,7 @@ export function TableRow<T extends object>({
 
 const cellStyles = tv({
   extend: focusRing,
-  // TODO: Fix these selected styles to use Radix colors
-  base: "border-b border-gray-dim group-last/row:border-b-0 [--selected-border:theme(colors.blue.200)] dark:[--selected-border:theme(colors.blue.900)] group-selected/row:border-[--selected-border] [:has(+[data-selected])_&]:border-[--selected-border] p-3 truncate -outline-offset-2",
+  base: "border-b border-gray-dim group-last/row:border-b-0 group-selected/row:border-purple-dim [:has(+[data-selected])_&]:border-purple-dim p-2 truncate -outline-offset-2",
 });
 
 export function TableCell(props: CellProps) {

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -56,14 +56,14 @@ export function TabList<T extends object>(props: TabListProps<T>) {
 
 const tabProps = tv({
   extend: focusRing,
-  base: "flex items-center cursor-pointer rounded-full px-4 py-1.5 text-sm font-medium transition forced-color-adjust-none",
+  base: "flex items-center cursor-pointer rounded-full px-4 py-1.5 text-sm transition forced-color-adjust-none",
   variants: {
     isSelected: {
       false: "bg-gray-ghost text-gray-dim hover:text-gray-normal",
       true: "bg-gray-12 text-gray-1 dark:bg-graydark-12 dark:text-graydark-1 forced-colors:text-[HighlightText] forced-colors:bg-[Highlight]",
     },
     isDisabled: {
-      true: "text-gray-2 dark:text-gray-6 cursor-default forced-colors:text-[GrayText] selected:text-gray-3 dark:selected:text-gray-5 forced-colors:selected:text-[HighlightText] selected:bg-gray-2 dark:selected:bg-gray-6 forced-colors:selected:bg-[GrayText]",
+      true: "opacity-50 cursor-default forced-colors:text-[GrayText] selected:text-gray-3 dark:selected:text-gray-5 forced-colors:selected:text-[HighlightText] selected:bg-gray-2 dark:selected:bg-gray-6 forced-colors:selected:bg-[GrayText]",
     },
   },
 });

--- a/src/components/TagGroup/TagGroup.tsx
+++ b/src/components/TagGroup/TagGroup.tsx
@@ -1,5 +1,4 @@
-import { XIcon } from "lucide-react";
-import { createContext, useContext } from "react";
+import { RiCloseLine } from "@remixicon/react";
 import {
   Tag as AriaTag,
   TagGroup as AriaTagGroup,
@@ -16,57 +15,33 @@ import { tv } from "tailwind-variants";
 import { FieldDescription, Label } from "../Field";
 import { focusRing } from "../utils";
 
-const colors = {
-  gray: "bg-gray-1 text-gray-6 border-gray-2 hover:border-gray-3 dark:bg-gray-8 dark:text-gray-3 dark:border-gray-6 dark:hover:border-gray-5",
-  green:
-    "bg-green-1 text-green-10 border-green-2 hover:border-green-3 dark:bg-green-3/20 dark:text-green-4 dark:border-green-3/10 dark:hover:border-green-3/20",
-  yellow:
-    "bg-yellow-1 text-yellow-10 border-yellow-2 hover:border-yellow-3 dark:bg-yellow-3/20 dark:text-yellow-4 dark:border-yellow-3/10 dark:hover:border-yellow-3/20",
-  blue: "bg-blue-1 text-blue-10 border-blue-2 hover:border-blue-3 dark:bg-blue-4/20 dark:text-blue-3 dark:border-blue-4/10 dark:hover:border-blue-4/20",
-};
-
-type Color = keyof typeof colors;
-const ColorContext = createContext<Color>("gray");
-
 const tagStyles = tv({
   extend: focusRing,
-  base: "transition cursor-default text-xs rounded-full border px-3 py-0.5 flex items-center max-w-fit gap-1",
+  base: "transition cursor-pointer text-sm rounded-full border px-3 py-1 flex items-center max-w-fit gap-1",
   variants: {
-    color: {
-      gray: "",
-      green: "",
-      yellow: "",
-      blue: "",
-    },
     allowsRemoving: {
       true: "pr-1",
     },
     isSelected: {
-      true: "bg-blue-9 text-white border-transparent forced-colors:bg-[Highlight] forced-colors:text-[HighlightText] forced-color-adjust-none",
+      false:
+        "text-gray-dim border-gray-dim hover:text-gray-normal hover:border-gray-normal",
+      true: "bg-purple-9 dark:bg-purpledark-9 text-white border border-transparent forced-colors:bg-[Highlight] forced-colors:text-[HighlightText] forced-color-adjust-none",
     },
     isDisabled: {
-      true: "bg-gray-1 text-gray-3 forced-colors:text-[GrayText]",
+      true: "cursor-default text-gray-dim opacity-50 forced-colors:text-[GrayText]",
     },
   },
-  compoundVariants: (Object.keys(colors) as Color[]).map((color) => ({
-    isSelected: false,
-    color,
-    class: colors[color],
-  })),
 });
 
 export interface TagGroupProps<T>
   extends Omit<AriaTagGroupProps, "children">,
     Pick<TagListProps<T>, "items" | "children" | "renderEmptyState"> {
-  color?: Color;
   label?: string;
   description?: string;
   errorMessage?: string;
 }
 
-export interface TagProps extends AriaTagProps {
-  color?: Color;
-}
+export interface TagProps extends AriaTagProps {}
 
 export function TagGroup<T extends object>({
   label,
@@ -80,18 +55,16 @@ export function TagGroup<T extends object>({
   return (
     <AriaTagGroup
       {...props}
-      className={twMerge("flex flex-col gap-1", props.className)}
+      className={twMerge("flex flex-col gap-2", props.className)}
     >
       <Label>{label}</Label>
-      <ColorContext.Provider value={props.color || "gray"}>
-        <TagList
-          items={items}
-          renderEmptyState={renderEmptyState}
-          className="flex flex-wrap gap-1"
-        >
-          {children}
-        </TagList>
-      </ColorContext.Provider>
+      <TagList
+        items={items}
+        renderEmptyState={renderEmptyState}
+        className="flex flex-wrap gap-1"
+      >
+        {children}
+      </TagList>
       {description && <FieldDescription>{description}</FieldDescription>}
       {errorMessage && (
         <Text slot="errorMessage" className="text-sm text-red-9">
@@ -104,18 +77,18 @@ export function TagGroup<T extends object>({
 
 const removeButtonStyles = tv({
   extend: focusRing,
-  base: "cursor-default rounded-full transition-[background-color] p-0.5 flex items-center justify-center hover:bg-black/10 dark:hover:bg-white/10 pressed:bg-black/20 dark:pressed:bg-white/20",
+  base: "cursor-pointer rounded-full transition-[background-color] p-0.5 flex items-center justify-center hover:bg-black/10 dark:hover:bg-white/10 pressed:bg-black/20 dark:pressed:bg-white/20",
 });
 
-export function Tag({ children, color, ...props }: TagProps) {
+export function Tag({ children, ...props }: TagProps) {
   const textValue = typeof children === "string" ? children : undefined;
-  const groupColor = useContext(ColorContext);
+
   return (
     <AriaTag
       textValue={textValue}
       {...props}
       className={composeRenderProps(props.className, (className, renderProps) =>
-        tagStyles({ ...renderProps, className, color: color || groupColor }),
+        tagStyles({ ...renderProps, className }),
       )}
     >
       {({ allowsRemoving }) => (
@@ -123,7 +96,7 @@ export function Tag({ children, color, ...props }: TagProps) {
           {children}
           {allowsRemoving && (
             <Button slot="remove" className={removeButtonStyles}>
-              <XIcon aria-hidden className="w-3 h-3" />
+              <RiCloseLine aria-hidden className="w-3 h-3" />
             </Button>
           )}
         </>

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -8,12 +8,12 @@ import { focusRing } from "../utils";
 
 const styles = tv({
   extend: focusRing,
-  base: "px-5 py-2 text-sm text-center transition rounded-lg border border-black/10 dark:border-white/10 forced-colors:border-[ButtonBorder] shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1)] dark:shadow-none cursor-default forced-color-adjust-none",
+  base: "px-5 py-2 text-sm text-center transition rounded-lg border border-black/10 dark:border-white/10 forced-colors:border-[ButtonBorder] cursor-pointer forced-color-adjust-none",
   variants: {
     isSelected: {
       false:
-        "bg-gray-1 hover:bg-gray-2 pressed:bg-gray-3 text-gray-10 dark:bg-gray-6 dark:hover:bg-gray-5 dark:pressed:bg-gray-4 dark:text-gray-1 forced-colors:!bg-[ButtonFace] forced-colors:!text-[ButtonText]",
-      true: "bg-gray-9 hover:bg-gray-10 pressed:bg-gray-11 text-white dark:bg-gray-3 dark:hover:bg-gray-2 dark:pressed:bg-gray-1 dark:text-black forced-colors:!bg-[Highlight] forced-colors:!text-[HighlightText]",
+        "bg-gray-1 hover:bg-gray-2 pressed:bg-gray-3 text-gray-normal dark:bg-gray-6 dark:hover:bg-gray-5 dark:pressed:bg-gray-4 dark:text-gray-1 forced-colors:!bg-[ButtonFace] forced-colors:!text-[ButtonText]",
+      true: "bg-purple-9 hover:bg-purple-10 text-white dark:bg-purpledark-9 dark:hover:bg-purpledark-10 forced-colors:!bg-[Highlight] forced-colors:!text-[HighlightText]",
     },
     isDisabled: {
       true: "bg-gray-1 dark:bg-gray-11 forced-colors:!bg-[ButtonFace] text-gray-3 dark:text-gray-6 forced-colors:!text-[GrayText] border-black/5 dark:border-white/5 forced-colors:border-[GrayText]",

--- a/src/components/Toolbar/Toolbar.stories.tsx
+++ b/src/components/Toolbar/Toolbar.stories.tsx
@@ -1,4 +1,4 @@
-import { BoldIcon, ItalicIcon, UnderlineIcon } from "lucide-react";
+import { RiBold, RiItalic, RiUnderline } from "@remixicon/react";
 import { Group } from "react-aria-components";
 import { Toolbar } from ".";
 import { Button } from "../Button";
@@ -18,13 +18,13 @@ export const Example = (args: any) => (
   <Toolbar aria-label="Text formatting" {...args}>
     <Group aria-label="Style" className="contents">
       <ToggleButton aria-label="Bold" className="p-2.5">
-        <BoldIcon className="w-4 h-4" />
+        <RiBold className="w-4 h-4" />
       </ToggleButton>
       <ToggleButton aria-label="Italic" className="p-2.5">
-        <ItalicIcon className="w-4 h-4" />
+        <RiItalic className="w-4 h-4" />
       </ToggleButton>
       <ToggleButton aria-label="Underline" className="p-2.5">
-        <UnderlineIcon className="w-4 h-4" />
+        <RiUnderline className="w-4 h-4" />
       </ToggleButton>
     </Group>
     <Separator

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,5 +1,5 @@
+import { RiPrinterLine, RiSaveLine } from "@remixicon/react";
 import type { Meta } from "@storybook/react";
-import { PrinterIcon, SaveIcon } from "lucide-react";
 import { Tooltip, TooltipTrigger } from ".";
 import { Button } from "../Button";
 
@@ -13,13 +13,13 @@ export const Example = (args: any) => (
   <div className="flex gap-2">
     <TooltipTrigger>
       <Button variant="secondary" className="px-2">
-        <SaveIcon className="w-5 h-5" />
+        <RiSaveLine />
       </Button>
       <Tooltip {...args}>Save</Tooltip>
     </TooltipTrigger>
     <TooltipTrigger>
       <Button variant="secondary" className="px-2">
-        <PrinterIcon className="w-5 h-5" />
+        <RiPrinterLine />
       </Button>
       <Tooltip {...args}>Print</Tooltip>
     </TooltipTrigger>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -14,7 +14,7 @@ export interface TooltipProps extends Omit<AriaTooltipProps, "children"> {
 }
 
 const styles = tv({
-  base: "group bg-gray-10 dark:bg-gray-9 border border-gray-11 dark:border-white/10 dark:shadow-none text-white text-sm rounded-lg drop-shadow-lg will-change-transform px-3 py-1",
+  base: "group bg-gray-12 dark:bg-graydark-12 dark:shadow-none text-gray-1 dark:text-graydark-1 text-sm rounded-lg drop-shadow-lg will-change-transform px-3 py-1",
   variants: {
     isEntering: {
       true: "animate-in fade-in placement-bottom:slide-in-from-top-0.5 placement-top:slide-in-from-bottom-0.5 placement-left:slide-in-from-right-0.5 placement-right:slide-in-from-left-0.5 ease-out duration-2",
@@ -39,7 +39,7 @@ export function Tooltip({ children, ...props }: TooltipProps) {
           width={8}
           height={8}
           viewBox="0 0 8 8"
-          className="fill-gray-10 dark:fill-gray-9 forced-colors:fill-[Canvas] stroke-gray-10 dark:stroke-white/10 forced-colors:stroke-[ButtonBorder] group-placement-bottom:rotate-180 group-placement-left:-rotate-90 group-placement-right:rotate-90"
+          className="fill-gray-12 dark:fill-graydark-12 forced-colors:fill-[Canvas] group-placement-bottom:rotate-180 group-placement-left:-rotate-90 group-placement-right:rotate-90"
         >
           <path d="M0 0 L4 4 L8 0" />
         </svg>


### PR DESCRIPTION
## What changed?
- Fix all broken component styles. Resolves #95 
- Remove Lucide icons and use Remix Icon. Resolves #92 

## Why?
When React Aria was imported along with Radix Tailwind Colors, some styles broke, and it was difficult to test without Storybook. Now that Storybook is in place it was easier to go through and update all component styles.

## How was this tested?
Manual testing.

## Anything else?
There might be a few edge-case components that were missed but this should cover our bases for now!