### PR TITLE
feat: Add ability to hide completed quests

### DIFF
--- a/.changeset/light-dragons-fix.md
+++ b/.changeset/light-dragons-fix.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Support hiding and showing completed quests

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -22,7 +22,9 @@ export function ProgressBar({ label, ...props }: ProgressBarProps) {
         <>
           <div className="flex justify-between gap-2">
             <Label className="text-gray-normal">{label}</Label>
-            <span className="text-sm text-gray-dim">{valueText}</span>
+            <span className="text-sm text-gray-dim tabular-nums">
+              {valueText}
+            </span>
           </div>
           <div className="w-64 h-2 rounded-full bg-gray-4 dark:bg-graydark-4 outline outline-1 -outline-offset-1 outline-transparent relative overflow-hidden">
             <div

--- a/src/routes/_authenticated/quests/route.tsx
+++ b/src/routes/_authenticated/quests/route.tsx
@@ -272,7 +272,7 @@ function IndexRoute() {
             >
               <div className="flex items-center justify-start gap-2 w-full text-gray-dim">
                 <RiCheckLine size={20} />
-                {`${completedQuests} completed quests hidden`}
+                {`${completedQuests} completed ${completedQuests > 1 ? "quests" : "quest"} hidden`}
               </div>
             </GridListItem>
           )}

--- a/src/routes/_authenticated/quests/route.tsx
+++ b/src/routes/_authenticated/quests/route.tsx
@@ -193,7 +193,7 @@ function IndexRoute() {
             valueLabel={`${completedQuests} of ${totalQuests}`}
             className="mr-4"
           />
-          {completedQuests && completedQuests > 0 && (
+          {Boolean(completedQuests && completedQuests > 0) && (
             <TooltipTrigger>
               <Button
                 aria-label="Show completed quests"


### PR DESCRIPTION
## What changed?
- Add ability to hide and show completed quests
- Relocate "Add quest" to toolbar above quest list
- Save quest sorting and show completed status in local storage for better performance and to prevent a backend roundtrip
- Use toggle buttons instead of a dropdown menu for sorting

![CleanShot 2024-10-21 at 13 19 53@2x](https://github.com/user-attachments/assets/8586cb80-ef3a-4916-817f-4f3000560d92)