### PR TITLE
feat: Add toasts

### DIFF
--- a/.changeset/chilled-badgers-glow.md
+++ b/.changeset/chilled-badgers-glow.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Display confirmation toasts on success actions throughout the app

--- a/.changeset/chilled-badgers-glow.md
+++ b/.changeset/chilled-badgers-glow.md
@@ -1,5 +1,5 @@
 ---
-"namesake": minor
+"namesake": patch
 ---
 
 Display confirmation toasts on success actions throughout the app

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-helmet-async": "^2.0.5",
     "react-markdown": "^9.0.1",
     "resend": "^4.0.0",
+    "sonner": "^1.5.0",
     "storybook": "^8.3.6",
     "tailwind-variants": "^0.2.1",
     "tailwindcss": "^3.4.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       resend:
         specifier: ^4.0.0
         version: 4.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      sonner:
+        specifier: ^1.5.0
+        version: 1.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook:
         specifier: ^8.3.6
         version: 8.3.6
@@ -6354,6 +6357,12 @@ packages:
   slice-ansi@7.1.0:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
+
+  sonner@1.5.0:
+    resolution: {integrity: sha512-FBjhG/gnnbN6FY0jaNnqZOMmB73R+5IiyYAw8yBj7L54ER7HB3fOSE5OFiQiE2iXWxeXKvg6fIP4LtVppHEdJA==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -14857,6 +14866,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
+
+  sonner@1.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   source-map-js@1.2.1: {}
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,5 +1,12 @@
 import type { Role } from "@convex/constants";
 import {
+  RiAlertLine,
+  RiCheckLine,
+  RiInformationLine,
+  RiLoader4Line,
+  RiSpam2Line,
+} from "@remixicon/react";
+import {
   type NavigateOptions,
   Outlet,
   type ToOptions,
@@ -7,8 +14,10 @@ import {
   useRouter,
 } from "@tanstack/react-router";
 import type { ConvexAuthState } from "convex/react";
+import { useTheme } from "next-themes";
 import React, { Suspense } from "react";
 import { RouterProvider } from "react-aria-components";
+import { Toaster } from "sonner";
 
 declare module "react-aria-components" {
   interface RouterConfig {
@@ -29,6 +38,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 
 function RootRoute() {
   const router = useRouter();
+  const { theme } = useTheme();
 
   const TanStackRouterDevtools =
     process.env.NODE_ENV === "production"
@@ -57,6 +67,28 @@ function RootRoute() {
       <Suspense>
         <TanStackRouterDevtools />
       </Suspense>
+      <Toaster
+        theme={theme as "light" | "dark" | "system"}
+        offset={16}
+        gap={8}
+        toastOptions={{
+          unstyled: true,
+          classNames: {
+            toast:
+              "bg-gray-12 dark:bg-graydark-12 rounded-lg p-4 w-full font-sans text-sm shadow-md flex items-center gap-2 text-gray-1 dark:text-graydark-1",
+            title: "text-gray-1 dark:text-graydark-1",
+            description: "text-gray-3 dark:text-graydark-3",
+            icon: "text-gray-5 dark:text-graydark-5",
+          },
+        }}
+        icons={{
+          success: <RiCheckLine />,
+          info: <RiInformationLine />,
+          warning: <RiAlertLine />,
+          error: <RiSpam2Line />,
+          loading: <RiLoader4Line />,
+        }}
+      />
     </RouterProvider>
   );
 }

--- a/src/routes/_authenticated/admin/quests/index.tsx
+++ b/src/routes/_authenticated/admin/quests/index.tsx
@@ -22,9 +22,10 @@ import { api } from "@convex/_generated/api";
 import type { DataModel } from "@convex/_generated/dataModel";
 import { ICONS, JURISDICTIONS, type Jurisdiction } from "@convex/constants";
 import { RiAddLine, RiMoreFill, RiSignpostLine } from "@remixicon/react";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { useState } from "react";
+import { toast } from "sonner";
 
 export const Route = createFileRoute("/_authenticated/admin/quests/")({
   component: QuestsRoute,
@@ -43,6 +44,7 @@ const NewQuestModal = ({
   const [icon, setIcon] = useState("");
   const [title, setTitle] = useState("");
   const [jurisdiction, setJurisdiction] = useState<Jurisdiction | null>(null);
+  const navigate = useNavigate();
 
   const clearForm = () => {
     setIcon("");
@@ -50,12 +52,23 @@ const NewQuestModal = ({
     setJurisdiction(null);
   };
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    createQuest({ title, icon, jurisdiction: jurisdiction ?? undefined });
+    const questId = await createQuest({
+      title,
+      icon,
+      jurisdiction: jurisdiction ?? undefined,
+    });
 
-    clearForm();
-    onSubmit();
+    if (questId) {
+      toast(`Created quest: ${title}`);
+      clearForm();
+      onSubmit();
+      navigate({
+        to: "/admin/quests/$questId",
+        params: { questId },
+      });
+    }
   };
 
   return (

--- a/src/routes/_authenticated/quests/$questId.tsx
+++ b/src/routes/_authenticated/quests/$questId.tsx
@@ -16,6 +16,7 @@ import { ICONS } from "@convex/constants";
 import { RiMoreFill, RiSignpostLine } from "@remixicon/react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
+import { toast } from "sonner";
 
 export const Route = createFileRoute("/_authenticated/quests/$questId")({
   component: QuestDetailRoute,
@@ -38,15 +39,21 @@ function QuestDetailRoute() {
   const markIncomplete = useMutation(api.userQuests.markIncomplete);
   const removeQuest = useMutation(api.userQuests.removeQuest);
 
-  const handleMarkComplete = (questId: Id<"quests">) =>
-    markComplete({ questId });
-  const handleMarkIncomplete = (questId: Id<"quests">) =>
-    markIncomplete({ questId });
-  const handleRemoveQuest = (questId: Id<"quests">) => {
-    // TODO: Add confirmation toast
-    removeQuest({ questId });
-    // Redirect to quests
-    navigate({ to: "/quests" });
+  const handleMarkComplete = (questId: Id<"quests">, title: string) => {
+    markComplete({ questId }).then(() => {
+      toast(`Marked ${title} complete`);
+    });
+  };
+  const handleMarkIncomplete = (questId: Id<"quests">, title: string) => {
+    markIncomplete({ questId }).then(() => {
+      toast(`Marked ${title} as in progress`);
+    });
+  };
+  const handleRemoveQuest = (questId: Id<"quests">, title: string) => {
+    removeQuest({ questId }).then(() => {
+      toast(`Removed ${title} quest`);
+      navigate({ to: "/quests" });
+    });
   };
 
   // TODO: Improve loading state to prevent flash of empty
@@ -80,17 +87,23 @@ function QuestDetailRoute() {
           />
           <Menu placement="bottom end">
             {!userQuest.completionTime && (
-              <MenuItem onAction={() => handleMarkComplete(quest._id)}>
+              <MenuItem
+                onAction={() => handleMarkComplete(quest._id, quest.title)}
+              >
                 Mark complete
               </MenuItem>
             )}
             {userQuest.completionTime && (
-              <MenuItem onAction={() => handleMarkIncomplete(quest._id)}>
+              <MenuItem
+                onAction={() => handleMarkIncomplete(quest._id, quest.title)}
+              >
                 Mark as in progress
               </MenuItem>
             )}
             <MenuSeparator />
-            <MenuItem onAction={() => handleRemoveQuest(quest._id)}>
+            <MenuItem
+              onAction={() => handleRemoveQuest(quest._id, quest.title)}
+            >
               Remove quest
             </MenuItem>
           </Menu>

--- a/src/routes/_authenticated/quests/route.tsx
+++ b/src/routes/_authenticated/quests/route.tsx
@@ -32,6 +32,7 @@ import {
 } from "convex/react";
 import { useEffect, useState } from "react";
 import type { Selection } from "react-aria-components";
+import { toast } from "sonner";
 import { twMerge } from "tailwind-merge";
 
 export const Route = createFileRoute("/_authenticated/quests")({
@@ -59,12 +60,15 @@ const NewQuestModal = ({
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    for (const questId of selectedQuests) {
-      addQuest({ questId: questId as Id<"quests"> });
-    }
+    const promises = Array.from(selectedQuests).map((questId) =>
+      addQuest({ questId: questId as Id<"quests"> }),
+    );
 
-    clearForm();
-    onSubmit();
+    Promise.all(promises).then(() => {
+      toast(`Added ${promises.length} quest${promises.length > 1 ? "s" : ""}`);
+      clearForm();
+      onSubmit();
+    });
   };
 
   return (
@@ -130,6 +134,9 @@ function IndexRoute() {
   const [isNewQuestModalOpen, setIsNewQuestModalOpen] = useState(false);
 
   const toggleShowCompleted = () => {
+    toast(
+      showCompleted ? "Hiding completed quests" : "Showing completed quests",
+    );
     setShowCompleted(!showCompleted);
   };
 


### PR DESCRIPTION
## What changed?
- Install [Sonner](https://sonner.emilkowal.ski/) with custom styling
- Add toasts to confirmation flows throughout the app:
  - Marking a quest complete
  - Marking a quest as in progress
  - Removing a quest
  - Hiding and showing completed quests
  - Creating a new quest
  - Adding one or more quests
- Resolves #115 

## Why?
- Provide context-specific feedback to users after actions