### PR TITLE
feat: Display time estimates for each quest

### DIFF
--- a/.changeset/swift-suns-laugh.md
+++ b/.changeset/swift-suns-laugh.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Display time required to complete a quest

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -335,13 +335,11 @@ export type Cost = {
   description: string;
 };
 
-export const FREE = "free";
-
 /**
  * Estimated time units.
  * Used to display estimated time in quest details.
  */
-export const ESTIMATED_TIME_UNITS = {
+export const TIME_UNITS = {
   minutes: "Minutes",
   hours: "Hours",
   days: "Days",
@@ -349,7 +347,7 @@ export const ESTIMATED_TIME_UNITS = {
   months: "Months",
 } as const;
 
-export type TimeRequiredUnit = keyof typeof ESTIMATED_TIME_UNITS;
+export type TimeRequiredUnit = keyof typeof TIME_UNITS;
 
 export type TimeRequired = {
   min: number;

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -329,3 +329,36 @@ export const STATUS: Record<Status, StatusDetails> = {
 } as const;
 
 export const STATUS_ORDER: Status[] = Object.keys(STATUS) as Status[];
+
+export type Cost = {
+  cost: number;
+  description: string;
+};
+
+export const FREE = "free";
+
+/**
+ * Estimated time units.
+ * Used to display estimated time in quest details.
+ */
+export const ESTIMATED_TIME_UNITS = {
+  minutes: "Minutes",
+  hours: "Hours",
+  days: "Days",
+  weeks: "Weeks",
+  months: "Months",
+} as const;
+
+export type TimeRequiredUnit = keyof typeof ESTIMATED_TIME_UNITS;
+
+export type TimeRequired = {
+  min: number;
+  max: number;
+  unit: TimeRequiredUnit;
+};
+
+export const DEFAULT_TIME_REQUIRED: TimeRequired = {
+  min: 5,
+  max: 10,
+  unit: "minutes",
+};

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -3,13 +3,16 @@ import {
   RiAccountCircleLine,
   RiAtLine,
   RiBankLine,
+  RiCalendar2Line,
   RiCalendarLine,
+  RiCalendarScheduleLine,
   RiChat3Line,
   RiCheckboxBlankCircleLine,
   RiCheckboxCircleFill,
   RiCheckboxLine,
   RiComputerLine,
   RiDropdownList,
+  RiFlashlightLine,
   RiFolderCheckLine,
   RiFolderLine,
   RiGamepadLine,
@@ -159,6 +162,7 @@ export const GROUP_QUESTS_BY = {
   dateAdded: "Date added",
   category: "Category",
   status: "Status",
+  timeRequired: "Time required",
 } as const;
 export type GroupQuestsBy = keyof typeof GROUP_QUESTS_BY;
 
@@ -166,10 +170,10 @@ export type GroupQuestsBy = keyof typeof GROUP_QUESTS_BY;
  * Generic group details.
  * Used for UI display of filter groups.
  */
-interface GroupDetails {
+export type GroupDetails = {
   label: string;
   icon: RemixiconComponentType;
-}
+};
 
 /**
  * Categories.
@@ -336,23 +340,42 @@ export type Cost = {
 };
 
 /**
- * Estimated time units.
- * Used to display estimated time in quest details.
+ * Time units.
+ * Used to display time required in quest details.
  */
-export const TIME_UNITS = {
-  minutes: "Minutes",
-  hours: "Hours",
-  days: "Days",
-  weeks: "Weeks",
-  months: "Months",
-} as const;
+export type TimeUnit = "minutes" | "hours" | "days" | "weeks" | "months";
 
-export type TimeRequiredUnit = keyof typeof TIME_UNITS;
+export const TIME_UNITS: Record<TimeUnit, GroupDetails> = {
+  minutes: {
+    label: "Minutes",
+    icon: RiFlashlightLine,
+  },
+  hours: {
+    label: "Hours",
+    icon: RiTimeLine,
+  },
+  days: {
+    label: "Days",
+    icon: RiCalendarLine,
+  },
+  weeks: {
+    label: "Weeks",
+    icon: RiCalendar2Line,
+  },
+  months: {
+    label: "Months",
+    icon: RiCalendarScheduleLine,
+  },
+};
+
+export const TIME_UNITS_ORDER: TimeUnit[] = Object.keys(
+  TIME_UNITS,
+) as TimeUnit[];
 
 export type TimeRequired = {
   min: number;
   max: number;
-  unit: TimeRequiredUnit;
+  unit: TimeUnit;
 };
 
 export const DEFAULT_TIME_REQUIRED: TimeRequired = {

--- a/convex/quests.ts
+++ b/convex/quests.ts
@@ -1,7 +1,8 @@
 import { v } from "convex/values";
 import { query } from "./_generated/server";
+import { DEFAULT_TIME_REQUIRED } from "./constants";
 import { userMutation } from "./helpers";
-import { category, jurisdiction } from "./validators";
+import { category, jurisdiction, timeRequiredUnit } from "./validators";
 
 // TODO: Add `returns` value validation
 // https://docs.convex.dev/functions/validation
@@ -51,6 +52,7 @@ export const createQuest = userMutation({
       title: args.title,
       category: args.category,
       jurisdiction: args.jurisdiction,
+      timeRequired: DEFAULT_TIME_REQUIRED,
       creationUser: ctx.userId,
     });
   },
@@ -71,6 +73,13 @@ export const updateQuest = userMutation({
         }),
       ),
     ),
+    timeRequired: v.optional(
+      v.object({
+        min: v.number(),
+        max: v.number(),
+        unit: timeRequiredUnit,
+      }),
+    ),
     urls: v.optional(v.array(v.string())),
     content: v.optional(v.string()),
   },
@@ -81,6 +90,7 @@ export const updateQuest = userMutation({
       jurisdiction: args.jurisdiction,
       category: args.category,
       costs: args.costs,
+      timeRequired: args.timeRequired,
       urls: args.urls,
       content: args.content,
     });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -9,6 +9,7 @@ import {
   role,
   status,
   theme,
+  timeRequiredUnit,
 } from "./validators";
 
 /**
@@ -18,6 +19,7 @@ import {
  * @param creationUser - The user who created the quest.
  * @param jurisdiction - The US State the quest applies to. (e.g. "MA")
  * @param costs - The costs of the quest in USD.
+ * @param timeRequired - The estimated time required to complete the quest.
  * @param urls - Links to official documentation about changing names for this quest.
  * @param deletionTime - Time in ms since epoch when the quest was deleted.
  * @param content - Text written in markdown comprising the contents of the quest.
@@ -35,6 +37,11 @@ const quests = defineTable({
       }),
     ),
   ),
+  timeRequired: v.object({
+    min: v.number(),
+    max: v.number(),
+    unit: timeRequiredUnit,
+  }),
   urls: v.optional(v.array(v.string())),
   deletionTime: v.optional(v.number()),
   content: v.optional(v.string()),

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { internalMutation } from "./_generated/server";
-import { JURISDICTIONS } from "./constants";
+import { DEFAULT_TIME_REQUIRED, JURISDICTIONS } from "./constants";
 
 const seed = internalMutation(async (ctx) => {
   if (process.env.NODE_ENV === "production") {
@@ -49,6 +49,7 @@ const seed = internalMutation(async (ctx) => {
         title: questTitle,
         category: "core",
         jurisdiction: questJurisdiction,
+        timeRequired: DEFAULT_TIME_REQUIRED,
         creationUser: userId,
       });
       console.log(`Created quest ${questTitle} (${questJurisdiction})`);

--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -1,13 +1,13 @@
 import { v } from "convex/values";
 import {
   CATEGORIES,
-  ESTIMATED_TIME_UNITS,
   FIELDS,
   GROUP_QUESTS_BY,
   JURISDICTIONS,
   ROLES,
   STATUS,
   THEMES,
+  TIME_UNITS,
 } from "./constants";
 
 export const jurisdiction = v.union(
@@ -41,5 +41,5 @@ export const category = v.union(
 );
 
 export const timeRequiredUnit = v.union(
-  ...Object.keys(ESTIMATED_TIME_UNITS).map((unit) => v.literal(unit)),
+  ...Object.keys(TIME_UNITS).map((unit) => v.literal(unit)),
 );

--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import {
   CATEGORIES,
+  ESTIMATED_TIME_UNITS,
   FIELDS,
   GROUP_QUESTS_BY,
   JURISDICTIONS,
@@ -37,4 +38,8 @@ export const groupQuestsBy = v.union(
 
 export const category = v.union(
   ...Object.keys(CATEGORIES).map((category) => v.literal(category)),
+);
+
+export const timeRequiredUnit = v.union(
+  ...Object.keys(ESTIMATED_TIME_UNITS).map((unit) => v.literal(unit)),
 );

--- a/src/components/NumberField/NumberField.tsx
+++ b/src/components/NumberField/NumberField.tsx
@@ -35,7 +35,7 @@ export function NumberField({
       {...props}
       className={composeTailwindRenderProps(
         props.className,
-        "group flex flex-col gap-1",
+        "group flex flex-col gap-1.5",
       )}
     >
       <Label>{label}</Label>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -53,7 +53,7 @@ export function Select<T extends object>({
       {...props}
       className={composeTailwindRenderProps(
         props.className,
-        "group flex flex-col gap-2",
+        "group flex flex-col gap-1.5",
       )}
     >
       {label && <Label>{label}</Label>}

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -39,7 +39,7 @@ export function TextArea({
       {...props}
       className={composeTailwindRenderProps(
         props.className,
-        "flex flex-col gap-2",
+        "flex flex-col gap-1.5",
       )}
     >
       {label && <Label>{label}</Label>}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -39,7 +39,7 @@ export function TextField({
       {...props}
       className={composeTailwindRenderProps(
         props.className,
-        "flex flex-col gap-2",
+        "flex flex-col gap-1.5",
       )}
       type={
         props.type === "password" && isPasswordVisible ? "text" : props.type

--- a/src/routes/_authenticated/_home.tsx
+++ b/src/routes/_authenticated/_home.tsx
@@ -24,10 +24,14 @@ import {
   DATE_ADDED,
   DATE_ADDED_ORDER,
   type DateAdded,
+  type GroupDetails,
   type GroupQuestsBy,
   STATUS,
   STATUS_ORDER,
   type Status,
+  TIME_UNITS,
+  TIME_UNITS_ORDER,
+  type TimeUnit,
 } from "@convex/constants";
 import { RiAddLine, RiListCheck2, RiSignpostLine } from "@remixicon/react";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
@@ -61,6 +65,11 @@ function sortGroupedQuests(
       const indexB = DATE_ADDED_ORDER.indexOf(groupB as DateAdded);
       return indexA - indexB;
     }
+    case "timeRequired": {
+      const indexA = TIME_UNITS_ORDER.indexOf(groupA as TimeUnit);
+      const indexB = TIME_UNITS_ORDER.indexOf(groupB as TimeUnit);
+      return indexA - indexB;
+    }
   }
 }
 
@@ -85,11 +94,15 @@ function IndexRoute() {
     const questsByCategory = useQuery(api.userQuests.getUserQuestsByCategory);
     const questsByDate = useQuery(api.userQuests.getUserQuestsByDate);
     const questsByStatus = useQuery(api.userQuests.getUserQuestsByStatus);
+    const questsByTimeRequired = useQuery(
+      api.userQuests.getUserQuestsByTimeRequired,
+    );
 
     const groupedQuests = {
       category: questsByCategory,
       dateAdded: questsByDate,
       status: questsByStatus,
+      timeRequired: questsByTimeRequired,
     }[groupByValue];
 
     if (groupedQuests === undefined) return;
@@ -111,8 +124,9 @@ function IndexRoute() {
 
     const allCategoryKeys = [
       ...Object.values(CATEGORIES).map((category) => category.label),
-      ...Object.values(DATE_ADDED).map((date) => date.label),
       ...Object.values(STATUS).map((status) => status.label),
+      ...Object.values(DATE_ADDED).map((date) => date.label),
+      ...Object.values(TIME_UNITS).map((timeUnit) => timeUnit.label),
     ];
 
     return (
@@ -136,8 +150,9 @@ function IndexRoute() {
               >
                 <MenuSection title="Group by">
                   <MenuItem id="category">Category</MenuItem>
-                  <MenuItem id="dateAdded">Date added</MenuItem>
                   <MenuItem id="status">Status</MenuItem>
+                  <MenuItem id="dateAdded">Date added</MenuItem>
+                  <MenuItem id="timeRequired">Time required</MenuItem>
                 </MenuSection>
               </Menu>
             </MenuTrigger>
@@ -165,12 +180,22 @@ function IndexRoute() {
               )
               .map(([group, quests]) => {
                 if (quests.length === 0) return null;
-                const { label, icon: Icon } =
-                  groupByValue === "category"
-                    ? CATEGORIES[group as keyof typeof CATEGORIES]
-                    : groupByValue === "status"
-                      ? STATUS[group as keyof typeof STATUS]
-                      : DATE_ADDED[group as keyof typeof DATE_ADDED];
+                let groupDetails: GroupDetails;
+                switch (groupByValue) {
+                  case "category":
+                    groupDetails = CATEGORIES[group as keyof typeof CATEGORIES];
+                    break;
+                  case "status":
+                    groupDetails = STATUS[group as keyof typeof STATUS];
+                    break;
+                  case "timeRequired":
+                    groupDetails = TIME_UNITS[group as keyof typeof TIME_UNITS];
+                    break;
+                  case "dateAdded":
+                    groupDetails = DATE_ADDED[group as keyof typeof DATE_ADDED];
+                    break;
+                }
+                const { label, icon: Icon } = groupDetails;
 
                 return (
                   <Disclosure

--- a/src/routes/_authenticated/admin/quests/$questId.tsx
+++ b/src/routes/_authenticated/admin/quests/$questId.tsx
@@ -16,9 +16,9 @@ import {
   type Category,
   type Cost,
   DEFAULT_TIME_REQUIRED,
-  ESTIMATED_TIME_UNITS,
   JURISDICTIONS,
   type Jurisdiction,
+  TIME_UNITS,
   type TimeRequired,
   type TimeRequiredUnit,
 } from "@convex/constants";
@@ -191,7 +191,7 @@ const TimeRequiredInput = memo(function TimeRequiredInput({
           })
         }
       >
-        {Object.entries(ESTIMATED_TIME_UNITS).map(([key, label]) => (
+        {Object.entries(TIME_UNITS).map(([key, label]) => (
           <SelectItem key={key} id={key}>
             {label}
           </SelectItem>

--- a/src/routes/_authenticated/admin/quests/$questId.tsx
+++ b/src/routes/_authenticated/admin/quests/$questId.tsx
@@ -29,17 +29,20 @@ const URLInput = memo(function URLInput({
   value,
   onChange,
   onRemove,
+  hideLabel = false,
 }: {
   value: string;
   onChange: (value: string) => void;
   onRemove: () => void;
+  hideLabel?: boolean;
 }) {
   return (
     <div className="flex gap-2 items-end">
       <TextField
         value={value}
         onChange={onChange}
-        label="URL"
+        label={hideLabel ? undefined : "URL"}
+        aria-label={hideLabel ? "URL" : undefined}
         className="flex-1 w-96"
       />
       <Button type="button" variant="secondary" onPress={onRemove}>
@@ -209,6 +212,7 @@ function AdminQuestDetailRoute() {
             onRemove={() => {
               setUrls(urls.filter((_, i) => i !== index));
             }}
+            hideLabel={index > 0}
           />
         ))}
         <Button

--- a/src/routes/_authenticated/admin/quests/$questId.tsx
+++ b/src/routes/_authenticated/admin/quests/$questId.tsx
@@ -20,7 +20,7 @@ import {
   type Jurisdiction,
   TIME_UNITS,
   type TimeRequired,
-  type TimeRequiredUnit,
+  type TimeUnit,
 } from "@convex/constants";
 import { RiQuestionLine } from "@remixicon/react";
 import { createFileRoute } from "@tanstack/react-router";
@@ -187,13 +187,13 @@ const TimeRequiredInput = memo(function TimeRequiredInput({
         onSelectionChange={(key) =>
           onChange({
             ...timeRequired,
-            unit: key as TimeRequiredUnit,
+            unit: key as TimeUnit,
           })
         }
       >
-        {Object.entries(TIME_UNITS).map(([key, label]) => (
+        {Object.entries(TIME_UNITS).map(([key, unit]) => (
           <SelectItem key={key} id={key}>
-            {label}
+            {unit.label}
           </SelectItem>
         ))}
       </Select>

--- a/src/routes/_authenticated/admin/quests/$questId.tsx
+++ b/src/routes/_authenticated/admin/quests/$questId.tsx
@@ -1,5 +1,7 @@
 import {
+  AnimateChangeInHeight,
   Button,
+  Checkbox,
   Form,
   NumberField,
   RichTextEditor,
@@ -12,8 +14,13 @@ import type { Id } from "@convex/_generated/dataModel";
 import {
   CATEGORIES,
   type Category,
+  type Cost,
+  DEFAULT_TIME_REQUIRED,
+  ESTIMATED_TIME_UNITS,
   JURISDICTIONS,
   type Jurisdiction,
+  type TimeRequired,
+  type TimeRequiredUnit,
 } from "@convex/constants";
 import { RiQuestionLine } from "@remixicon/react";
 import { createFileRoute } from "@tanstack/react-router";
@@ -58,9 +65,9 @@ const CostInput = memo(function CostInput({
   onRemove,
   hideLabel = false,
 }: {
-  cost: { cost: number; description: string };
-  onChange: (cost: { cost: number; description: string }) => void;
-  onRemove: (cost: { cost: number; description: string }) => void;
+  cost: Cost;
+  onChange: (cost: Cost) => void;
+  onRemove: (cost: Cost) => void;
   hideLabel?: boolean;
 }) {
   return (
@@ -89,6 +96,111 @@ const CostInput = memo(function CostInput({
   );
 });
 
+const CostsInput = memo(function CostsInput({
+  costs,
+  onChange,
+}: {
+  costs: Cost[] | null;
+  onChange: (costs: Cost[] | null) => void;
+}) {
+  return (
+    <AnimateChangeInHeight>
+      <Checkbox
+        label="Free"
+        isSelected={!costs}
+        onChange={(isSelected) =>
+          onChange(isSelected ? null : [{ cost: 0, description: "" }])
+        }
+      />
+      {costs && (
+        <div className="flex flex-col gap-2 mt-4">
+          {costs.map((cost, index) => (
+            <CostInput
+              // biome-ignore lint/suspicious/noArrayIndexKey:
+              key={index}
+              cost={cost}
+              onChange={(value) => {
+                const newCosts = [...costs];
+                newCosts[index] = value;
+                onChange(newCosts);
+              }}
+              onRemove={() => {
+                onChange(costs.filter((_, i) => i !== index));
+              }}
+              hideLabel={index > 0}
+            />
+          ))}
+          <Button
+            type="button"
+            variant="secondary"
+            onPress={() =>
+              onChange([...(costs ?? []), { cost: 0, description: "" }])
+            }
+          >
+            Add cost
+          </Button>
+        </div>
+      )}
+    </AnimateChangeInHeight>
+  );
+});
+
+const TimeRequiredInput = memo(function TimeRequiredInput({
+  timeRequired,
+  onChange,
+}: {
+  timeRequired: TimeRequired;
+  onChange: (timeRequired: TimeRequired) => void;
+}) {
+  if (!timeRequired) return null;
+
+  return (
+    <div className="flex items-end gap-2">
+      <NumberField
+        label="Min. Req. Time"
+        className="w-28"
+        value={timeRequired?.min}
+        maxValue={Math.max(timeRequired.max, 60)}
+        onChange={(value) =>
+          onChange({
+            ...timeRequired,
+            min: value,
+          })
+        }
+      />
+      <NumberField
+        label="Max Req. Time"
+        className="w-28"
+        value={timeRequired.max}
+        minValue={Math.min(timeRequired.min, 1)}
+        onChange={(value) =>
+          onChange({
+            ...timeRequired,
+            max: value,
+          })
+        }
+      />
+      <Select
+        label="Unit"
+        className="w-40"
+        selectedKey={timeRequired.unit}
+        onSelectionChange={(key) =>
+          onChange({
+            ...timeRequired,
+            unit: key as TimeRequiredUnit,
+          })
+        }
+      >
+        {Object.entries(ESTIMATED_TIME_UNITS).map(([key, label]) => (
+          <SelectItem key={key} id={key}>
+            {label}
+          </SelectItem>
+        ))}
+      </Select>
+    </div>
+  );
+});
+
 function AdminQuestDetailRoute() {
   const { questId } = Route.useParams();
   const quest = useQuery(api.quests.getQuest, {
@@ -99,8 +211,9 @@ function AdminQuestDetailRoute() {
   const [title, setTitle] = useState("");
   const [category, setCategory] = useState<Category | null>(null);
   const [jurisdiction, setJurisdiction] = useState<Jurisdiction | null>(null);
-  const [costs, setCosts] = useState<{ cost: number; description: string }[]>(
-    [],
+  const [costs, setCosts] = useState<Cost[] | null>(null);
+  const [timeRequired, setTimeRequired] = useState<TimeRequired>(
+    DEFAULT_TIME_REQUIRED,
   );
   const [urls, setUrls] = useState<string[]>([]);
   const [content, setContent] = useState("");
@@ -110,7 +223,8 @@ function AdminQuestDetailRoute() {
       setTitle(quest.title ?? "");
       setCategory(quest.category as Category);
       setJurisdiction(quest.jurisdiction as Jurisdiction);
-      setCosts(quest.costs ?? []);
+      setCosts(quest.costs as Cost[]);
+      setTimeRequired(quest.timeRequired as TimeRequired);
       setUrls(quest.urls ?? []);
       setContent(quest.content ?? "");
     }
@@ -127,6 +241,7 @@ function AdminQuestDetailRoute() {
       category: category ?? undefined,
       jurisdiction: jurisdiction ?? undefined,
       costs: costs ?? undefined,
+      timeRequired: timeRequired ?? undefined,
       urls: urls ?? undefined,
       content,
     }).then(() => {
@@ -173,31 +288,11 @@ function AdminQuestDetailRoute() {
           </SelectItem>
         ))}
       </Select>
-      <div className="flex flex-col gap-2">
-        {costs.map((cost, index) => (
-          <CostInput
-            // biome-ignore lint/suspicious/noArrayIndexKey:
-            key={index}
-            cost={cost}
-            onChange={(value) => {
-              const newCosts = [...costs];
-              newCosts[index] = value;
-              setCosts(newCosts);
-            }}
-            onRemove={() => {
-              setCosts(costs.filter((_, i) => i !== index));
-            }}
-            hideLabel={index > 0}
-          />
-        ))}
-        <Button
-          type="button"
-          variant="secondary"
-          onPress={() => setCosts([...costs, { cost: 0, description: "" }])}
-        >
-          Add cost
-        </Button>
-      </div>
+      <CostsInput costs={costs} onChange={setCosts} />
+      <TimeRequiredInput
+        timeRequired={timeRequired}
+        onChange={setTimeRequired}
+      />
       <div className="flex flex-col gap-2">
         {urls.map((url, index) => (
           <URLInput


### PR DESCRIPTION
## What changed?
- Display a time estimate for each quest
- Add sorting by time required
- Adjust spacing between labels and form fields
- Resolves #196 

![CleanShot 2024-11-17 at 01 44 41@2x](https://github.com/user-attachments/assets/8a386473-bc07-4a53-8531-ee1a6414961e)
![CleanShot 2024-11-17 at 01 44 29@2x](https://github.com/user-attachments/assets/8df8ce50-f356-4026-9943-5caadf376b3c)
![CleanShot 2024-11-17 at 02 19 05@2x](https://github.com/user-attachments/assets/89b12e6d-18b3-454e-be72-831fc1a0f050)

## Why?
Inform users of the time required to complete a step in the process so they can plan around other life events. Create a space to populate future averages and other data about time required.