### PR TITLE
fix: Prevent render error when `groupBy` is undefined

### DIFF
--- a/.changeset/wise-pianos-own.md
+++ b/.changeset/wise-pianos-own.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix bug that would prevent the quests sidebar from rendering if the same group by method was selected and the localStorage result set to undefined

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -15,12 +15,12 @@ export function ProgressBar({ label, ...props }: ProgressBarProps) {
       {...props}
       className={composeTailwindRenderProps(
         props.className,
-        "flex flex-col flex-1 gap-1",
+        "flex flex-col flex-1 gap-1.5",
       )}
     >
       {({ percentage, valueText, isIndeterminate }) => (
         <>
-          <div className="flex justify-between gap-2">
+          <div className="flex justify-between gap-2 -mt-0.5">
             <Label className="text-gray-normal">{label}</Label>
             <span className="text-sm text-gray-dim tabular-nums">
               {valueText}


### PR DESCRIPTION
## What changed?
Prevent a render error when `groupBy` was undefined e.g. when a user deselected the current selection. Prevent by passing `disallowEmptySelection`.

Also:
- Only scroll the quests lists in the sidebar while leaving the meter and actions static
- Adjust quest meter spacing and position for vertical centering
- Put "category" first in the Group By menu and default to "category" sorting