### PR TITLE
feat: Support adding `questFields` to a `questStep`; display form fields within a quest

### DIFF
--- a/.changeset/seven-radios-suffer.md
+++ b/.changeset/seven-radios-suffer.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Display form fields within quest steps

--- a/convex/questFields.ts
+++ b/convex/questFields.ts
@@ -10,6 +10,19 @@ export const getAllFields = query({
   },
 });
 
+export const getFields = query({
+  args: { fieldIds: v.array(v.id("questFields")) },
+  handler: async (ctx, args) => {
+    const fields = await Promise.all(
+      args.fieldIds.map(async (fieldId) => {
+        const field = await ctx.db.get(fieldId);
+        if (field) return field;
+      }),
+    ).then((fields) => fields.filter((field) => field !== undefined));
+    return fields;
+  },
+});
+
 export const createField = userMutation({
   args: {
     type: field,

--- a/convex/questSteps.ts
+++ b/convex/questSteps.ts
@@ -10,6 +10,7 @@ export const create = userMutation({
     questId: v.id("quests"),
     title: v.string(),
     description: v.optional(v.string()),
+    fields: v.optional(v.array(v.id("questFields"))),
   },
   handler: async (ctx, args) => {
     const questStepId = await ctx.db.insert("questSteps", {
@@ -17,6 +18,7 @@ export const create = userMutation({
       title: args.title,
       description: args.description,
       creationUser: ctx.userId,
+      fields: args.fields,
     });
 
     const quest = await ctx.db.get(args.questId);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -31,13 +31,7 @@ const questSteps = defineTable({
   creationUser: v.id("users"),
   title: v.string(),
   description: v.optional(v.string()),
-  fields: v.optional(
-    v.array(
-      v.object({
-        fieldId: v.id("questFields"),
-      }),
-    ),
-  ),
+  fields: v.optional(v.array(v.id("questFields"))),
 }).index("questId", ["questId"]);
 
 /**
@@ -115,7 +109,7 @@ const userQuests = defineTable({
  */
 const userData = defineTable({
   userId: v.id("users"),
-  fieldId: v.id("fields"),
+  fieldId: v.id("questFields"),
   value: v.string(),
 }).index("userId", ["userId"]);
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -58,7 +58,7 @@ const boxStyles = tv({
       true: "bg-purple-9 dark:bg-purpledark-9 border-transparent",
     },
     isInvalid: {
-      true: "text-red-9 dark:text-reddark-9 forced-colors:![--color:Mark] group-pressed:[--color:theme(colors.red.800)] dark:group-pressed:[--color:theme(colors.red.700)]",
+      true: "text-red-9 dark:text-reddark-9 forced-colors:![--color:Mark]",
     },
     isDisabled: {
       true: "text-gray-7 dark:text-graydark-7 forced-colors:![--color:GrayText]",

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -4,7 +4,7 @@ import {
   Checkbox as AriaCheckbox,
   CheckboxGroup as AriaCheckboxGroup,
   type CheckboxGroupProps as AriaCheckboxGroupProps,
-  type CheckboxProps,
+  type CheckboxProps as AriaCheckboxProps,
   type ValidationResult,
   composeRenderProps,
 } from "react-aria-components";
@@ -40,7 +40,7 @@ export function CheckboxGroup(props: CheckboxGroupProps) {
 }
 
 const checkboxStyles = tv({
-  base: "flex gap-2 items-center group text-sm transition",
+  base: "flex gap-2 items-center group transition w-max",
   variants: {
     isDisabled: {
       false: "text-gray-normal cursor-pointer",
@@ -69,31 +69,46 @@ const boxStyles = tv({
 const iconStyles =
   "w-5 h-5 text-white group-disabled:text-gray-4 dark:group-disabled:text-gray-9 forced-colors:text-[HighlightText]";
 
+export interface CheckboxProps extends AriaCheckboxProps {
+  label?: string;
+  description?: string;
+}
+
 export function Checkbox(props: CheckboxProps) {
   return (
-    <AriaCheckbox
-      {...props}
-      className={composeRenderProps(props.className, (className, renderProps) =>
-        checkboxStyles({ ...renderProps, className }),
+    <div>
+      <AriaCheckbox
+        {...props}
+        className={composeRenderProps(
+          props.className,
+          (className, renderProps) =>
+            checkboxStyles({ ...renderProps, className }),
+        )}
+      >
+        {({ isSelected, isIndeterminate, ...renderProps }) => (
+          <>
+            <div
+              className={boxStyles({
+                isSelected: isSelected || isIndeterminate,
+                ...renderProps,
+              })}
+            >
+              {isIndeterminate ? (
+                <RiSubtractLine aria-hidden className={iconStyles} />
+              ) : isSelected ? (
+                <RiCheckLine aria-hidden className={iconStyles} />
+              ) : null}
+            </div>
+            {props.label}
+            {props.children}
+          </>
+        )}
+      </AriaCheckbox>
+      {props.description && (
+        <FieldDescription className="ml-8">
+          {props.description}
+        </FieldDescription>
       )}
-    >
-      {({ isSelected, isIndeterminate, ...renderProps }) => (
-        <>
-          <div
-            className={boxStyles({
-              isSelected: isSelected || isIndeterminate,
-              ...renderProps,
-            })}
-          >
-            {isIndeterminate ? (
-              <RiSubtractLine aria-hidden className={iconStyles} />
-            ) : isSelected ? (
-              <RiCheckLine aria-hidden className={iconStyles} />
-            ) : null}
-          </div>
-          {props.children}
-        </>
-      )}
-    </AriaCheckbox>
+    </div>
   );
 }

--- a/src/components/QuestStep/QuestStep.tsx
+++ b/src/components/QuestStep/QuestStep.tsx
@@ -3,7 +3,7 @@ import type { Doc, Id } from "@convex/_generated/dataModel";
 import { useQuery } from "convex/react";
 import Markdown from "react-markdown";
 import { Card } from "../Card";
-import { CheckboxGroup } from "../Checkbox";
+import { Checkbox } from "../Checkbox";
 import { DateField } from "../DateField";
 import { NumberField } from "../NumberField";
 import { Select, SelectItem } from "../Select";
@@ -55,9 +55,7 @@ export function QuestFields(props: { questFields: Doc<"questFields">[] }) {
           </Select>
         );
       case "checkbox":
-        return (
-          <CheckboxGroup label={field.label} description={field.helpText} />
-        );
+        return <Checkbox label={field.label} description={field.helpText} />;
       case "date":
         return <DateField label={field.label} description={field.helpText} />;
       default:
@@ -66,7 +64,9 @@ export function QuestFields(props: { questFields: Doc<"questFields">[] }) {
   };
 
   // TODO: Add skeleton loaders
-  return <>{props.questFields.map((field) => markupForField(field))}</>;
+  return props.questFields.map((field) => (
+    <div key={field._id}>{markupForField(field)}</div>
+  ));
 }
 
 export function QuestStep({ title, description, fields }: QuestStepProps) {

--- a/src/components/QuestStep/QuestStep.tsx
+++ b/src/components/QuestStep/QuestStep.tsx
@@ -65,6 +65,7 @@ export function QuestFields(props: { questFields: Doc<"questFields">[] }) {
     }
   };
 
+  // TODO: Add skeleton loaders
   return <>{props.questFields.map((field) => markupForField(field))}</>;
 }
 

--- a/src/components/QuestStep/QuestStep.tsx
+++ b/src/components/QuestStep/QuestStep.tsx
@@ -1,0 +1,87 @@
+import { api } from "@convex/_generated/api";
+import type { Doc, Id } from "@convex/_generated/dataModel";
+import { useQuery } from "convex/react";
+import Markdown from "react-markdown";
+import { Card } from "../Card";
+import { CheckboxGroup } from "../Checkbox";
+import { DateField } from "../DateField";
+import { NumberField } from "../NumberField";
+import { Select, SelectItem } from "../Select";
+import { TextArea } from "../TextArea";
+import { TextField } from "../TextField";
+
+export interface QuestStepProps {
+  title: string;
+  description?: string;
+  fields?: Id<"questFields">[];
+}
+
+export function QuestFields(props: { questFields: Doc<"questFields">[] }) {
+  const markupForField = (field: Doc<"questFields">) => {
+    switch (field.type) {
+      case "text":
+        return (
+          <TextField
+            label={field.label}
+            description={field.helpText}
+            type="text"
+          />
+        );
+      case "email":
+        return (
+          <TextField
+            label={field.label}
+            description={field.helpText}
+            type="email"
+          />
+        );
+      case "phone":
+        return (
+          <TextField
+            label={field.label}
+            description={field.helpText}
+            type="tel"
+          />
+        );
+      case "textarea":
+        return <TextArea label={field.label} description={field.helpText} />;
+      case "number":
+        return <NumberField label={field.label} description={field.helpText} />;
+      case "select":
+        return (
+          <Select label={field.label} description={field.helpText}>
+            {/* TODO: Add select options */}
+            <SelectItem />
+          </Select>
+        );
+      case "checkbox":
+        return (
+          <CheckboxGroup label={field.label} description={field.helpText} />
+        );
+      case "date":
+        return <DateField label={field.label} description={field.helpText} />;
+      default:
+        return undefined;
+    }
+  };
+
+  return <>{props.questFields.map((field) => markupForField(field))}</>;
+}
+
+export function QuestStep({ title, description, fields }: QuestStepProps) {
+  const questFields = useQuery(api.questFields.getFields, {
+    fieldIds: fields ?? [],
+  });
+
+  return (
+    <Card className="flex flex-col gap-2">
+      <h2 className="text-xl font-semibold">{title}</h2>
+      {description && (
+        <div>
+          <Markdown className="prose dark:prose-invert">{description}</Markdown>
+        </div>
+      )}
+      {questFields && <QuestFields questFields={questFields} />}
+    </Card>
+  );
+}

--- a/src/routes/_authenticated/admin/quests/$questId.tsx
+++ b/src/routes/_authenticated/admin/quests/$questId.tsx
@@ -11,6 +11,7 @@ import {
   SelectItem,
   TextField,
 } from "@/components";
+import { QuestStep } from "@/components/QuestStep/QuestStep";
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 import { FIELDS, ICONS } from "@convex/constants";
@@ -18,7 +19,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { useState } from "react";
 import { MenuTrigger } from "react-aria-components";
-import Markdown from "react-markdown";
 
 export const Route = createFileRoute("/_authenticated/admin/quests/$questId")({
   component: AdminQuestDetailRoute,
@@ -75,16 +75,11 @@ function AdminQuestDetailRoute() {
               (step, i) =>
                 step && (
                   <li key={`${quest.title}-step-${i}`}>
-                    <Card className="flex flex-col gap-2">
-                      <h2 className="text-xl font-semibold">{step.title}</h2>
-                      {step.description && (
-                        <div>
-                          <Markdown className="prose dark:prose-invert">
-                            {step.description}
-                          </Markdown>
-                        </div>
-                      )}
-                    </Card>
+                    <QuestStep
+                      title={step.title}
+                      description={step.description}
+                      fields={step.fields}
+                    />
                   </li>
                 ),
             )}

--- a/src/routes/_authenticated/quests/$questId.tsx
+++ b/src/routes/_authenticated/quests/$questId.tsx
@@ -1,19 +1,18 @@
 import {
   Badge,
   Button,
-  Card,
   Menu,
   MenuItem,
   MenuTrigger,
   PageHeader,
 } from "@/components";
+import { QuestStep } from "@/components/QuestStep/QuestStep";
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 import { ICONS } from "@convex/constants";
 import { RiMoreLine } from "@remixicon/react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
-import Markdown from "react-markdown";
 
 export const Route = createFileRoute("/_authenticated/quests/$questId")({
   component: QuestDetailRoute,
@@ -82,10 +81,11 @@ function QuestDetailRoute() {
             (step, i) =>
               step && (
                 <li key={`${quest.title}-step-${i}`}>
-                  <Card>
-                    <h2 className="text-xl font-medium mb-2">{step.title}</h2>
-                    <Markdown>{step.description}</Markdown>
-                  </Card>
+                  <QuestStep
+                    title={step.title}
+                    description={step.description}
+                    fields={step.fields}
+                  />
                 </li>
               ),
           )}


### PR DESCRIPTION
## What changed?
- Connect `questSteps` table to `questFields` table by supplying an array of `questFields` to a `fields` column for a step
- Create a new `QuestStep` component to handle displaying the step title, description, and fields
- Use the `QuestStep` component within the admin and on user-facing quests
- Support linking `questFields` to a `questStep` via the Admin UI
- Extend `Checkbox` component with support for `label` and `description`

## Why?
Ongoing work to provide v1 experience. Pre-defining fields that can be re-used across multiple quests will help enforce consistency and allow us to define canonical inputs for common entries like email and name.

## How was this change made?
Removed old tables, connected new data, tested end-to-end to make sure everything works.

## How was this tested?
Manual testing.

## Anything else?
First part of #111; will follow-up with saving user data from form fields.