### PR TITLE
feat: Support field deletion and creation of fields from within a quest step

### DIFF
--- a/.changeset/little-planets-protect.md
+++ b/.changeset/little-planets-protect.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Support deleting fields, allow adding fields directly from quest steps, constrain width of app

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -187,7 +187,6 @@ export const JURISDICTIONS = {
   CT: "Connecticut",
   DC: "District of Columbia",
   DE: "Delaware",
-  FED: "Federal",
   FL: "Florida",
   GA: "Georgia",
   HI: "Hawaii",

--- a/convex/questFields.ts
+++ b/convex/questFields.ts
@@ -39,3 +39,45 @@ export const createField = userMutation({
     });
   },
 });
+
+export const getFieldUsageCount = query({
+  args: { fieldId: v.id("questFields") },
+  handler: async (ctx, args) => {
+    const quests = await ctx.db
+      .query("questSteps")
+      .filter((q) => q.field("fields") !== null)
+      .collect();
+
+    return quests.filter((quest) => quest.fields?.includes(args.fieldId))
+      .length;
+  },
+});
+
+export const deleteField = userMutation({
+  args: { fieldId: v.id("questFields") },
+  handler: async (ctx, args) => {
+    const usageCount = await getFieldUsageCount(ctx, args);
+    if (usageCount > 0) {
+      throw new Error("Field is in use and cannot be deleted.");
+    }
+    await ctx.db.patch(args.fieldId, { deletionTime: Date.now() });
+  },
+});
+
+export const undeleteField = userMutation({
+  args: { fieldId: v.id("questFields") },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.fieldId, { deletionTime: undefined });
+  },
+});
+
+export const permanentlyDeleteField = userMutation({
+  args: { fieldId: v.id("questFields") },
+  handler: async (ctx, args) => {
+    const usageCount = await getFieldUsageCount(ctx, args);
+    if (usageCount > 0) {
+      throw new Error("Field is in use and cannot be deleted.");
+    }
+    await ctx.db.delete(args.fieldId);
+  },
+});

