### PR TITLE
fix: Skip top-level redirects in main nav

### DIFF
--- a/.changeset/lucky-geese-occur.md
+++ b/.changeset/lucky-geese-occur.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Skip top-level redirects in main nav

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -20,11 +20,11 @@ export const AppHeader = () => {
 
   return (
     <div className="flex shrink-0 gap-4 bg-gray-app items-center w-screen h-14 px-4 border-b border-gray-dim sticky top-0 z-20">
-      <Link href={{ to: "/" }}>
+      <Link href={{ to: "/quests" }}>
         <Logo className="h-[1.25rem]" />
       </Link>
       <Authenticated>
-        {isAdmin && <Link href={{ to: "/admin" }}>Admin</Link>}
+        {isAdmin && <Link href={{ to: "/admin/quests" }}>Admin</Link>}
         <div className="ml-auto">
           <MenuTrigger>
             <Button
@@ -33,7 +33,7 @@ export const AppHeader = () => {
               icon={RiAccountCircleFill}
             />
             <Menu>
-              <MenuItem href={{ to: "/settings" }}>Settings</MenuItem>
+              <MenuItem href={{ to: "/settings/overview" }}>Settings</MenuItem>
               <MenuItem
                 href="https://namesake.fyi/chat"
                 target="_blank"

--- a/src/routes/_authenticated/quests/route.tsx
+++ b/src/routes/_authenticated/quests/route.tsx
@@ -195,34 +195,37 @@ function IndexRoute() {
             valueLabel={`${completedQuests} of ${totalQuests}`}
             className="mr-4"
           />
-          <MenuTrigger>
-            <Button icon={RiMoreFill} variant="icon" />
-            <Menu>
-              <MenuItem
-                onAction={() => setSortBy("newest")}
-                isDisabled={sortBy === "newest"}
-              >
-                Sort by newest
-              </MenuItem>
-              <MenuItem
-                onAction={() => setSortBy("oldest")}
-                isDisabled={sortBy === "oldest"}
-              >
-                Sort by oldest
-              </MenuItem>
+          <TooltipTrigger>
+            <MenuTrigger>
+              <Button icon={RiMoreFill} variant="icon" />
+              <Menu>
+                <MenuItem
+                  onAction={() => setSortBy("newest")}
+                  isDisabled={sortBy === "newest"}
+                >
+                  Sort by newest
+                </MenuItem>
+                <MenuItem
+                  onAction={() => setSortBy("oldest")}
+                  isDisabled={sortBy === "oldest"}
+                >
+                  Sort by oldest
+                </MenuItem>
 
-              {typeof completedQuests === "number" && completedQuests > 0 && (
-                <>
-                  <MenuSeparator />
-                  <MenuItem onAction={toggleShowCompleted}>
-                    {showCompleted
-                      ? `Hide ${completedQuests} completed ${completedQuests > 1 ? "quests" : "quest"}`
-                      : `Show ${completedQuests} completed ${completedQuests > 1 ? "quests" : "quest"}`}
-                  </MenuItem>
-                </>
-              )}
-            </Menu>
-          </MenuTrigger>
+                {typeof completedQuests === "number" && completedQuests > 0 && (
+                  <>
+                    <MenuSeparator />
+                    <MenuItem onAction={toggleShowCompleted}>
+                      {showCompleted
+                        ? `Hide ${completedQuests} completed ${completedQuests > 1 ? "quests" : "quest"}`
+                        : `Show ${completedQuests} completed ${completedQuests > 1 ? "quests" : "quest"}`}
+                    </MenuItem>
+                  </>
+                )}
+              </Menu>
+            </MenuTrigger>
+            <Tooltip>Sort and filter</Tooltip>
+          </TooltipTrigger>
           <TooltipTrigger>
             <Button
               aria-label="Add quest"


### PR DESCRIPTION
## What changed?
- Point nav links to the correct page to prevent unnecessary redirects
- Add tooltip to dropdown for sorting and filtering quests