### PR TITLE
refactor: Improve redirect logic for auth and unauth users

### DIFF
--- a/.changeset/khaki-dogs-reflect.md
+++ b/.changeset/khaki-dogs-reflect.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Improve auth redirect logic

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@auth/core": "^0.34.2",
-    "@convex-dev/auth": "^0.0.67",
+    "@convex-dev/auth": "^0.0.69",
     "@faker-js/faker": "^9.0.1",
     "@mdxeditor/editor": "^3.11.4",
     "@pdfme/common": "^4.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^0.34.2
         version: 0.34.2
       '@convex-dev/auth':
-        specifier: ^0.0.67
-        version: 0.0.67(convex@1.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        specifier: ^0.0.69
+        version: 0.0.69(convex@1.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@faker-js/faker':
         specifier: ^9.0.1
         version: 9.0.1
@@ -639,8 +639,8 @@ packages:
       react: ^16.8.0 || ^17 || ^18
       react-dom: ^16.8.0 || ^17 || ^18
 
-  '@convex-dev/auth@0.0.67':
-    resolution: {integrity: sha512-XUNTe3X7qxzAkpgP/qekuQ7Fc3qE1i2BrbBjyKO5jyFJ0qrvoNr0PRSKofnLYnjTrjG12wkm9KJx56og4pyJUw==}
+  '@convex-dev/auth@0.0.69':
+    resolution: {integrity: sha512-qM7Q1ntNTuOCtUILBzZhSANY/zDpntjtg31ME1bV43+RnM/JfiWpduvs/qTQXWUiil60DawuZ0tdpGse8uNxvg==}
     hasBin: true
     peerDependencies:
       convex: ^1.14.4
@@ -7648,7 +7648,7 @@ snapshots:
     transitivePeerDependencies:
       - '@lezer/common'
 
-  '@convex-dev/auth@0.0.67(convex@1.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@convex-dev/auth@0.0.69(convex@1.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@auth/core': 0.31.0
       arctic: 1.9.2

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -1,7 +1,8 @@
 import { useAuthActions } from "@convex-dev/auth/react";
+import { api } from "@convex/_generated/api";
 import { RiAccountCircleFill } from "@remixicon/react";
-import { useQuery } from "convex/react";
-import { api } from "../../../convex/_generated/api";
+import { redirect } from "@tanstack/react-router";
+import { Authenticated, useQuery } from "convex/react";
 import { Button } from "../Button";
 import { Link } from "../Link";
 import { Logo } from "../Logo";
@@ -12,32 +13,39 @@ export const AppHeader = () => {
   const role = useQuery(api.users.getCurrentUserRole);
   const isAdmin = role === "admin";
 
+  const handleSignOut = () => {
+    signOut();
+    redirect({ to: "/", throw: true });
+  };
+
   return (
-    <div className="flex gap-4 items-center w-screen py-3 px-4 border-b border-gray-dim">
+    <div className="flex gap-4 items-center w-screen h-14 px-4 border-b border-gray-dim">
       <Link href={{ to: "/" }}>
         <Logo className="h-[1.25rem]" />
       </Link>
-      {isAdmin && <Link href={{ to: "/admin" }}>Admin</Link>}
-      <div className="ml-auto">
-        <MenuTrigger>
-          <Button aria-label="User settings" variant="icon">
-            <RiAccountCircleFill />
-          </Button>
-          <Menu>
-            <MenuItem href={{ to: "/settings" }}>Settings</MenuItem>
-            <MenuSeparator />
-            <MenuItem
-              href="https://namesake.fyi/chat"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Support&hellip;
-            </MenuItem>
-            <MenuSeparator />
-            <MenuItem onAction={signOut}>Sign Out</MenuItem>
-          </Menu>
-        </MenuTrigger>
-      </div>
+      <Authenticated>
+        {isAdmin && <Link href={{ to: "/admin" }}>Admin</Link>}
+        <div className="ml-auto">
+          <MenuTrigger>
+            <Button aria-label="User settings" variant="icon">
+              <RiAccountCircleFill />
+            </Button>
+            <Menu>
+              <MenuItem href={{ to: "/settings" }}>Settings</MenuItem>
+              <MenuSeparator />
+              <MenuItem
+                href="https://namesake.fyi/chat"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Support&hellip;
+              </MenuItem>
+              <MenuSeparator />
+              <MenuItem onAction={handleSignOut}>Sign out</MenuItem>
+            </Menu>
+          </MenuTrigger>
+        </div>
+      </Authenticated>
     </div>
   );
 };

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,225 +11,315 @@
 // Import Routes
 
 import { Route as rootRoute } from './routes/__root'
-import { Route as QuestsRouteImport } from './routes/quests/route'
-import { Route as AdminRouteImport } from './routes/admin/route'
-import { Route as IndexImport } from './routes/index'
-import { Route as SettingsIndexImport } from './routes/settings/index'
-import { Route as AdminIndexImport } from './routes/admin/index'
-import { Route as QuestsQuestIdImport } from './routes/quests/$questId'
-import { Route as AdminQuestsIndexImport } from './routes/admin/quests/index'
-import { Route as AdminFormsIndexImport } from './routes/admin/forms/index'
-import { Route as AdminQuestsQuestIdImport } from './routes/admin/quests/$questId'
-import { Route as AdminFormsFormIdImport } from './routes/admin/forms/$formId'
+import { Route as UnauthenticatedImport } from './routes/_unauthenticated'
+import { Route as AuthenticatedImport } from './routes/_authenticated'
+import { Route as AuthenticatedIndexImport } from './routes/_authenticated/index'
+import { Route as UnauthenticatedLoginImport } from './routes/_unauthenticated/login'
+import { Route as AuthenticatedQuestsRouteImport } from './routes/_authenticated/quests/route'
+import { Route as AuthenticatedAdminRouteImport } from './routes/_authenticated/admin/route'
+import { Route as AuthenticatedSettingsIndexImport } from './routes/_authenticated/settings/index'
+import { Route as AuthenticatedAdminIndexImport } from './routes/_authenticated/admin/index'
+import { Route as AuthenticatedQuestsQuestIdImport } from './routes/_authenticated/quests/$questId'
+import { Route as AuthenticatedAdminQuestsIndexImport } from './routes/_authenticated/admin/quests/index'
+import { Route as AuthenticatedAdminFormsIndexImport } from './routes/_authenticated/admin/forms/index'
+import { Route as AuthenticatedAdminQuestsQuestIdImport } from './routes/_authenticated/admin/quests/$questId'
+import { Route as AuthenticatedAdminFormsFormIdImport } from './routes/_authenticated/admin/forms/$formId'
 
 // Create/Update Routes
 
-const QuestsRouteRoute = QuestsRouteImport.update({
+const UnauthenticatedRoute = UnauthenticatedImport.update({
+  id: '/_unauthenticated',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const AuthenticatedRoute = AuthenticatedImport.update({
+  id: '/_authenticated',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const AuthenticatedIndexRoute = AuthenticatedIndexImport.update({
+  path: '/',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
+
+const UnauthenticatedLoginRoute = UnauthenticatedLoginImport.update({
+  path: '/login',
+  getParentRoute: () => UnauthenticatedRoute,
+} as any)
+
+const AuthenticatedQuestsRouteRoute = AuthenticatedQuestsRouteImport.update({
   path: '/quests',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => AuthenticatedRoute,
 } as any)
 
-const AdminRouteRoute = AdminRouteImport.update({
+const AuthenticatedAdminRouteRoute = AuthenticatedAdminRouteImport.update({
   path: '/admin',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => AuthenticatedRoute,
 } as any)
 
-const IndexRoute = IndexImport.update({
+const AuthenticatedSettingsIndexRoute = AuthenticatedSettingsIndexImport.update(
+  {
+    path: '/settings/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any,
+)
+
+const AuthenticatedAdminIndexRoute = AuthenticatedAdminIndexImport.update({
   path: '/',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => AuthenticatedAdminRouteRoute,
 } as any)
 
-const SettingsIndexRoute = SettingsIndexImport.update({
-  path: '/settings/',
-  getParentRoute: () => rootRoute,
-} as any)
+const AuthenticatedQuestsQuestIdRoute = AuthenticatedQuestsQuestIdImport.update(
+  {
+    path: '/$questId',
+    getParentRoute: () => AuthenticatedQuestsRouteRoute,
+  } as any,
+)
 
-const AdminIndexRoute = AdminIndexImport.update({
-  path: '/',
-  getParentRoute: () => AdminRouteRoute,
-} as any)
+const AuthenticatedAdminQuestsIndexRoute =
+  AuthenticatedAdminQuestsIndexImport.update({
+    path: '/quests/',
+    getParentRoute: () => AuthenticatedAdminRouteRoute,
+  } as any)
 
-const QuestsQuestIdRoute = QuestsQuestIdImport.update({
-  path: '/$questId',
-  getParentRoute: () => QuestsRouteRoute,
-} as any)
+const AuthenticatedAdminFormsIndexRoute =
+  AuthenticatedAdminFormsIndexImport.update({
+    path: '/forms/',
+    getParentRoute: () => AuthenticatedAdminRouteRoute,
+  } as any)
 
-const AdminQuestsIndexRoute = AdminQuestsIndexImport.update({
-  path: '/quests/',
-  getParentRoute: () => AdminRouteRoute,
-} as any)
+const AuthenticatedAdminQuestsQuestIdRoute =
+  AuthenticatedAdminQuestsQuestIdImport.update({
+    path: '/quests/$questId',
+    getParentRoute: () => AuthenticatedAdminRouteRoute,
+  } as any)
 
-const AdminFormsIndexRoute = AdminFormsIndexImport.update({
-  path: '/forms/',
-  getParentRoute: () => AdminRouteRoute,
-} as any)
-
-const AdminQuestsQuestIdRoute = AdminQuestsQuestIdImport.update({
-  path: '/quests/$questId',
-  getParentRoute: () => AdminRouteRoute,
-} as any)
-
-const AdminFormsFormIdRoute = AdminFormsFormIdImport.update({
-  path: '/forms/$formId',
-  getParentRoute: () => AdminRouteRoute,
-} as any)
+const AuthenticatedAdminFormsFormIdRoute =
+  AuthenticatedAdminFormsFormIdImport.update({
+    path: '/forms/$formId',
+    getParentRoute: () => AuthenticatedAdminRouteRoute,
+  } as any)
 
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexImport
+    '/_authenticated': {
+      id: '/_authenticated'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof AuthenticatedImport
       parentRoute: typeof rootRoute
     }
-    '/admin': {
-      id: '/admin'
+    '/_unauthenticated': {
+      id: '/_unauthenticated'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof UnauthenticatedImport
+      parentRoute: typeof rootRoute
+    }
+    '/_authenticated/admin': {
+      id: '/_authenticated/admin'
       path: '/admin'
       fullPath: '/admin'
-      preLoaderRoute: typeof AdminRouteImport
-      parentRoute: typeof rootRoute
+      preLoaderRoute: typeof AuthenticatedAdminRouteImport
+      parentRoute: typeof AuthenticatedImport
     }
-    '/quests': {
-      id: '/quests'
+    '/_authenticated/quests': {
+      id: '/_authenticated/quests'
       path: '/quests'
       fullPath: '/quests'
-      preLoaderRoute: typeof QuestsRouteImport
-      parentRoute: typeof rootRoute
+      preLoaderRoute: typeof AuthenticatedQuestsRouteImport
+      parentRoute: typeof AuthenticatedImport
     }
-    '/quests/$questId': {
-      id: '/quests/$questId'
+    '/_unauthenticated/login': {
+      id: '/_unauthenticated/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof UnauthenticatedLoginImport
+      parentRoute: typeof UnauthenticatedImport
+    }
+    '/_authenticated/': {
+      id: '/_authenticated/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof AuthenticatedIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/quests/$questId': {
+      id: '/_authenticated/quests/$questId'
       path: '/$questId'
       fullPath: '/quests/$questId'
-      preLoaderRoute: typeof QuestsQuestIdImport
-      parentRoute: typeof QuestsRouteImport
+      preLoaderRoute: typeof AuthenticatedQuestsQuestIdImport
+      parentRoute: typeof AuthenticatedQuestsRouteImport
     }
-    '/admin/': {
-      id: '/admin/'
+    '/_authenticated/admin/': {
+      id: '/_authenticated/admin/'
       path: '/'
       fullPath: '/admin/'
-      preLoaderRoute: typeof AdminIndexImport
-      parentRoute: typeof AdminRouteImport
+      preLoaderRoute: typeof AuthenticatedAdminIndexImport
+      parentRoute: typeof AuthenticatedAdminRouteImport
     }
-    '/settings/': {
-      id: '/settings/'
+    '/_authenticated/settings/': {
+      id: '/_authenticated/settings/'
       path: '/settings'
       fullPath: '/settings'
-      preLoaderRoute: typeof SettingsIndexImport
-      parentRoute: typeof rootRoute
+      preLoaderRoute: typeof AuthenticatedSettingsIndexImport
+      parentRoute: typeof AuthenticatedImport
     }
-    '/admin/forms/$formId': {
-      id: '/admin/forms/$formId'
+    '/_authenticated/admin/forms/$formId': {
+      id: '/_authenticated/admin/forms/$formId'
       path: '/forms/$formId'
       fullPath: '/admin/forms/$formId'
-      preLoaderRoute: typeof AdminFormsFormIdImport
-      parentRoute: typeof AdminRouteImport
+      preLoaderRoute: typeof AuthenticatedAdminFormsFormIdImport
+      parentRoute: typeof AuthenticatedAdminRouteImport
     }
-    '/admin/quests/$questId': {
-      id: '/admin/quests/$questId'
+    '/_authenticated/admin/quests/$questId': {
+      id: '/_authenticated/admin/quests/$questId'
       path: '/quests/$questId'
       fullPath: '/admin/quests/$questId'
-      preLoaderRoute: typeof AdminQuestsQuestIdImport
-      parentRoute: typeof AdminRouteImport
+      preLoaderRoute: typeof AuthenticatedAdminQuestsQuestIdImport
+      parentRoute: typeof AuthenticatedAdminRouteImport
     }
-    '/admin/forms/': {
-      id: '/admin/forms/'
+    '/_authenticated/admin/forms/': {
+      id: '/_authenticated/admin/forms/'
       path: '/forms'
       fullPath: '/admin/forms'
-      preLoaderRoute: typeof AdminFormsIndexImport
-      parentRoute: typeof AdminRouteImport
+      preLoaderRoute: typeof AuthenticatedAdminFormsIndexImport
+      parentRoute: typeof AuthenticatedAdminRouteImport
     }
-    '/admin/quests/': {
-      id: '/admin/quests/'
+    '/_authenticated/admin/quests/': {
+      id: '/_authenticated/admin/quests/'
       path: '/quests'
       fullPath: '/admin/quests'
-      preLoaderRoute: typeof AdminQuestsIndexImport
-      parentRoute: typeof AdminRouteImport
+      preLoaderRoute: typeof AuthenticatedAdminQuestsIndexImport
+      parentRoute: typeof AuthenticatedAdminRouteImport
     }
   }
 }
 
 // Create and export the route tree
 
-interface AdminRouteRouteChildren {
-  AdminIndexRoute: typeof AdminIndexRoute
-  AdminFormsFormIdRoute: typeof AdminFormsFormIdRoute
-  AdminQuestsQuestIdRoute: typeof AdminQuestsQuestIdRoute
-  AdminFormsIndexRoute: typeof AdminFormsIndexRoute
-  AdminQuestsIndexRoute: typeof AdminQuestsIndexRoute
+interface AuthenticatedAdminRouteRouteChildren {
+  AuthenticatedAdminIndexRoute: typeof AuthenticatedAdminIndexRoute
+  AuthenticatedAdminFormsFormIdRoute: typeof AuthenticatedAdminFormsFormIdRoute
+  AuthenticatedAdminQuestsQuestIdRoute: typeof AuthenticatedAdminQuestsQuestIdRoute
+  AuthenticatedAdminFormsIndexRoute: typeof AuthenticatedAdminFormsIndexRoute
+  AuthenticatedAdminQuestsIndexRoute: typeof AuthenticatedAdminQuestsIndexRoute
 }
 
-const AdminRouteRouteChildren: AdminRouteRouteChildren = {
-  AdminIndexRoute: AdminIndexRoute,
-  AdminFormsFormIdRoute: AdminFormsFormIdRoute,
-  AdminQuestsQuestIdRoute: AdminQuestsQuestIdRoute,
-  AdminFormsIndexRoute: AdminFormsIndexRoute,
-  AdminQuestsIndexRoute: AdminQuestsIndexRoute,
+const AuthenticatedAdminRouteRouteChildren: AuthenticatedAdminRouteRouteChildren =
+  {
+    AuthenticatedAdminIndexRoute: AuthenticatedAdminIndexRoute,
+    AuthenticatedAdminFormsFormIdRoute: AuthenticatedAdminFormsFormIdRoute,
+    AuthenticatedAdminQuestsQuestIdRoute: AuthenticatedAdminQuestsQuestIdRoute,
+    AuthenticatedAdminFormsIndexRoute: AuthenticatedAdminFormsIndexRoute,
+    AuthenticatedAdminQuestsIndexRoute: AuthenticatedAdminQuestsIndexRoute,
+  }
+
+const AuthenticatedAdminRouteRouteWithChildren =
+  AuthenticatedAdminRouteRoute._addFileChildren(
+    AuthenticatedAdminRouteRouteChildren,
+  )
+
+interface AuthenticatedQuestsRouteRouteChildren {
+  AuthenticatedQuestsQuestIdRoute: typeof AuthenticatedQuestsQuestIdRoute
 }
 
-const AdminRouteRouteWithChildren = AdminRouteRoute._addFileChildren(
-  AdminRouteRouteChildren,
+const AuthenticatedQuestsRouteRouteChildren: AuthenticatedQuestsRouteRouteChildren =
+  {
+    AuthenticatedQuestsQuestIdRoute: AuthenticatedQuestsQuestIdRoute,
+  }
+
+const AuthenticatedQuestsRouteRouteWithChildren =
+  AuthenticatedQuestsRouteRoute._addFileChildren(
+    AuthenticatedQuestsRouteRouteChildren,
+  )
+
+interface AuthenticatedRouteChildren {
+  AuthenticatedAdminRouteRoute: typeof AuthenticatedAdminRouteRouteWithChildren
+  AuthenticatedQuestsRouteRoute: typeof AuthenticatedQuestsRouteRouteWithChildren
+  AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute
+  AuthenticatedSettingsIndexRoute: typeof AuthenticatedSettingsIndexRoute
+}
+
+const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
+  AuthenticatedAdminRouteRoute: AuthenticatedAdminRouteRouteWithChildren,
+  AuthenticatedQuestsRouteRoute: AuthenticatedQuestsRouteRouteWithChildren,
+  AuthenticatedIndexRoute: AuthenticatedIndexRoute,
+  AuthenticatedSettingsIndexRoute: AuthenticatedSettingsIndexRoute,
+}
+
+const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
+  AuthenticatedRouteChildren,
 )
 
-interface QuestsRouteRouteChildren {
-  QuestsQuestIdRoute: typeof QuestsQuestIdRoute
+interface UnauthenticatedRouteChildren {
+  UnauthenticatedLoginRoute: typeof UnauthenticatedLoginRoute
 }
 
-const QuestsRouteRouteChildren: QuestsRouteRouteChildren = {
-  QuestsQuestIdRoute: QuestsQuestIdRoute,
+const UnauthenticatedRouteChildren: UnauthenticatedRouteChildren = {
+  UnauthenticatedLoginRoute: UnauthenticatedLoginRoute,
 }
 
-const QuestsRouteRouteWithChildren = QuestsRouteRoute._addFileChildren(
-  QuestsRouteRouteChildren,
+const UnauthenticatedRouteWithChildren = UnauthenticatedRoute._addFileChildren(
+  UnauthenticatedRouteChildren,
 )
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/admin': typeof AdminRouteRouteWithChildren
-  '/quests': typeof QuestsRouteRouteWithChildren
-  '/quests/$questId': typeof QuestsQuestIdRoute
-  '/admin/': typeof AdminIndexRoute
-  '/settings': typeof SettingsIndexRoute
-  '/admin/forms/$formId': typeof AdminFormsFormIdRoute
-  '/admin/quests/$questId': typeof AdminQuestsQuestIdRoute
-  '/admin/forms': typeof AdminFormsIndexRoute
-  '/admin/quests': typeof AdminQuestsIndexRoute
+  '': typeof UnauthenticatedRouteWithChildren
+  '/admin': typeof AuthenticatedAdminRouteRouteWithChildren
+  '/quests': typeof AuthenticatedQuestsRouteRouteWithChildren
+  '/login': typeof UnauthenticatedLoginRoute
+  '/': typeof AuthenticatedIndexRoute
+  '/quests/$questId': typeof AuthenticatedQuestsQuestIdRoute
+  '/admin/': typeof AuthenticatedAdminIndexRoute
+  '/settings': typeof AuthenticatedSettingsIndexRoute
+  '/admin/forms/$formId': typeof AuthenticatedAdminFormsFormIdRoute
+  '/admin/quests/$questId': typeof AuthenticatedAdminQuestsQuestIdRoute
+  '/admin/forms': typeof AuthenticatedAdminFormsIndexRoute
+  '/admin/quests': typeof AuthenticatedAdminQuestsIndexRoute
 }
 
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/quests': typeof QuestsRouteRouteWithChildren
-  '/quests/$questId': typeof QuestsQuestIdRoute
-  '/admin': typeof AdminIndexRoute
-  '/settings': typeof SettingsIndexRoute
-  '/admin/forms/$formId': typeof AdminFormsFormIdRoute
-  '/admin/quests/$questId': typeof AdminQuestsQuestIdRoute
-  '/admin/forms': typeof AdminFormsIndexRoute
-  '/admin/quests': typeof AdminQuestsIndexRoute
+  '': typeof UnauthenticatedRouteWithChildren
+  '/quests': typeof AuthenticatedQuestsRouteRouteWithChildren
+  '/login': typeof UnauthenticatedLoginRoute
+  '/': typeof AuthenticatedIndexRoute
+  '/quests/$questId': typeof AuthenticatedQuestsQuestIdRoute
+  '/admin': typeof AuthenticatedAdminIndexRoute
+  '/settings': typeof AuthenticatedSettingsIndexRoute
+  '/admin/forms/$formId': typeof AuthenticatedAdminFormsFormIdRoute
+  '/admin/quests/$questId': typeof AuthenticatedAdminQuestsQuestIdRoute
+  '/admin/forms': typeof AuthenticatedAdminFormsIndexRoute
+  '/admin/quests': typeof AuthenticatedAdminQuestsIndexRoute
 }
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
-  '/': typeof IndexRoute
-  '/admin': typeof AdminRouteRouteWithChildren
-  '/quests': typeof QuestsRouteRouteWithChildren
-  '/quests/$questId': typeof QuestsQuestIdRoute
-  '/admin/': typeof AdminIndexRoute
-  '/settings/': typeof SettingsIndexRoute
-  '/admin/forms/$formId': typeof AdminFormsFormIdRoute
-  '/admin/quests/$questId': typeof AdminQuestsQuestIdRoute
-  '/admin/forms/': typeof AdminFormsIndexRoute
-  '/admin/quests/': typeof AdminQuestsIndexRoute
+  '/_authenticated': typeof AuthenticatedRouteWithChildren
+  '/_unauthenticated': typeof UnauthenticatedRouteWithChildren
+  '/_authenticated/admin': typeof AuthenticatedAdminRouteRouteWithChildren
+  '/_authenticated/quests': typeof AuthenticatedQuestsRouteRouteWithChildren
+  '/_unauthenticated/login': typeof UnauthenticatedLoginRoute
+  '/_authenticated/': typeof AuthenticatedIndexRoute
+  '/_authenticated/quests/$questId': typeof AuthenticatedQuestsQuestIdRoute
+  '/_authenticated/admin/': typeof AuthenticatedAdminIndexRoute
+  '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
+  '/_authenticated/admin/forms/$formId': typeof AuthenticatedAdminFormsFormIdRoute
+  '/_authenticated/admin/quests/$questId': typeof AuthenticatedAdminQuestsQuestIdRoute
+  '/_authenticated/admin/forms/': typeof AuthenticatedAdminFormsIndexRoute
+  '/_authenticated/admin/quests/': typeof AuthenticatedAdminQuestsIndexRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | '/'
+    | ''
     | '/admin'
     | '/quests'
+    | '/login'
+    | '/'
     | '/quests/$questId'
     | '/admin/'
     | '/settings'
@@ -239,8 +329,10 @@ export interface FileRouteTypes {
     | '/admin/quests'
   fileRoutesByTo: FileRoutesByTo
   to:
-    | '/'
+    | ''
     | '/quests'
+    | '/login'
+    | '/'
     | '/quests/$questId'
     | '/admin'
     | '/settings'
@@ -250,31 +342,30 @@ export interface FileRouteTypes {
     | '/admin/quests'
   id:
     | '__root__'
-    | '/'
-    | '/admin'
-    | '/quests'
-    | '/quests/$questId'
-    | '/admin/'
-    | '/settings/'
-    | '/admin/forms/$formId'
-    | '/admin/quests/$questId'
-    | '/admin/forms/'
-    | '/admin/quests/'
+    | '/_authenticated'
+    | '/_unauthenticated'
+    | '/_authenticated/admin'
+    | '/_authenticated/quests'
+    | '/_unauthenticated/login'
+    | '/_authenticated/'
+    | '/_authenticated/quests/$questId'
+    | '/_authenticated/admin/'
+    | '/_authenticated/settings/'
+    | '/_authenticated/admin/forms/$formId'
+    | '/_authenticated/admin/quests/$questId'
+    | '/_authenticated/admin/forms/'
+    | '/_authenticated/admin/quests/'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  AdminRouteRoute: typeof AdminRouteRouteWithChildren
-  QuestsRouteRoute: typeof QuestsRouteRouteWithChildren
-  SettingsIndexRoute: typeof SettingsIndexRoute
+  AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
+  UnauthenticatedRoute: typeof UnauthenticatedRouteWithChildren
 }
 
 const rootRouteChildren: RootRouteChildren = {
-  IndexRoute: IndexRoute,
-  AdminRouteRoute: AdminRouteRouteWithChildren,
-  QuestsRouteRoute: QuestsRouteRouteWithChildren,
-  SettingsIndexRoute: SettingsIndexRoute,
+  AuthenticatedRoute: AuthenticatedRouteWithChildren,
+  UnauthenticatedRoute: UnauthenticatedRouteWithChildren,
 }
 
 export const routeTree = rootRoute
@@ -289,57 +380,78 @@ export const routeTree = rootRoute
     "__root__": {
       "filePath": "__root.tsx",
       "children": [
-        "/",
-        "/admin",
-        "/quests",
-        "/settings/"
+        "/_authenticated",
+        "/_unauthenticated"
       ]
     },
-    "/": {
-      "filePath": "index.tsx"
-    },
-    "/admin": {
-      "filePath": "admin/route.tsx",
+    "/_authenticated": {
+      "filePath": "_authenticated.tsx",
       "children": [
-        "/admin/",
-        "/admin/forms/$formId",
-        "/admin/quests/$questId",
-        "/admin/forms/",
-        "/admin/quests/"
+        "/_authenticated/admin",
+        "/_authenticated/quests",
+        "/_authenticated/",
+        "/_authenticated/settings/"
       ]
     },
-    "/quests": {
-      "filePath": "quests/route.tsx",
+    "/_unauthenticated": {
+      "filePath": "_unauthenticated.tsx",
       "children": [
-        "/quests/$questId"
+        "/_unauthenticated/login"
       ]
     },
-    "/quests/$questId": {
-      "filePath": "quests/$questId.tsx",
-      "parent": "/quests"
+    "/_authenticated/admin": {
+      "filePath": "_authenticated/admin/route.tsx",
+      "parent": "/_authenticated",
+      "children": [
+        "/_authenticated/admin/",
+        "/_authenticated/admin/forms/$formId",
+        "/_authenticated/admin/quests/$questId",
+        "/_authenticated/admin/forms/",
+        "/_authenticated/admin/quests/"
+      ]
     },
-    "/admin/": {
-      "filePath": "admin/index.tsx",
-      "parent": "/admin"
+    "/_authenticated/quests": {
+      "filePath": "_authenticated/quests/route.tsx",
+      "parent": "/_authenticated",
+      "children": [
+        "/_authenticated/quests/$questId"
+      ]
     },
-    "/settings/": {
-      "filePath": "settings/index.tsx"
+    "/_unauthenticated/login": {
+      "filePath": "_unauthenticated/login.tsx",
+      "parent": "/_unauthenticated"
     },
-    "/admin/forms/$formId": {
-      "filePath": "admin/forms/$formId.tsx",
-      "parent": "/admin"
+    "/_authenticated/": {
+      "filePath": "_authenticated/index.tsx",
+      "parent": "/_authenticated"
     },
-    "/admin/quests/$questId": {
-      "filePath": "admin/quests/$questId.tsx",
-      "parent": "/admin"
+    "/_authenticated/quests/$questId": {
+      "filePath": "_authenticated/quests/$questId.tsx",
+      "parent": "/_authenticated/quests"
     },
-    "/admin/forms/": {
-      "filePath": "admin/forms/index.tsx",
-      "parent": "/admin"
+    "/_authenticated/admin/": {
+      "filePath": "_authenticated/admin/index.tsx",
+      "parent": "/_authenticated/admin"
     },
-    "/admin/quests/": {
-      "filePath": "admin/quests/index.tsx",
-      "parent": "/admin"
+    "/_authenticated/settings/": {
+      "filePath": "_authenticated/settings/index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/admin/forms/$formId": {
+      "filePath": "_authenticated/admin/forms/$formId.tsx",
+      "parent": "/_authenticated/admin"
+    },
+    "/_authenticated/admin/quests/$questId": {
+      "filePath": "_authenticated/admin/quests/$questId.tsx",
+      "parent": "/_authenticated/admin"
+    },
+    "/_authenticated/admin/forms/": {
+      "filePath": "_authenticated/admin/forms/index.tsx",
+      "parent": "/_authenticated/admin"
+    },
+    "/_authenticated/admin/quests/": {
+      "filePath": "_authenticated/admin/quests/index.tsx",
+      "parent": "/_authenticated/admin"
     }
   }
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,13 +1,4 @@
-import {
-  AppHeader,
-  Button,
-  Card,
-  Form,
-  Link,
-  Logo,
-  TextField,
-} from "@/components";
-import { useAuthActions } from "@convex-dev/auth/react";
+import type { Role } from "@convex/types";
 import {
   type NavigateOptions,
   Outlet,
@@ -15,10 +6,9 @@ import {
   createRootRouteWithContext,
   useRouter,
 } from "@tanstack/react-router";
-import { type ConvexAuthState, useConvexAuth } from "convex/react";
-import { useState } from "react";
+import type { ConvexAuthState } from "convex/react";
+import React, { Suspense } from "react";
 import { RouterProvider } from "react-aria-components";
-import type { Role } from "../../convex/types";
 
 declare module "react-aria-components" {
   interface RouterConfig {
@@ -29,7 +19,7 @@ declare module "react-aria-components" {
 
 interface RouterContext {
   title: string;
-  auth: ConvexAuthState;
+  auth: Promise<ConvexAuthState>;
   role: Role;
 }
 
@@ -39,105 +29,16 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 
 function RootRoute() {
   const router = useRouter();
-  const { isAuthenticated } = useConvexAuth();
-  const isProd = process.env.NODE_ENV === "production";
 
-  const SignInWithMagicLink = ({
-    handleLinkSent,
-  }: {
-    handleLinkSent: () => void;
-  }) => {
-    const { signIn } = useAuthActions();
-    const [isSubmitting, setIsSubmitting] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-
-    return (
-      <Form
-        onSubmit={(event) => {
-          event.preventDefault();
-          setIsSubmitting(true);
-          setError(null);
-
-          const formData = new FormData(event.currentTarget);
-          signIn("resend", formData)
-            .then(handleLinkSent)
-            .catch((error) => {
-              console.error(error);
-              setError("Could not send sign-in link. Please try again.");
-              setIsSubmitting(false);
-            });
-        }}
-      >
-        {/* TODO: Make a banner component */}
-        {error && <p>{error}</p>}
-        <TextField
-          label="Email"
-          name="email"
-          type="email"
-          autoComplete="email"
-        />
-        <Button type="submit" isDisabled={isSubmitting} variant="primary">
-          Send sign-in link
-        </Button>
-      </Form>
-    );
-  };
-
-  const SignIn = () => {
-    const [step, setStep] = useState<"signIn" | "linkSent">("signIn");
-
-    return (
-      <Card>
-        {step === "signIn" ? (
-          <SignInWithMagicLink handleLinkSent={() => setStep("linkSent")} />
-        ) : (
-          <div>
-            <p>Check your email.</p>
-            <p>A sign-in link has been sent to your email address.</p>
-            <Button onPress={() => setStep("signIn")}>Cancel</Button>
-          </div>
-        )}
-      </Card>
-    );
-  };
-
-  const ClosedSignups = () => (
-    <Card>
-      <p>
-        Namesake is in active development and currently closed to signups. For
-        name change support, join us on{" "}
-        <Link href="https://namesake.fyi/chat">Discord</Link>.
-      </p>
-    </Card>
-  );
-
-  type AppProps = {
-    isAuthenticated: boolean;
-    isClosed: boolean;
-  };
-
-  const App = ({ isAuthenticated, isClosed }: AppProps) => {
-    if (isClosed || !isAuthenticated) {
-      return (
-        <div className="flex flex-col w-96 max-w-full mx-auto h-screen place-content-center gap-8">
-          <Logo className="mb-4" />
-          {isClosed ? <ClosedSignups /> : <SignIn />}
-          <div className="flex gap-4 justify-center">
-            <Link href="https://namesake.fyi">Namesake</Link>
-            <Link href="https://namesake.fyi/chat">Support</Link>
-            <Link href="https://status.namesake.fyi">System Status</Link>
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <main className="flex flex-col flex-1 min-h-screen text-gray-normal">
-        <AppHeader />
-        <Outlet />
-      </main>
-    );
-  };
+  const TanStackRouterDevtools =
+    process.env.NODE_ENV === "production"
+      ? () => null // Render nothing in production
+      : React.lazy(() =>
+          // Lazy load in development
+          import("@tanstack/router-devtools").then((res) => ({
+            default: res.TanStackRouterDevtools,
+          })),
+        );
 
   return (
     // TODO: Improve this API
@@ -152,7 +53,10 @@ function RootRoute() {
         typeof path === "string" ? path : router.buildLocation(path).href
       }
     >
-      <App isAuthenticated={isAuthenticated} isClosed={isProd} />
+      <Outlet />
+      <Suspense>
+        <TanStackRouterDevtools />
+      </Suspense>
     </RouterProvider>
   );
 }

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -1,0 +1,19 @@
+import { AppHeader } from "@/components";
+import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated")({
+  beforeLoad: async ({ context }) => {
+    const auth = await context.auth;
+    if (!auth.isAuthenticated) throw redirect({ to: "/login" });
+  },
+  component: AuthenticatedRoute,
+});
+
+function AuthenticatedRoute() {
+  return (
+    <main className="flex flex-col flex-1 min-h-screen text-gray-normal">
+      <AppHeader />
+      <Outlet />
+    </main>
+  );
+}

--- a/src/routes/_authenticated/admin/forms/$formId.tsx
+++ b/src/routes/_authenticated/admin/forms/$formId.tsx
@@ -1,10 +1,10 @@
 import { Badge, PageHeader } from "@/components";
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
-import { api } from "../../../../convex/_generated/api";
-import type { Id } from "../../../../convex/_generated/dataModel";
 
-export const Route = createFileRoute("/admin/forms/$formId")({
+export const Route = createFileRoute("/_authenticated/admin/forms/$formId")({
   component: AdminFormDetailRoute,
 });
 

--- a/src/routes/_authenticated/admin/forms/index.tsx
+++ b/src/routes/_authenticated/admin/forms/index.tsx
@@ -19,15 +19,15 @@ import {
   TableRow,
   TextField,
 } from "@/components";
+import { api } from "@convex/_generated/api";
+import type { DataModel } from "@convex/_generated/dataModel";
+import { JURISDICTIONS } from "@convex/constants";
 import { RiAddLine, RiFileTextLine, RiMoreFill } from "@remixicon/react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { useState } from "react";
-import { api } from "../../../../convex/_generated/api";
-import type { DataModel } from "../../../../convex/_generated/dataModel";
-import { JURISDICTIONS } from "../../../../convex/constants";
 
-export const Route = createFileRoute("/admin/forms/")({
+export const Route = createFileRoute("/_authenticated/admin/forms/")({
   component: FormsRoute,
 });
 

--- a/src/routes/_authenticated/admin/index.tsx
+++ b/src/routes/_authenticated/admin/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
-export const Route = createFileRoute("/admin/")({
+export const Route = createFileRoute("/_authenticated/admin/")({
   beforeLoad: () => {
     throw redirect({
       to: "/admin/quests",

--- a/src/routes/_authenticated/admin/quests/$questId.tsx
+++ b/src/routes/_authenticated/admin/quests/$questId.tsx
@@ -7,14 +7,14 @@ import {
   RichTextEditor,
   TextField,
 } from "@/components";
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { useState } from "react";
 import Markdown from "react-markdown";
-import { api } from "../../../../convex/_generated/api";
-import type { Id } from "../../../../convex/_generated/dataModel";
 
-export const Route = createFileRoute("/admin/quests/$questId")({
+export const Route = createFileRoute("/_authenticated/admin/quests/$questId")({
   component: AdminQuestDetailRoute,
 });
 

--- a/src/routes/_authenticated/admin/quests/index.tsx
+++ b/src/routes/_authenticated/admin/quests/index.tsx
@@ -18,15 +18,15 @@ import {
   TableRow,
   TextField,
 } from "@/components";
+import { api } from "@convex/_generated/api";
+import type { DataModel } from "@convex/_generated/dataModel";
+import { JURISDICTIONS } from "@convex/constants";
 import { RiAddLine, RiMoreFill, RiSignpostLine } from "@remixicon/react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { useState } from "react";
-import { api } from "../../../../convex/_generated/api";
-import type { DataModel } from "../../../../convex/_generated/dataModel";
-import { JURISDICTIONS } from "../../../../convex/constants";
 
-export const Route = createFileRoute("/admin/quests/")({
+export const Route = createFileRoute("/_authenticated/admin/quests/")({
   component: QuestsRoute,
 });
 
@@ -95,7 +95,9 @@ const NewQuestModal = ({
 
 const QuestTableRow = ({
   quest,
-}: { quest: DataModel["quests"]["document"] }) => {
+}: {
+  quest: DataModel["quests"]["document"];
+}) => {
   const questCount = useQuery(api.usersQuests.getQuestCount, {
     questId: quest._id,
   });

--- a/src/routes/_authenticated/admin/route.tsx
+++ b/src/routes/_authenticated/admin/route.tsx
@@ -7,7 +7,7 @@ import {
 } from "@remixicon/react";
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 
-export const Route = createFileRoute("/admin")({
+export const Route = createFileRoute("/_authenticated/admin")({
   beforeLoad: ({ context }) => {
     const isAdmin = context.role === "admin";
 

--- a/src/routes/_authenticated/index.tsx
+++ b/src/routes/_authenticated/index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/")({
+  beforeLoad: () => {
+    throw redirect({ to: "/quests" });
+  },
+});

--- a/src/routes/_authenticated/quests/$questId.tsx
+++ b/src/routes/_authenticated/quests/$questId.tsx
@@ -6,14 +6,14 @@ import {
   MenuTrigger,
   PageHeader,
 } from "@/components";
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
 import { RiMoreLine } from "@remixicon/react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import Markdown from "react-markdown";
-import { api } from "../../../convex/_generated/api";
-import type { Id } from "../../../convex/_generated/dataModel";
 
-export const Route = createFileRoute("/quests/$questId")({
+export const Route = createFileRoute("/_authenticated/quests/$questId")({
   component: QuestDetailRoute,
 });
 

--- a/src/routes/_authenticated/quests/route.tsx
+++ b/src/routes/_authenticated/quests/route.tsx
@@ -8,6 +8,8 @@ import {
   GridListItem,
   Modal,
 } from "@/components";
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
 import { RiAddLine, RiSignpostLine } from "@remixicon/react";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
 import {
@@ -18,10 +20,8 @@ import {
 } from "convex/react";
 import { useState } from "react";
 import type { Selection } from "react-aria-components";
-import { api } from "../../../convex/_generated/api";
-import type { Id } from "../../../convex/_generated/dataModel";
 
-export const Route = createFileRoute("/quests")({
+export const Route = createFileRoute("/_authenticated/quests")({
   component: IndexRoute,
 });
 

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -10,16 +10,16 @@ import {
   TextField,
 } from "@/components";
 import { useAuthActions } from "@convex-dev/auth/react";
+import { api } from "@convex/_generated/api";
+import type { Theme } from "@convex/types";
 import { RiCheckLine, RiLoader4Line } from "@remixicon/react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
-import { api } from "../../../convex/_generated/api";
-import type { Theme } from "../../../convex/types";
 
-export const Route = createFileRoute("/settings/")({
+export const Route = createFileRoute("/_authenticated/settings/")({
   component: SettingsRoute,
 });
 

--- a/src/routes/_unauthenticated.tsx
+++ b/src/routes/_unauthenticated.tsx
@@ -1,0 +1,14 @@
+import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_unauthenticated")({
+  beforeLoad: async ({ context }) => {
+    const auth = await context.auth;
+    // If already authenticated, redirect to dashboard
+    if (auth.isAuthenticated) throw redirect({ to: "/" });
+  },
+  component: UnauthenticatedRoute,
+});
+
+function UnauthenticatedRoute() {
+  return <Outlet />;
+}

--- a/src/routes/_unauthenticated/login.tsx
+++ b/src/routes/_unauthenticated/login.tsx
@@ -1,0 +1,88 @@
+import { Button, Card, Form, Link, Logo, TextField } from "@/components";
+import { useAuthActions } from "@convex-dev/auth/react";
+import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
+
+export const Route = createFileRoute("/_unauthenticated/login")({
+  component: LoginRoute,
+});
+
+const SignInWithMagicLink = ({
+  handleLinkSent,
+}: {
+  handleLinkSent: () => void;
+}) => {
+  const { signIn } = useAuthActions();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <Form
+      onSubmit={(event) => {
+        event.preventDefault();
+        setIsSubmitting(true);
+        setError(null);
+
+        const formData = new FormData(event.currentTarget);
+        signIn("resend", formData)
+          .then(handleLinkSent)
+          .catch((error) => {
+            console.error(error);
+            setError("Could not send sign-in link. Please try again.");
+            setIsSubmitting(false);
+          });
+      }}
+    >
+      {/* TODO: Make a banner component */}
+      {error && <p>{error}</p>}
+      <TextField label="Email" name="email" type="email" autoComplete="email" />
+      <Button type="submit" isDisabled={isSubmitting} variant="primary">
+        Send sign-in link
+      </Button>
+    </Form>
+  );
+};
+
+const SignIn = () => {
+  const [step, setStep] = useState<"signIn" | "linkSent">("signIn");
+
+  return (
+    <Card>
+      {step === "signIn" ? (
+        <SignInWithMagicLink handleLinkSent={() => setStep("linkSent")} />
+      ) : (
+        <div>
+          <p>Check your email.</p>
+          <p>A sign-in link has been sent to your email address.</p>
+          <Button onPress={() => setStep("signIn")}>Cancel</Button>
+        </div>
+      )}
+    </Card>
+  );
+};
+
+const ClosedSignups = () => (
+  <Card>
+    <p>
+      Namesake is in active development and currently closed to signups. For
+      name change support, join us on{" "}
+      <Link href="https://namesake.fyi/chat">Discord</Link>.
+    </p>
+  </Card>
+);
+
+function LoginRoute() {
+  const isClosed = process.env.NODE_ENV === "production";
+
+  return (
+    <div className="flex flex-col w-96 max-w-full mx-auto h-screen place-content-center gap-8">
+      <Logo className="mb-4" />
+      {isClosed ? <ClosedSignups /> : <SignIn />}
+      <div className="flex gap-4 justify-center">
+        <Link href="https://namesake.fyi">Namesake</Link>
+        <Link href="https://namesake.fyi/chat">Support</Link>
+        <Link href="https://status.namesake.fyi">System Status</Link>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,0 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
-
-export const Route = createFileRoute("/")({
-  beforeLoad: ({ context }) => {
-    if (context.auth.isAuthenticated) throw redirect({ to: "/quests" });
-  },
-});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -17,7 +17,8 @@
     "noFallthroughCasesInSwitch": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@convex/*": ["convex/*"]
     }
   }
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -15,7 +15,8 @@
     "noFallthroughCasesInSwitch": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@convex/*": ["convex/*"]
     }
   },
   "include": ["vite.config.ts"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,10 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: [{ find: "@", replacement: "/src" }],
+    alias: [
+      { find: "@", replacement: "/src" },
+      { find: "@convex", replacement: "/convex" },
+    ],
   },
   test: {
     environment: "edge-runtime",


### PR DESCRIPTION
## What changed?
Improve redirect logic for unauth and auth users.

## Why?
Existing logic wasn't working well.

## How was this change made?
Created two pathless routes for `_authenticated` (which redirects to `/login` if user is unauthenticated) and `_unauthenticated` (which redirects to `/` if user is already authenticated).

This way, all routes like `/settings`, `/quests`, etc. can be protected with a redirect to `/login` for unauthenticated users, and `/login` can redirect to the dashboard for authenticated users.

## How was this tested?
Manual testing.

## Anything else?
Also creates an `@convex` alias, upgrades `@convex-dev/auth`, and displays TanStack Router Devtools on dev environments.