### PR TITLE
chore: Disable prod registration but allow sign-in

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -17,10 +17,13 @@ const bannerStyles = tv({
   base: "flex gap-2 p-3 pr-4 items-start w-full text-sm rounded-lg bg-gray-3 dark:bg-graydark-3 text-gray-dim",
   variants: {
     variant: {
-      info: "bg-blue-3 dark:bg-bluedark-3 text-blue-normal",
-      success: "bg-green-3 dark:bg-greendark-3 text-green-normal",
-      danger: "bg-red-3 dark:bg-reddark-3 text-red-normal",
-      warning: "bg-amber-3 dark:bg-amberdark-3 text-amber-normal",
+      info: "bg-blue-3 dark:bg-bluedark-3 text-blue-normal [&_a]:text-blue-normal",
+      success:
+        "bg-green-3 dark:bg-greendark-3 text-green-normal [&_a]:text-green-normal",
+      danger:
+        "bg-red-3 dark:bg-reddark-3 text-red-normal [&_a]:text-red-normal",
+      warning:
+        "bg-amber-3 dark:bg-amberdark-3 text-amber-normal [&_a]:text-amber-normal",
     },
   },
   defaultVariants: {

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -69,11 +69,10 @@ const SignIn = () => {
       console.error(error);
       if (error instanceof ConvexError) {
         setError(error.message);
-        setIsSubmitting(false);
       } else {
         setError("Something went wrong. Try again.");
-        setIsSubmitting(false);
       }
+      setIsSubmitting(false);
     }
   };
 
@@ -186,7 +185,11 @@ const ForgotPassword = ({ onBack }: { onBack: () => void }) => {
             })
             .catch((error) => {
               console.error(error);
-              setError(`Couldn't send code. Try again.`);
+              if (error instanceof ConvexError) {
+                setError(error.message);
+              } else {
+                setError("Couldn't send code. Is this email correct?");
+              }
               setIsSubmitting(false);
             })
             .finally(() => setIsSubmitting(false));

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -31,6 +31,7 @@ const SignIn = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate({ from: "/signin" });
+  const isClosed = process.env.NODE_ENV === "production";
 
   if (flow === "reset")
     return <ForgotPassword onBack={() => setFlow("signIn")} />;
@@ -117,28 +118,32 @@ const SignIn = () => {
           </Form>
         </TabPanel>
         <TabPanel id="signUp">
-          <Form onSubmit={handleSubmit}>
-            <TextField
-              label="Email"
-              name="email"
-              type="email"
-              autoComplete="email"
-              isRequired
-              value={email}
-              onChange={setEmail}
-            />
-            <TextField
-              label="Password"
-              name="password"
-              type="password"
-              isRequired
-              value={password}
-              onChange={setPassword}
-            />
-            <Button type="submit" isDisabled={isSubmitting} variant="primary">
-              {isSubmitting ? "Registering..." : "Register"}
-            </Button>
-          </Form>
+          {isClosed ? (
+            <ClosedSignups />
+          ) : (
+            <Form onSubmit={handleSubmit}>
+              <TextField
+                label="Email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                isRequired
+                value={email}
+                onChange={setEmail}
+              />
+              <TextField
+                label="Password"
+                name="password"
+                type="password"
+                isRequired
+                value={password}
+                onChange={setPassword}
+              />
+              <Button type="submit" isDisabled={isSubmitting} variant="primary">
+                {isSubmitting ? "Registering..." : "Register"}
+              </Button>
+            </Form>
+          )}
         </TabPanel>
       </Tabs>
     </Card>
@@ -262,12 +267,10 @@ const ForgotPassword = ({ onBack }: { onBack: () => void }) => {
 };
 
 function LoginRoute() {
-  const isClosed = process.env.NODE_ENV === "production";
-
   return (
     <div className="flex flex-col w-96 max-w-full mx-auto min-h-dvh place-content-center gap-8 px-4 py-12">
       <Logo className="mb-4" />
-      {isClosed ? <ClosedSignups /> : <SignIn />}
+      <SignIn />
       <div className="flex gap-4 justify-center">
         <Link href="https://namesake.fyi">{`Namesake v${APP_VERSION}`}</Link>
         <Link href="https://namesake.fyi/chat">Support</Link>

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -119,7 +119,13 @@ const SignIn = () => {
         </TabPanel>
         <TabPanel id="signUp">
           {isClosed ? (
-            <ClosedSignups />
+            <Banner variant="info">
+              <p>
+                Namesake is in active development and currently closed to
+                signups. For name change support, join us on{" "}
+                <Link href="https://namesake.fyi/chat">Discord</Link>.
+              </p>
+            </Banner>
           ) : (
             <Form onSubmit={handleSubmit}>
               <TextField
@@ -149,16 +155,6 @@ const SignIn = () => {
     </Card>
   );
 };
-
-const ClosedSignups = () => (
-  <Card>
-    <p>
-      Namesake is in active development and currently closed to signups. For
-      name change support, join us on{" "}
-      <Link href="https://namesake.fyi/chat">Discord</Link>.
-    </p>
-  </Card>
-);
 
 const ForgotPassword = ({ onBack }: { onBack: () => void }) => {
   const navigate = useNavigate({ from: "/signin" });

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -33,12 +33,12 @@ const SignIn = () => {
   const navigate = useNavigate({ from: "/signin" });
   const isClosed = process.env.NODE_ENV === "production";
 
-  if (flow === "reset")
-    return <ForgotPassword onBack={() => setFlow("signIn")} />;
-
   useEffect(() => {
     if (isAuthenticated) navigate({ to: "/quests" });
   }, [isAuthenticated, navigate]);
+
+  if (flow === "reset")
+    return <ForgotPassword onBack={() => setFlow("signIn")} />;
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -12,6 +12,7 @@ import {
   TextField,
 } from "@/components";
 import { useAuthActions } from "@convex-dev/auth/react";
+import { RiArrowLeftSLine } from "@remixicon/react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useConvexAuth } from "convex/react";
 import { ConvexError } from "convex/values";
@@ -191,7 +192,16 @@ const ForgotPassword = ({ onBack }: { onBack: () => void }) => {
             .finally(() => setIsSubmitting(false));
         }}
       >
-        <h2 className="text-lg font-medium">Reset password</h2>
+        <header className="flex items-center gap-3">
+          <Button
+            onPress={onBack}
+            icon={RiArrowLeftSLine}
+            variant="icon"
+            aria-label="Back to sign-in"
+            className="-m-2"
+          />
+          <h2 className="text-lg font-medium">Reset password</h2>
+        </header>
         {error && <Banner variant="danger">{error}</Banner>}
         <TextField
           name="email"
@@ -203,7 +213,6 @@ const ForgotPassword = ({ onBack }: { onBack: () => void }) => {
         <Button type="submit" variant="primary" isDisabled={isSubmitting}>
           Send code
         </Button>
-        <Button onPress={onBack}>Back to sign in</Button>
       </Form>
     </Card>
   ) : (


### PR DESCRIPTION
## What changed?
- Instead of blocking sign-in on prod, disable registration only
- Update link color for banners
- Fix an error with rendering the "Forgot password" pane
- Improve error messaging for sending forgot password code when no account exists

![CleanShot 2024-10-20 at 11 47 35@2x](https://github.com/user-attachments/assets/adbb1239-504c-4d19-8b01-985647e1f445)