### PR TITLE
feat: Improve user dropdown menu

### DIFF
--- a/.changeset/pretty-masks-notice.md
+++ b/.changeset/pretty-masks-notice.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Unify display of user settings and make it simpler to change themes

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -26,11 +26,13 @@ import {
   MapPin,
   MessageCircle,
   Milestone,
+  Moon,
   Phone,
   RectangleEllipsis,
   Scale,
   ShoppingBag,
   SquareCheck,
+  Sun,
   Zap,
 } from "lucide-react";
 
@@ -143,12 +145,21 @@ export const FIELDS: Record<string, FieldDetails> = {
   },
 } as const;
 
-export const THEMES = {
-  system: "System",
-  light: "Light",
-  dark: "Dark",
+export type Theme = "system" | "light" | "dark";
+export const THEMES: Record<Theme, FieldDetails> = {
+  system: {
+    label: "System",
+    icon: Computer,
+  },
+  light: {
+    label: "Light",
+    icon: Sun,
+  },
+  dark: {
+    label: "Dark",
+    icon: Moon,
+  },
 } as const;
-export type Theme = keyof typeof THEMES;
 
 export const ROLES = {
   user: "User",

--- a/src/components/AppSidebar/AppSidebar.tsx
+++ b/src/components/AppSidebar/AppSidebar.tsx
@@ -6,7 +6,8 @@ import { Badge } from "../Badge";
 import { Button } from "../Button";
 import { Link } from "../Link";
 import { Logo } from "../Logo";
-import { Menu, MenuItem, MenuTrigger } from "../Menu";
+import { Menu, MenuItem, MenuTrigger, SubmenuTrigger } from "../Menu";
+import { Popover } from "../Popover";
 import { Tooltip } from "../Tooltip";
 import { TooltipTrigger } from "../Tooltip";
 
@@ -54,6 +55,16 @@ export const AppSidebar = ({ children }: AppSidebarProps) => {
             {user?.name}
           </Button>
           <Menu placement="top start">
+            <SubmenuTrigger>
+              <MenuItem>Theme</MenuItem>
+              <Popover>
+                <Menu>
+                  <MenuItem>System</MenuItem>
+                  <MenuItem>Light</MenuItem>
+                  <MenuItem>Dark</MenuItem>
+                </Menu>
+              </Popover>
+            </SubmenuTrigger>
             <MenuItem
               href="https://namesake.fyi/chat"
               target="_blank"

--- a/src/components/ListBox/ListBox.tsx
+++ b/src/components/ListBox/ListBox.tsx
@@ -6,8 +6,8 @@ import {
   Collection,
   Header,
   type ListBoxItemProps,
-  Section,
-  type SectionProps,
+  MenuSection,
+  type MenuSectionProps,
   composeRenderProps,
 } from "react-aria-components";
 import { tv } from "tailwind-variants";
@@ -63,7 +63,7 @@ export function ListBoxItem(props: ListBoxItemProps) {
 }
 
 export const dropdownItemStyles = tv({
-  base: "group flex items-center gap-1.5 cursor-pointer select-none py-2 px-2.5 rounded-lg outline outline-0 text-sm forced-color-adjust-none",
+  base: "group flex items-center gap-1.5 cursor-pointer select-none py-2 px-2.5 pr-3 rounded-lg outline outline-0 text-sm forced-color-adjust-none",
   variants: {
     isDisabled: {
       false: "text-gray-normal",
@@ -106,7 +106,7 @@ export function DropdownItem(props: ListBoxItemProps) {
   );
 }
 
-export interface DropdownSectionProps<T> extends SectionProps<T> {
+export interface DropdownSectionProps<T> extends MenuSectionProps<T> {
   title?: string;
 }
 
@@ -114,11 +114,11 @@ export function DropdownSection<T extends object>(
   props: DropdownSectionProps<T>,
 ) {
   return (
-    <Section>
+    <MenuSection>
       <Header className="text-sm font-semibold text-gray-dim px-4 py-1 truncate sticky -top-[5px] -mt-px -mx-1 z-10 bg-gray-subtle border-b border-gray-dim [&+*]:mt-1">
         {props.title}
       </Header>
       <Collection items={props.items}>{props.children}</Collection>
-    </Section>
+    </MenuSection>
   );
 }

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,11 +1,11 @@
-import { Check, ChevronRight } from "lucide-react";
+import { Check, ChevronRight, type LucideIcon } from "lucide-react";
 import {
   Menu as AriaMenu,
   MenuItem as AriaMenuItem,
+  type MenuItemProps as AriaMenuItemProps,
   type MenuProps as AriaMenuProps,
   MenuTrigger as AriaMenuTrigger,
   SubmenuTrigger as AriaSubmenuTrigger,
-  type MenuItemProps,
   type MenuTriggerProps,
   Separator,
   type SeparatorProps,
@@ -38,7 +38,11 @@ export function Menu<T extends object>(props: MenuProps<T>) {
   );
 }
 
-export function MenuItem({ className, ...props }: MenuItemProps) {
+interface MenuItemProps extends AriaMenuItemProps {
+  icon?: LucideIcon;
+}
+
+export function MenuItem({ className, icon: Icon, ...props }: MenuItemProps) {
   return (
     <AriaMenuItem
       {...props}
@@ -55,11 +59,15 @@ export function MenuItem({ className, ...props }: MenuItemProps) {
                 {isSelected && <Check aria-hidden className="w-4 h-4" />}
               </span>
             )}
+            {Icon && <Icon aria-hidden className="w-4 h-4" />}
             <span className="flex items-center flex-1 gap-2 font-normal truncate group-selected:font-semibold">
               {children}
             </span>
             {hasSubmenu && (
-              <ChevronRight aria-hidden className="absolute w-4 h-4 right-2" />
+              <ChevronRight
+                aria-hidden
+                className="absolute w-4 h-4 right-2.5"
+              />
             )}
           </>
         ),

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -3,18 +3,14 @@ import {
   Link,
   Modal,
   PageHeader,
-  Radio,
-  RadioGroup,
   Switch,
   TextField,
 } from "@/components";
 import { useAuthActions } from "@convex-dev/auth/react";
 import { api } from "@convex/_generated/api";
-import type { Theme } from "@convex/constants";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { Check, LoaderCircle } from "lucide-react";
-import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
 
@@ -24,7 +20,6 @@ export const Route = createFileRoute("/_authenticated/settings/account")({
 
 function SettingsAccountRoute() {
   const { signOut } = useAuthActions();
-  const { setTheme } = useTheme();
   const user = useQuery(api.users.getCurrentUser);
 
   // Name change field
@@ -74,14 +69,6 @@ function SettingsAccountRoute() {
   // Is minor switch
   const updateIsMinor = useMutation(api.users.setCurrentUserIsMinor);
 
-  // Theme change
-  const updateTheme = useMutation(api.users.setUserTheme);
-
-  const handleUpdateTheme = (value: string) => {
-    updateTheme({ theme: value as Theme });
-    setTheme(value);
-  };
-
   // Account deletion
   const clearLocalStorage = () => {
     localStorage.removeItem("theme");
@@ -113,15 +100,6 @@ function SettingsAccountRoute() {
           >
             Is minor
           </Switch>
-          <RadioGroup
-            label="Theme"
-            value={user.theme}
-            onChange={handleUpdateTheme}
-          >
-            <Radio value="system">System</Radio>
-            <Radio value="light">Light</Radio>
-            <Radio value="dark">Dark</Radio>
-          </RadioGroup>
           <Button onPress={signOut}>Sign out</Button>
           <Button onPress={() => setIsDeleteModalOpen(true)}>
             Delete account


### PR DESCRIPTION
## What changed?
- Expand user settings menu
- Relocate theme picker to menu and remove from account settings
- Relocate Admin and Settings links to menu and remove from top-level display
- Add "About Namesake" menu item linking to homepage
- Extend `MenuItem` with support for `icon`
- Add default icons for each `theme`

![CleanShot 2024-11-23 at 11 51 11@2x](https://github.com/user-attachments/assets/a5e6c291-c231-45f0-ab9a-b3a0cba92e48)

## Why?
Unify access to settings pages, make it easier to change themes