--- a/convex/questSteps.ts
+++ b/convex/questSteps.ts
@@ -40,7 +40,17 @@ export const getStepsForQuest = query({
 
     const steps = await Promise.all(
       quest.steps.map(async (stepId) => {
-        return await ctx.db.get(stepId);
+        const step = await ctx.db.get(stepId);
+        if (!step) return;
+
+        const fields = step.fields
+          ? await Promise.all(step.fields.map((fieldId) => ctx.db.get(fieldId)))
+          : [];
+
+        return {
+          ...step,
+          fields: fields.filter((field) => field !== null),
+        };
       }),
     );
     return steps;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -22,6 +22,8 @@ const quests = defineTable({
 
 /**
  * Represents a single step in a quest.
+ * @param questId - The quest this step belongs to.
+ * @param creationUser - The user who created the step.
  * @param title - The title of the step. (e.g. "Fill out form")
  * @param description - A description of the step.
  * @param fields - An array of form fields to complete the step.
@@ -40,13 +42,16 @@ const questSteps = defineTable({
  * to pre-fill fields that point to the same data in future quests.
  * @param type - The type of field. (e.g. "text", "select")
  * @param label - The label for the field. (e.g. "First Name")
+ * @param slug - A unique identifier for the field, camel cased. (e.g. "firstName")
  * @param helpText - Additional help text for the field.
+ * @param deletionTime - Time in ms since epoch when the field was deleted.
  */
 const questFields = defineTable({
   type: field,
   label: v.string(),
   slug: v.string(),
   helpText: v.optional(v.string()),
+  deletionTime: v.optional(v.number()),
 });
 
 /**

--- a/convex/userQuests.ts
+++ b/convex/userQuests.ts
@@ -105,3 +105,14 @@ export const markIncomplete = userMutation({
     await ctx.db.patch(userQuest._id, { completionTime: undefined });
   },
 });
+
+export const removeQuest = userMutation({
+  args: { questId: v.id("quests") },
+  handler: async (ctx, args) => {
+    const userQuest = await getUserQuestByQuestId(ctx, {
+      questId: args.questId,
+    });
+    if (userQuest === null) throw new Error("Quest not found");
+    await ctx.db.delete(userQuest._id);
+  },
+});

--- a/package.json
+++ b/package.json
@@ -96,5 +96,5 @@
     "vite": "^5.4.5",
     "vitest": "^2.1.1"
   },
-  "packageManager": "pnpm@9.11.0+sha256.1c0e33f70e5df9eede84a357bdfa0b1f9dba6e58194628d48a1055756f553754"
+  "packageManager": "pnpm@9.11.0"
 }

--- a/package.json
+++ b/package.json
@@ -96,5 +96,5 @@
     "vite": "^5.4.5",
     "vitest": "^2.1.1"
   },
-  "packageManager": "pnpm@9.9.0"
+  "packageManager": "pnpm@9.11.0+sha256.1c0e33f70e5df9eede84a357bdfa0b1f9dba6e58194628d48a1055756f553754"
 }

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -19,7 +19,7 @@ export const AppHeader = () => {
   };
 
   return (
-    <div className="flex gap-4 bg-gray-app items-center w-screen h-14 px-4 border-b border-gray-dim sticky top-0">
+    <div className="flex gap-4 bg-gray-app items-center w-screen h-14 px-4 border-b border-gray-dim sticky top-0 z-50">
       <Link href={{ to: "/" }}>
         <Logo className="h-[1.25rem]" />
       </Link>

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -22,7 +22,7 @@ export function Label(props: LabelProps) {
     <AriaLabel
       {...props}
       className={twMerge(
-        "text-sm text-gray-dim cursor-default w-fit",
+        "text-sm text-gray-normal cursor-default w-fit",
         props.className,
       )}
     />

--- a/src/components/QuestStep/QuestStep.stories.tsx
+++ b/src/components/QuestStep/QuestStep.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { QuestStep } from "./QuestStep";
+
+const meta = {
+  component: QuestStep,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof QuestStep>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "Get started",
+    description: "This is the first step in the quest.",
+  },
+};

--- a/src/components/QuestStep/QuestStep.tsx
+++ b/src/components/QuestStep/QuestStep.tsx
@@ -1,6 +1,4 @@
-import { api } from "@convex/_generated/api";
-import type { Doc, Id } from "@convex/_generated/dataModel";
-import { useQuery } from "convex/react";
+import type { Doc } from "@convex/_generated/dataModel";
 import Markdown from "react-markdown";
 import { Card } from "../Card";
 import { Checkbox } from "../Checkbox";
@@ -13,7 +11,7 @@ import { TextField } from "../TextField";
 export interface QuestStepProps {
   title: string;
   description?: string;
-  fields?: Id<"questFields">[];
+  fields?: Doc<"questFields">[];
 }
 
 export function QuestFields(props: { questFields: Doc<"questFields">[] }) {
@@ -70,10 +68,6 @@ export function QuestFields(props: { questFields: Doc<"questFields">[] }) {
 }
 
 export function QuestStep({ title, description, fields }: QuestStepProps) {
-  const questFields = useQuery(api.questFields.getFields, {
-    fieldIds: fields ?? [],
-  });
-
   return (
     <Card className="flex flex-col gap-2">
       <h2 className="text-xl font-semibold">{title}</h2>
@@ -82,7 +76,7 @@ export function QuestStep({ title, description, fields }: QuestStepProps) {
           <Markdown className="prose dark:prose-invert">{description}</Markdown>
         </div>
       )}
-      {questFields && <QuestFields questFields={questFields} />}
+      {fields && <QuestFields questFields={fields} />}
     </Card>
   );
 }

--- a/src/components/QuestStep/index.ts
+++ b/src/components/QuestStep/index.ts
@@ -1,0 +1,1 @@
+export * from "./QuestStep";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -29,6 +29,7 @@ export * from "./NumberField";
 export * from "./PageHeader";
 export * from "./Popover";
 export * from "./ProgressBar";
+export * from "./QuestStep";
 export * from "./RadioGroup";
 export * from "./RangeCalendar";
 export * from "./RichTextEditor";

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticat
 import { Route as AuthenticatedQuestsRouteImport } from './routes/_authenticated/quests/route'
 import { Route as AuthenticatedAdminRouteImport } from './routes/_authenticated/admin/route'
 import { Route as AuthenticatedSettingsIndexImport } from './routes/_authenticated/settings/index'
+import { Route as AuthenticatedQuestsIndexImport } from './routes/_authenticated/quests/index'
 import { Route as AuthenticatedAdminIndexImport } from './routes/_authenticated/admin/index'
 import { Route as AuthenticatedSettingsOverviewImport } from './routes/_authenticated/settings/overview'
 import { Route as AuthenticatedSettingsDataImport } from './routes/_authenticated/settings/data'
@@ -74,6 +75,11 @@ const AuthenticatedSettingsIndexRoute = AuthenticatedSettingsIndexImport.update(
     getParentRoute: () => AuthenticatedSettingsRouteRoute,
   } as any,
 )
+
+const AuthenticatedQuestsIndexRoute = AuthenticatedQuestsIndexImport.update({
+  path: '/',
+  getParentRoute: () => AuthenticatedQuestsRouteRoute,
+} as any)
 
 const AuthenticatedAdminIndexRoute = AuthenticatedAdminIndexImport.update({
   path: '/',
@@ -209,6 +215,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminIndexImport
       parentRoute: typeof AuthenticatedAdminRouteImport
     }
+    '/_authenticated/quests/': {
+      id: '/_authenticated/quests/'
+      path: '/'
+      fullPath: '/quests/'
+      preLoaderRoute: typeof AuthenticatedQuestsIndexImport
+      parentRoute: typeof AuthenticatedQuestsRouteImport
+    }
     '/_authenticated/settings/': {
       id: '/_authenticated/settings/'
       path: '/'
@@ -282,11 +295,13 @@ const AuthenticatedAdminRouteRouteWithChildren =
 
 interface AuthenticatedQuestsRouteRouteChildren {
   AuthenticatedQuestsQuestIdRoute: typeof AuthenticatedQuestsQuestIdRoute
+  AuthenticatedQuestsIndexRoute: typeof AuthenticatedQuestsIndexRoute
 }
 
 const AuthenticatedQuestsRouteRouteChildren: AuthenticatedQuestsRouteRouteChildren =
   {
     AuthenticatedQuestsQuestIdRoute: AuthenticatedQuestsQuestIdRoute,
+    AuthenticatedQuestsIndexRoute: AuthenticatedQuestsIndexRoute,
   }
 
 const AuthenticatedQuestsRouteRouteWithChildren =
@@ -353,6 +368,7 @@ export interface FileRoutesByFullPath {
   '/settings/data': typeof AuthenticatedSettingsDataRoute
   '/settings/overview': typeof AuthenticatedSettingsOverviewRoute
   '/admin/': typeof AuthenticatedAdminIndexRoute
+  '/quests/': typeof AuthenticatedQuestsIndexRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
   '/admin/forms/$formId': typeof AuthenticatedAdminFormsFormIdRoute
   '/admin/quests/$questId': typeof AuthenticatedAdminQuestsQuestIdRoute
@@ -363,13 +379,13 @@ export interface FileRoutesByFullPath {
 
 export interface FileRoutesByTo {
   '': typeof UnauthenticatedRouteWithChildren
-  '/quests': typeof AuthenticatedQuestsRouteRouteWithChildren
   '/login': typeof UnauthenticatedLoginRoute
   '/': typeof AuthenticatedIndexRoute
   '/quests/$questId': typeof AuthenticatedQuestsQuestIdRoute
   '/settings/data': typeof AuthenticatedSettingsDataRoute
   '/settings/overview': typeof AuthenticatedSettingsOverviewRoute
   '/admin': typeof AuthenticatedAdminIndexRoute
+  '/quests': typeof AuthenticatedQuestsIndexRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
   '/admin/forms/$formId': typeof AuthenticatedAdminFormsFormIdRoute
   '/admin/quests/$questId': typeof AuthenticatedAdminQuestsQuestIdRoute
@@ -391,6 +407,7 @@ export interface FileRoutesById {
   '/_authenticated/settings/data': typeof AuthenticatedSettingsDataRoute
   '/_authenticated/settings/overview': typeof AuthenticatedSettingsOverviewRoute
   '/_authenticated/admin/': typeof AuthenticatedAdminIndexRoute
+  '/_authenticated/quests/': typeof AuthenticatedQuestsIndexRoute
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
   '/_authenticated/admin/forms/$formId': typeof AuthenticatedAdminFormsFormIdRoute
   '/_authenticated/admin/quests/$questId': typeof AuthenticatedAdminQuestsQuestIdRoute
@@ -412,6 +429,7 @@ export interface FileRouteTypes {
     | '/settings/data'
     | '/settings/overview'
     | '/admin/'
+    | '/quests/'
     | '/settings/'
     | '/admin/forms/$formId'
     | '/admin/quests/$questId'
@@ -421,13 +439,13 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | ''
-    | '/quests'
     | '/login'
     | '/'
     | '/quests/$questId'
     | '/settings/data'
     | '/settings/overview'
     | '/admin'
+    | '/quests'
     | '/settings'
     | '/admin/forms/$formId'
     | '/admin/quests/$questId'
@@ -447,6 +465,7 @@ export interface FileRouteTypes {
     | '/_authenticated/settings/data'
     | '/_authenticated/settings/overview'
     | '/_authenticated/admin/'
+    | '/_authenticated/quests/'
     | '/_authenticated/settings/'
     | '/_authenticated/admin/forms/$formId'
     | '/_authenticated/admin/quests/$questId'
@@ -513,7 +532,8 @@ export const routeTree = rootRoute
       "filePath": "_authenticated/quests/route.tsx",
       "parent": "/_authenticated",
       "children": [
-        "/_authenticated/quests/$questId"
+        "/_authenticated/quests/$questId",
+        "/_authenticated/quests/"
       ]
     },
     "/_authenticated/settings": {
@@ -548,6 +568,10 @@ export const routeTree = rootRoute
     "/_authenticated/admin/": {
       "filePath": "_authenticated/admin/index.tsx",
       "parent": "/_authenticated/admin"
+    },
+    "/_authenticated/quests/": {
+      "filePath": "_authenticated/quests/index.tsx",
+      "parent": "/_authenticated/quests"
     },
     "/_authenticated/settings/": {
       "filePath": "_authenticated/settings/index.tsx",

--- a/src/routes/_authenticated/admin/quests/$questId.tsx
+++ b/src/routes/_authenticated/admin/quests/$questId.tsx
@@ -71,18 +71,18 @@ function AdminQuestDetailRoute() {
       <div className="flex flex-col gap-6">
         {steps ? (
           <ol className="flex flex-col gap-4">
-            {steps.map(
-              (step, i) =>
-                step && (
-                  <li key={`${quest.title}-step-${i}`}>
-                    <QuestStep
-                      title={step.title}
-                      description={step.description}
-                      fields={step.fields}
-                    />
-                  </li>
-                ),
-            )}
+            {steps.map((step, i) => {
+              if (!step) return;
+              return (
+                <li key={`${quest.title}-step-${i}`}>
+                  <QuestStep
+                    title={step.title}
+                    description={step.description}
+                    fields={step.fields}
+                  />
+                </li>
+              );
+            })}
           </ol>
         ) : (
           "No steps"

--- a/src/routes/_authenticated/admin/quests/$questId.tsx
+++ b/src/routes/_authenticated/admin/quests/$questId.tsx
@@ -5,6 +5,7 @@ import {
   Form,
   Menu,
   MenuItem,
+  MenuSeparator,
   PageHeader,
   RichTextEditor,
   Select,
@@ -15,10 +16,12 @@ import { QuestStep } from "@/components/QuestStep/QuestStep";
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 import { FIELDS, ICONS } from "@convex/constants";
+import { RiAddLine } from "@remixicon/react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { useState } from "react";
 import { MenuTrigger } from "react-aria-components";
+import { NewFieldModal } from "../fields";
 
 export const Route = createFileRoute("/_authenticated/admin/quests/$questId")({
   component: AdminQuestDetailRoute,
@@ -35,6 +38,7 @@ function AdminQuestDetailRoute() {
   const allFields = useQuery(api.questFields.getAllFields);
   const addQuestStep = useMutation(api.questSteps.create);
   const [isNewStepFormVisible, setIsNewStepFormVisible] = useState(false);
+  const [isNewFieldModalOpen, setIsNewFieldModalOpen] = useState(false);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [fields, setFields] = useState<Id<"questFields">[]>([]);
@@ -59,6 +63,10 @@ function AdminQuestDetailRoute() {
     });
     clearForm();
     setIsNewStepFormVisible(false);
+  };
+
+  const handleFieldCreated = (newFieldId: Id<"questFields">) => {
+    setFields([...fields, newFieldId]);
   };
 
   return (
@@ -144,28 +152,45 @@ function AdminQuestDetailRoute() {
                     </Button>
                   </Card>
                 ))}
-              {allFields && (
-                <MenuTrigger>
-                  <Button variant="secondary">Add field</Button>
-                  <Menu>
-                    {allFields.map((field) => {
-                      const Icon = FIELDS[field.type].icon;
-                      return (
-                        <MenuItem
-                          key={field._id}
-                          textValue={field.label}
-                          onAction={() => setFields([...fields, field._id])}
-                        >
-                          <Icon size={20} />
-                          {field.label}
-                        </MenuItem>
-                      );
-                    })}
-                  </Menu>
-                </MenuTrigger>
-              )}
+
+              <MenuTrigger>
+                <Button variant="secondary">Add field</Button>
+                <Menu>
+                  {allFields && (
+                    <>
+                      {allFields.map((field) => {
+                        const Icon = FIELDS[field.type].icon;
+                        return (
+                          <MenuItem
+                            key={field._id}
+                            textValue={field.label}
+                            onAction={() => setFields([...fields, field._id])}
+                          >
+                            <Icon size={20} />
+                            {field.label}
+                          </MenuItem>
+                        );
+                      })}
+                      <MenuSeparator />
+                    </>
+                  )}
+                  <MenuItem
+                    key="new-field"
+                    textValue="New field"
+                    onAction={() => setIsNewFieldModalOpen(true)}
+                  >
+                    <RiAddLine size={20} />
+                    New field
+                  </MenuItem>
+                </Menu>
+              </MenuTrigger>
               <div className="flex gap-2 justify-end">
-                <Button onPress={() => setIsNewStepFormVisible(false)}>
+                <Button
+                  onPress={() => {
+                    setIsNewFieldModalOpen(false);
+                    setIsNewStepFormVisible(false);
+                  }}
+                >
                   Cancel
                 </Button>
                 <Button type="submit" variant="primary">
@@ -176,6 +201,12 @@ function AdminQuestDetailRoute() {
           </Card>
         )}
       </div>
+      <NewFieldModal
+        isOpen={isNewFieldModalOpen}
+        onOpenChange={setIsNewFieldModalOpen}
+        onSubmit={() => setIsNewFieldModalOpen(false)}
+        onFieldCreated={handleFieldCreated}
+      />
     </div>
   );
 }

--- a/src/routes/_authenticated/quests/$questId.tsx
+++ b/src/routes/_authenticated/quests/$questId.tsx
@@ -77,18 +77,18 @@ function QuestDetailRoute() {
       </PageHeader>
       {questSteps ? (
         <ol className="flex flex-col gap-6">
-          {questSteps.map(
-            (step, i) =>
-              step && (
-                <li key={`${quest.title}-step-${i}`}>
-                  <QuestStep
-                    title={step.title}
-                    description={step.description}
-                    fields={step.fields}
-                  />
-                </li>
-              ),
-          )}
+          {questSteps.map((step, i) => {
+            if (!step) return;
+            return (
+              <li key={`${quest.title}-step-${i}`}>
+                <QuestStep
+                  title={step.title}
+                  description={step.description}
+                  fields={step.fields}
+                />
+              </li>
+            );
+          })}
         </ol>
       ) : (
         <p>This quest has no steps yet.</p>

--- a/src/routes/_authenticated/quests/$questId.tsx
+++ b/src/routes/_authenticated/quests/$questId.tsx
@@ -1,8 +1,10 @@
 import {
   Badge,
   Button,
+  Empty,
   Menu,
   MenuItem,
+  MenuSeparator,
   MenuTrigger,
   PageHeader,
 } from "@/components";
@@ -10,8 +12,8 @@ import { QuestStep } from "@/components/QuestStep/QuestStep";
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 import { ICONS } from "@convex/constants";
-import { RiMoreLine } from "@remixicon/react";
-import { createFileRoute } from "@tanstack/react-router";
+import { RiMoreLine, RiSignpostLine } from "@remixicon/react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 
 export const Route = createFileRoute("/_authenticated/quests/$questId")({
@@ -20,6 +22,7 @@ export const Route = createFileRoute("/_authenticated/quests/$questId")({
 
 function QuestDetailRoute() {
   const { questId } = Route.useParams();
+  const navigate = useNavigate();
   // TODO: Opportunity to combine these queries?
   const quest = useQuery(api.quests.getQuest, {
     questId: questId as Id<"quests">,
@@ -32,17 +35,24 @@ function QuestDetailRoute() {
   });
   const markComplete = useMutation(api.userQuests.markComplete);
   const markIncomplete = useMutation(api.userQuests.markIncomplete);
+  const removeQuest = useMutation(api.userQuests.removeQuest);
 
   const handleMarkComplete = (questId: Id<"quests">) =>
     markComplete({ questId });
   const handleMarkIncomplete = (questId: Id<"quests">) =>
     markIncomplete({ questId });
+  const handleRemoveQuest = (questId: Id<"quests">) => {
+    // TODO: Add confirmation toast
+    removeQuest({ questId });
+    // Redirect to quests
+    navigate({ to: "/quests" });
+  };
 
   if (quest === undefined || userQuest === undefined) return;
   if (quest === null || userQuest === null) return "Quest not found";
 
   return (
-    <main className="col-span-2">
+    <main className="flex-1">
       <PageHeader
         icon={ICONS[quest.icon]}
         title={quest.title}
@@ -72,10 +82,14 @@ function QuestDetailRoute() {
                 Mark as in progress
               </MenuItem>
             )}
+            <MenuSeparator />
+            <MenuItem onAction={() => handleRemoveQuest(quest._id)}>
+              Remove quest
+            </MenuItem>
           </Menu>
         </MenuTrigger>
       </PageHeader>
-      {questSteps ? (
+      {questSteps && questSteps.length > 0 ? (
         <ol className="flex flex-col gap-6">
           {questSteps.map((step, i) => {
             if (!step) return;
@@ -91,7 +105,7 @@ function QuestDetailRoute() {
           })}
         </ol>
       ) : (
-        <p>This quest has no steps yet.</p>
+        <Empty title="This quest has no steps" icon={RiSignpostLine} />
       )}
     </main>
   );

--- a/src/routes/_authenticated/quests/index.tsx
+++ b/src/routes/_authenticated/quests/index.tsx
@@ -1,0 +1,11 @@
+import { Empty } from "@/components";
+import { RiSignpostLine } from "@remixicon/react";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/quests/")({
+  component: IndexRoute,
+});
+
+function IndexRoute() {
+  return <Empty title="No quest selected" icon={RiSignpostLine} />;
+}

--- a/src/routes/_authenticated/quests/route.tsx
+++ b/src/routes/_authenticated/quests/route.tsx
@@ -161,9 +161,9 @@ function IndexRoute() {
   };
 
   return (
-    <Container>
+    <Container className="max-w-screen-lg">
       <Authenticated>
-        <div className="grid grid-cols-3 items-start gap-6">
+        <div className="flex gap-6">
           <MyQuests />
           <Outlet />
         </div>


### PR DESCRIPTION
## What changed?
- Support field deletion and check for usage before allowing a user to delete a field
- Display field usage within the admin table for fields
- Support adding a new field directly from within a step for a quest
- Remove "FED" from Jurisdictions
- Refactor `getStepsForQuest` to return full fields objects instead of field ids

## Why?
Ongoing v1.0 work.

## How was this tested?
Manual testing.