### PR TITLE
feat: Improve settings display

### DIFF
--- a/.changeset/tasty-ducks-pretend.md
+++ b/.changeset/tasty-ducks-pretend.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Redesign settings pages

--- a/src/components/AppSidebar/AppSidebar.tsx
+++ b/src/components/AppSidebar/AppSidebar.tsx
@@ -1,19 +1,9 @@
+import { useTheme } from "@/utils/useTheme";
 import { useAuthActions } from "@convex-dev/auth/react";
 import { api } from "@convex/_generated/api";
 import { THEMES, type Theme } from "@convex/constants";
-import { Authenticated, useMutation, useQuery } from "convex/react";
-import {
-  CircleUser,
-  Cog,
-  GlobeLock,
-  LogOut,
-  MessageCircleQuestion,
-  Plus,
-  Snail,
-} from "lucide-react";
-import { useTheme } from "next-themes";
-import { useState } from "react";
-import type { Selection } from "react-aria-components";
+import { Authenticated, useQuery } from "convex/react";
+import { CircleUser, Cog, GlobeLock, LogOut, Plus } from "lucide-react";
 import { Badge } from "../Badge";
 import { Button } from "../Button";
 import { Link } from "../Link";
@@ -35,25 +25,10 @@ type AppSidebarProps = {
 
 export const AppSidebar = ({ children }: AppSidebarProps) => {
   const { signOut } = useAuthActions();
-  const { theme, setTheme } = useTheme();
-  const [selectedTheme, setSelectedTheme] = useState<Selection>(
-    new Set([theme ?? "system"]),
-  );
+  const { theme, themeSelection, setTheme } = useTheme();
+
   const user = useQuery(api.users.getCurrentUser);
   const isAdmin = user?.role === "admin";
-
-  // Theme change
-  const updateTheme = useMutation(api.users.setUserTheme);
-
-  const handleUpdateTheme = (theme: Selection) => {
-    const newTheme = [...theme][0] as Theme;
-    // Update the theme in the database
-    updateTheme({ theme: newTheme });
-    // Update the theme in next-themes
-    setTheme(newTheme);
-    // Update the selected theme in the menu
-    setSelectedTheme(new Set([newTheme]));
-  };
 
   const handleSignOut = async () => {
     await signOut();
@@ -95,22 +70,13 @@ export const AppSidebar = ({ children }: AppSidebarProps) => {
               {user?.name}
             </Button>
             <Menu placement="top start">
-              <MenuItem
-                icon={Snail}
-                href="https://namesake.fyi"
-                target="_blank"
-                rel="noreferrer"
-              >
-                About Namesake
-              </MenuItem>
-              <MenuSeparator />
               {isAdmin && (
                 <MenuItem icon={GlobeLock} href={{ to: "/admin" }}>
                   Admin
                 </MenuItem>
               )}
               <MenuItem href={{ to: "/settings/account" }} icon={Cog}>
-                Settings
+                Settings and Help
               </MenuItem>
               <SubmenuTrigger>
                 <MenuItem icon={THEMES[theme as Theme].icon} textValue="Theme">
@@ -123,8 +89,8 @@ export const AppSidebar = ({ children }: AppSidebarProps) => {
                   <Menu
                     disallowEmptySelection
                     selectionMode="single"
-                    selectedKeys={selectedTheme}
-                    onSelectionChange={handleUpdateTheme}
+                    selectedKeys={themeSelection}
+                    onSelectionChange={setTheme}
                   >
                     {Object.entries(THEMES).map(([theme, details]) => (
                       <MenuItem key={theme} id={theme} icon={details.icon}>
@@ -134,15 +100,6 @@ export const AppSidebar = ({ children }: AppSidebarProps) => {
                   </Menu>
                 </Popover>
               </SubmenuTrigger>
-              <MenuSeparator />
-              <MenuItem
-                href="https://namesake.fyi/chat"
-                target="_blank"
-                rel="noreferrer"
-                icon={MessageCircleQuestion}
-              >
-                Discord Community
-              </MenuItem>
               <MenuSeparator />
               <MenuItem icon={LogOut} onAction={handleSignOut}>
                 Sign out

--- a/src/components/AppSidebar/AppSidebar.tsx
+++ b/src/components/AppSidebar/AppSidebar.tsx
@@ -1,19 +1,20 @@
+import { useTheme } from "@/utils/useTheme";
 import { useAuthActions } from "@convex-dev/auth/react";
 import { api } from "@convex/_generated/api";
 import { THEMES, type Theme } from "@convex/constants";
-import { useMutation, useQuery } from "convex/react";
+import { useQuery } from "convex/react";
 import {
+  Bug,
   CircleUser,
   Cog,
+  DatabaseZap,
+  FileClock,
   GlobeLock,
   LogOut,
   MessageCircleQuestion,
   Plus,
   Snail,
 } from "lucide-react";
-import { useTheme } from "next-themes";
-import { useState } from "react";
-import type { Selection } from "react-aria-components";
 import { Badge } from "../Badge";
 import { Button } from "../Button";
 import { Link } from "../Link";
@@ -35,25 +36,10 @@ type AppSidebarProps = {
 
 export const AppSidebar = ({ children }: AppSidebarProps) => {
   const { signOut } = useAuthActions();
-  const { theme, setTheme } = useTheme();
-  const [selectedTheme, setSelectedTheme] = useState<Selection>(
-    new Set([theme ?? "system"]),
-  );
+  const { theme, themeSelection, setTheme } = useTheme();
+
   const user = useQuery(api.users.getCurrentUser);
   const isAdmin = user?.role === "admin";
-
-  // Theme change
-  const updateTheme = useMutation(api.users.setUserTheme);
-
-  const handleUpdateTheme = (theme: Selection) => {
-    const newTheme = [...theme][0] as Theme;
-    // Update the theme in the database
-    updateTheme({ theme: newTheme });
-    // Update the theme in next-themes
-    setTheme(newTheme);
-    // Update the selected theme in the menu
-    setSelectedTheme(new Set([newTheme]));
-  };
 
   const handleSignOut = async () => {
     await signOut();
@@ -98,6 +84,23 @@ export const AppSidebar = ({ children }: AppSidebarProps) => {
             >
               About Namesake
             </MenuItem>
+            <MenuItem
+              icon={FileClock}
+              href="https://github.com/namesakefyi/namesake/releases"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Changelog{" "}
+              <span className="text-gray-dim ml-auto">v{APP_VERSION}</span>
+            </MenuItem>
+            <MenuItem
+              icon={DatabaseZap}
+              href="https://status.namesake.fyi"
+              target="_blank"
+              rel="noreferrer"
+            >
+              System Status
+            </MenuItem>
             <MenuSeparator />
             <MenuItem href={{ to: "/settings/account" }} icon={Cog}>
               Settings
@@ -108,8 +111,8 @@ export const AppSidebar = ({ children }: AppSidebarProps) => {
                 <Menu
                   disallowEmptySelection
                   selectionMode="single"
-                  selectedKeys={selectedTheme}
-                  onSelectionChange={handleUpdateTheme}
+                  selectedKeys={themeSelection}
+                  onSelectionChange={setTheme}
                 >
                   {Object.entries(THEMES).map(([theme, details]) => (
                     <MenuItem key={theme} id={theme} icon={details.icon}>
@@ -126,6 +129,14 @@ export const AppSidebar = ({ children }: AppSidebarProps) => {
             )}
             <MenuSeparator />
             <MenuItem
+              href="https://github.com/namesakefyi/namesake/issues/new/choose"
+              target="_blank"
+              rel="noreferrer"
+              icon={Bug}
+            >
+              Report an issue
+            </MenuItem>
+            <MenuItem
               href="https://namesake.fyi/chat"
               target="_blank"
               rel="noreferrer"
@@ -133,6 +144,7 @@ export const AppSidebar = ({ children }: AppSidebarProps) => {
             >
               Support&hellip;
             </MenuItem>
+            <MenuSeparator />
             <MenuItem icon={LogOut} onAction={handleSignOut}>
               Sign out
             </MenuItem>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -16,7 +16,7 @@ export interface ButtonProps extends AriaButtonProps {
 
 export const buttonStyles = tv({
   extend: focusRing,
-  base: "py-2 text-sm font-medium whitespace-nowrap rounded-lg flex gap-1.5 items-center justify-center border border-black/10 dark:border-white/10 cursor-pointer",
+  base: "py-2 text-sm font-medium whitespace-nowrap rounded-lg flex gap-1.5 items-center justify-center border border-black/10 dark:border-white/10",
   variants: {
     variant: {
       primary: "bg-purple-solid text-white",
@@ -31,6 +31,7 @@ export const buttonStyles = tv({
       medium: "h-10 px-3",
     },
     isDisabled: {
+      false: "cursor-pointer",
       true: "cursor-default text-gray-dim opacity-50 forced-colors:text-[GrayText]",
     },
   },
@@ -72,7 +73,7 @@ export function Button({
         }),
       )}
     >
-      {Icon && <Icon size={size === "small" ? 16 : 20} />}
+      {Icon && <Icon size={size === "small" ? 12 : 16} />}
       {children}
     </AriaButton>
   );

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -9,8 +9,8 @@ export function Card({ children, className }: CardProps) {
   return (
     <div
       className={twMerge(
-        className,
         "p-6 text-gray-normal bg-gray-subtle border border-gray-dim rounded-xl",
+        className,
       )}
     >
       {children}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,4 +1,9 @@
-import { Check, ChevronRight, type LucideIcon } from "lucide-react";
+import {
+  Check,
+  ChevronRight,
+  ExternalLink,
+  type LucideIcon,
+} from "lucide-react";
 import {
   Menu as AriaMenu,
   MenuItem as AriaMenuItem,
@@ -63,8 +68,14 @@ export function MenuItem({ className, icon: Icon, ...props }: MenuItemProps) {
             <span className="flex items-center flex-1 gap-2 font-normal truncate group-selected:font-semibold">
               {children}
             </span>
+            {props.target === "_blank" && (
+              <ExternalLink
+                aria-hidden
+                className="size-4 ml-1 text-gray-8 dark:text-graydark-8"
+              />
+            )}
             {hasSubmenu && (
-              <ChevronRight aria-hidden className="w-4 h-4 ml-auto -mr-1" />
+              <ChevronRight aria-hidden className="size-4 ml-auto -mr-1" />
             )}
           </>
         ),

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,13 +1,12 @@
-import { type LinkProps, useMatchRoute } from "@tanstack/react-router";
-import type { LucideIcon } from "lucide-react";
+import { useMatchRoute } from "@tanstack/react-router";
+import { ExternalLink, type LucideIcon } from "lucide-react";
 import { Header } from "react-aria-components";
 import { tv } from "tailwind-variants";
 import { Badge } from "../Badge";
-import { Link } from "../Link";
+import { Link, type LinkProps } from "../Link";
 import { focusRing } from "../utils";
 
-interface NavItemProps {
-  href: LinkProps;
+interface NavItemProps extends LinkProps {
   icon?: LucideIcon;
   className?: string;
   children?: React.ReactNode;
@@ -34,16 +33,23 @@ const iconStyles = tv({
 
 export const NavItem = ({
   icon: Icon,
-  href,
   className,
   children,
+  ...props
 }: NavItemProps) => {
   const matchRoute = useMatchRoute();
-  const current = matchRoute({ ...href, fuzzy: true });
+  let current: boolean | undefined;
+
+  if (typeof props.href === "string") {
+    // Link is external, so we can't match it
+    current = false;
+  } else {
+    current = Boolean(matchRoute({ ...props.href, fuzzy: true }));
+  }
 
   return (
     <Link
-      href={{ ...href }}
+      {...props}
       className={({ isFocusVisible }) =>
         navItemStyles({
           isFocusVisible,
@@ -57,6 +63,12 @@ export const NavItem = ({
         <Icon size={20} className={iconStyles({ isActive: !!current })} />
       )}
       {children}
+      {props.target === "_blank" && (
+        <ExternalLink
+          aria-hidden
+          className="size-4 ml-auto text-gray-8 dark:text-graydark-8"
+        />
+      )}
     </Link>
   );
 };

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -4,20 +4,18 @@ import {
   composeRenderProps,
 } from "react-aria-components";
 import { tv } from "tailwind-variants";
+import { buttonStyles } from "../Button";
 import { focusRing } from "../utils";
 
 const styles = tv({
   extend: focusRing,
-  base: "px-5 py-2 text-sm text-center transition rounded-lg border border-black/10 dark:border-white/10 forced-colors:border-[ButtonBorder] cursor-pointer forced-color-adjust-none",
+  base: "h-10 px-3.5 [&:has(svg:only-child)]:px-2 text-sm text-center transition rounded-lg border border-black/10 dark:border-white/10 forced-colors:border-[ButtonBorder] shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1)] dark:shadow-none forced-color-adjust-none",
   variants: {
     isSelected: {
-      false:
-        "bg-gray-1 hover:bg-gray-2 pressed:bg-gray-3 text-gray-normal dark:bg-gray-6 dark:hover:bg-gray-5 dark:pressed:bg-gray-4 dark:text-gray-1 forced-colors:!bg-[ButtonFace] forced-colors:!text-[ButtonText]",
-      true: "bg-purple-9 hover:bg-purple-10 text-white dark:bg-purpledark-9 dark:hover:bg-purpledark-10 forced-colors:!bg-[Highlight] forced-colors:!text-[HighlightText]",
+      false: buttonStyles.variants.variant.secondary,
+      true: "bg-gray-12 dark:bg-graydark-12 text-gray-1 dark:text-gray-12 shadow-sm",
     },
-    isDisabled: {
-      true: "bg-gray-1 dark:bg-gray-11 forced-colors:!bg-[ButtonFace] text-gray-3 dark:text-gray-6 forced-colors:!text-[GrayText] border-black/5 dark:border-white/5 forced-colors:border-[GrayText]",
-    },
+    isDisabled: buttonStyles.variants.isDisabled,
   },
 });
 

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -9,7 +9,7 @@ import { focusRing } from "../utils";
 
 const styles = tv({
   extend: focusRing,
-  base: "h-10 px-3.5 [&:has(svg:only-child)]:px-2 text-sm text-center transition rounded-lg border border-black/10 dark:border-white/10 forced-colors:border-[ButtonBorder] shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1)] dark:shadow-none forced-color-adjust-none",
+  base: "h-10 px-3.5 [&:has(svg:only-child)]:px-2 text-sm text-center transition rounded-lg border border-black/10 dark:border-white/10",
   variants: {
     isSelected: {
       false: buttonStyles.variants.variant.secondary,

--- a/src/components/ToggleButtonGroup/ToggleButtonGroup.stories.tsx
+++ b/src/components/ToggleButtonGroup/ToggleButtonGroup.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta } from "@storybook/react";
+import { ToggleButtonGroup } from ".";
+
+const meta: Meta<typeof ToggleButtonGroup> = {
+  component: ToggleButtonGroup,
+};
+
+export default meta;
+
+export const Example = (args: any) => <ToggleButtonGroup {...args} />;

--- a/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,0 +1,27 @@
+import {
+  ToggleButtonGroup as AriaToggleButtonGroup,
+  type ToggleButtonGroupProps,
+  composeRenderProps,
+} from "react-aria-components";
+import { tv } from "tailwind-variants";
+
+const styles = tv({
+  base: "border rounded-lg grid grid-flow-col auto-cols-fr border-black/10 dark:border-white/10 *:border-0",
+  variants: {
+    orientation: {
+      horizontal: "flex-row",
+      vertical: "flex-col",
+    },
+  },
+});
+
+export function ToggleButtonGroup(props: ToggleButtonGroupProps) {
+  return (
+    <AriaToggleButtonGroup
+      {...props}
+      className={composeRenderProps(props.className, (className) =>
+        styles({ orientation: props.orientation || "horizontal", className }),
+      )}
+    />
+  );
+}

--- a/src/components/ToggleButtonGroup/index.ts
+++ b/src/components/ToggleButtonGroup/index.ts
@@ -1,0 +1,1 @@
+export * from "./ToggleButtonGroup";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -49,5 +49,6 @@ export * from "./TextArea";
 export * from "./TextField";
 export * from "./TimeField";
 export * from "./ToggleButton";
+export * from "./ToggleButtonGroup";
 export * from "./Toolbar";
 export * from "./Tooltip";

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -7,7 +7,7 @@ export const focusRing = tv({
   variants: {
     isFocusVisible: {
       false: "outline-0",
-      true: "outline-2 z-99",
+      true: "outline-2 z-9999",
     },
   },
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -72,7 +72,7 @@ if (!rootElement.innerHTML) {
     <StrictMode>
       <HelmetProvider>
         <ConvexAuthProvider client={convex}>
-          <ThemeProvider attribute="class">
+          <ThemeProvider attribute="class" disableTransitionOnChange>
             <InnerApp />
           </ThemeProvider>
         </ConvexAuthProvider>

--- a/src/routes/_authenticated/admin/fields/index.tsx
+++ b/src/routes/_authenticated/admin/fields/index.tsx
@@ -150,8 +150,11 @@ function FieldsRoute() {
   return (
     <div>
       <PageHeader title="Fields">
-        <Button onPress={() => setIsNewFieldModalOpen(true)} variant="primary">
-          <Plus />
+        <Button
+          onPress={() => setIsNewFieldModalOpen(true)}
+          variant="primary"
+          icon={Plus}
+        >
           New Field
         </Button>
       </PageHeader>

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -30,9 +30,9 @@ const SettingsSection = ({
   title: string;
   children: React.ReactNode;
 }) => (
-  <section className="flex flex-col lg:flex-row gap-4 mb-8 last-of-type:mb-0">
-    <h2 className="lg:w-1/3 text-lg font-medium">{title}</h2>
-    <Card className="lg:w-2/3 flex flex-col p-0 divide-y divide-gray-dim">
+  <section className="flex flex-col gap-4 mb-8 last-of-type:mb-0">
+    <h2 className="text-lg font-medium">{title}</h2>
+    <Card className="flex flex-col p-0 divide-y divide-gray-dim">
       {children}
     </Card>
   </section>
@@ -181,10 +181,7 @@ function SettingsAccountRoute() {
             </SettingsItem>
           </SettingsSection>
           <SettingsSection title="Appearance">
-            <SettingsItem
-              label="Theme"
-              description="Adjust your display preferences."
-            >
+            <SettingsItem label="Theme" description="Adjust your display.">
               <ToggleButtonGroup
                 selectionMode="single"
                 disallowEmptySelection
@@ -202,7 +199,7 @@ function SettingsAccountRoute() {
           <SettingsSection title="Danger Zone">
             <SettingsItem
               label="Delete account"
-              description="Permanently delete your Namesake account and all data."
+              description="Permanently delete your Namesake account and data."
             >
               <Button
                 onPress={() => setIsDeleteAccountDialogOpen(true)}

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -134,7 +134,6 @@ function SettingsAccountRoute() {
   const [isDeleteAccountDialogOpen, setIsDeleteAccountDialogOpen] =
     useState(false);
 
-  // Is minor switch
   const updateIsMinor = useMutation(api.users.setCurrentUserIsMinor);
 
   return (
@@ -162,7 +161,7 @@ function SettingsAccountRoute() {
               />
             </SettingsItem>
             <SettingsItem
-              label="Applying as a minor"
+              label="Under 18"
               description="Are you under 18 years old or applying on behalf of someone who is?"
             >
               <Switch

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -1,80 +1,141 @@
 import {
   Button,
-  Link,
+  Card,
+  Form,
   Modal,
   PageHeader,
   Switch,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
 } from "@/components";
+import { useTheme } from "@/utils/useTheme";
 import { useAuthActions } from "@convex-dev/auth/react";
 import { api } from "@convex/_generated/api";
+import { THEMES } from "@convex/constants";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
-import { Check, LoaderCircle } from "lucide-react";
-import { useEffect, useState } from "react";
-import { useDebouncedCallback } from "use-debounce";
+import { Pencil, Trash } from "lucide-react";
+import { useState } from "react";
+import { Header } from "react-aria-components";
 
 export const Route = createFileRoute("/_authenticated/settings/account")({
   component: SettingsAccountRoute,
 });
 
-function SettingsAccountRoute() {
-  const { signOut } = useAuthActions();
-  const user = useQuery(api.users.getCurrentUser);
+const SettingsSection = ({
+  title,
+  children,
+}: { title: string; children: React.ReactNode }) => (
+  <section className="flex flex-col lg:flex-row gap-4 mb-8 last-of-type:mb-0">
+    <h2 className="lg:w-1/3 text-lg font-medium">{title}</h2>
+    <Card className="lg:w-2/3 flex flex-col p-0 divide-y divide-gray-dim">
+      {children}
+    </Card>
+  </section>
+);
 
-  // Name change field
-  // TODO: Extract all this debounce logic + field as a component for reuse
+const SettingsItem = ({
+  label,
+  description,
+  children,
+}: { label: string; description?: string; children: React.ReactNode }) => (
+  <div className="flex justify-between items-center gap-8 p-4">
+    <div className="self-start">
+      <h3 className="text-base -mt-px">{label}</h3>
+      {description && (
+        <p className="text-xs text-gray-dim text-balance mt-0.5">
+          {description}
+        </p>
+      )}
+    </div>
+    <div>{children}</div>
+  </div>
+);
+
+const EditNameDialog = ({
+  defaultName,
+  isOpen,
+  onOpenChange,
+  onSubmit,
+}: {
+  defaultName: string;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onSubmit: () => void;
+}) => {
   const updateName = useMutation(api.users.setCurrentUserName);
-  const [name, setName] = useState<string>(user?.name ?? "");
-  const [isUpdatingName, setIsUpdatingName] = useState(false);
-  const [didUpdateName, setDidUpdateName] = useState(false);
+  const [name, setName] = useState(defaultName);
 
-  useEffect(() => {
-    if (!user?.name) return;
-    setName(user.name);
-  }, [user]);
-
-  let timeout: NodeJS.Timeout | null = null;
-
-  useEffect(() => {
-    if (timeout) clearTimeout(timeout);
-    if (didUpdateName)
-      timeout = setTimeout(() => setDidUpdateName(false), 2000);
-  }, [didUpdateName, timeout]);
-
-  const debouncedNameSave = useDebouncedCallback((name) => {
-    updateName({ name })
-      .then(() => {
-        setIsUpdatingName(false);
-        setDidUpdateName(true);
-      })
-      .catch((error) => {
-        console.error(error);
-        setIsUpdatingName(false);
-      });
-  }, 1000);
-
-  const handleUpdateName = (value: string) => {
-    setIsUpdatingName(true);
-    setName(value);
-    debouncedNameSave(value);
+  const handleSubmit = () => {
+    updateName({ name });
+    onSubmit();
   };
 
-  const textFieldIcon = isUpdatingName ? (
-    <LoaderCircle size={20} className="animate animate-spin mr-2" />
-  ) : didUpdateName ? (
-    <Check size={20} className="text-green-9 dark:text-greendark-9 mr-2" />
-  ) : undefined;
+  return (
+    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+      <Form onSubmit={handleSubmit}>
+        Edit name
+        <TextField name="name" label="Name" value={name} onChange={setName} />
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onPress={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary">
+            Save
+          </Button>
+        </div>
+      </Form>
+    </Modal>
+  );
+};
 
-  // Is minor switch
-  const updateIsMinor = useMutation(api.users.setCurrentUserIsMinor);
-
-  // Account deletion
+const DeleteAccountDialog = ({
+  isOpen,
+  onOpenChange,
+  onSubmit,
+}: {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onSubmit: () => void;
+}) => {
+  const { signOut } = useAuthActions();
   const clearLocalStorage = () => {
     localStorage.removeItem("theme");
   };
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const deleteAccount = useMutation(api.users.deleteCurrentUser);
+
+  const handleSubmit = () => {
+    clearLocalStorage();
+    deleteAccount();
+    signOut();
+    onSubmit();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+      <Header>Delete account?</Header>
+      <p>This will permanently erase your account and all data.</p>
+      <div className="flex justify-end w-full gap-2">
+        <Button onPress={() => onOpenChange(false)}>Cancel</Button>
+        <Button variant="destructive" onPress={handleSubmit}>
+          Delete
+        </Button>
+      </div>
+    </Modal>
+  );
+};
+
+function SettingsAccountRoute() {
+  const user = useQuery(api.users.getCurrentUser);
+  const { themeSelection, setTheme } = useTheme();
+
+  const [isNameDialogOpen, setIsNameDialogOpen] = useState(false);
+  const [isDeleteAccountDialogOpen, setIsDeleteAccountDialogOpen] =
+    useState(false);
+
+  // Is minor switch
+  const updateIsMinor = useMutation(api.users.setCurrentUserIsMinor);
 
   return (
     <>
@@ -84,66 +145,74 @@ function SettingsAccountRoute() {
       ) : user === null ? (
         "User not found, please reload"
       ) : (
-        <div className="flex flex-col gap-4">
-          <TextField
-            label="Name"
-            name="name"
-            value={name}
-            onChange={handleUpdateName}
-            description="How do you want to be addressed?"
-            suffix={textFieldIcon}
-          />
-          <Switch
-            name="isMinor"
-            isSelected={user.isMinor ?? false}
-            onChange={() => updateIsMinor({ isMinor: !user.isMinor })}
-          >
-            Is minor
-          </Switch>
-          <Button onPress={signOut}>Sign out</Button>
-          <Button onPress={() => setIsDeleteModalOpen(true)}>
-            Delete account
-          </Button>
-          <Modal
-            isOpen={isDeleteModalOpen}
-            onOpenChange={(isOpen) => setIsDeleteModalOpen(isOpen)}
-          >
-            Delete account?
-            <div className="flex justify-between w-full gap-4">
-              <Button onPress={() => setIsDeleteModalOpen(false)}>
-                Cancel
+        <>
+          <SettingsSection title="Personal Information">
+            <SettingsItem
+              label="Name"
+              description="How should Namesake refer to you? This can be different from your legal name."
+            >
+              <Button icon={Pencil} onPress={() => setIsNameDialogOpen(true)}>
+                {user?.name}
               </Button>
-              <Button
-                variant="destructive"
-                onPress={() => {
-                  clearLocalStorage();
-                  deleteAccount();
-                  signOut();
-                }}
+              <EditNameDialog
+                isOpen={isNameDialogOpen}
+                onOpenChange={setIsNameDialogOpen}
+                defaultName={user.name ?? ""}
+                onSubmit={() => setIsNameDialogOpen(false)}
+              />
+            </SettingsItem>
+            <SettingsItem
+              label="Applying as a minor"
+              description="Are you under 18 years old or applying on behalf of someone who is?"
+            >
+              <Switch
+                name="isMinor"
+                isSelected={user.isMinor ?? false}
+                onChange={() => updateIsMinor({ isMinor: !user.isMinor })}
               >
-                Delete
+                <span className="sr-only">Is minor</span>
+              </Switch>
+            </SettingsItem>
+          </SettingsSection>
+          <SettingsSection title="Appearance">
+            <SettingsItem
+              label="Theme"
+              description="Adjust your display preferences."
+            >
+              <ToggleButtonGroup
+                selectionMode="single"
+                disallowEmptySelection
+                selectedKeys={themeSelection}
+                onSelectionChange={setTheme}
+              >
+                {Object.entries(THEMES).map(([theme, details]) => (
+                  <ToggleButton key={theme} id={theme}>
+                    {details.label}
+                  </ToggleButton>
+                ))}
+              </ToggleButtonGroup>
+            </SettingsItem>
+          </SettingsSection>
+          <SettingsSection title="Danger zone">
+            <SettingsItem
+              label="Delete account"
+              description="Permanently delete your Namesake account and all data."
+            >
+              <Button
+                onPress={() => setIsDeleteAccountDialogOpen(true)}
+                icon={Trash}
+              >
+                Delete account
               </Button>
-            </div>
-          </Modal>
-        </div>
+              <DeleteAccountDialog
+                isOpen={isDeleteAccountDialogOpen}
+                onOpenChange={setIsDeleteAccountDialogOpen}
+                onSubmit={() => setIsDeleteAccountDialogOpen(false)}
+              />
+            </SettingsItem>
+          </SettingsSection>
+        </>
       )}
-      <div className="flex gap-2 items-center mt-4">
-        <Link
-          href="https://github.com/namesakefyi/namesake/releases"
-          target="_blank"
-          rel="noreferrer"
-        >{`Namesake v${APP_VERSION}`}</Link>
-        <Link
-          href="https://status.namesake.fyi"
-          target="_blank"
-          rel="noreferrer"
-        >
-          System Status
-        </Link>
-        <Link href="https://namesake.fyi/chat" target="_blank" rel="noreferrer">
-          Support
-        </Link>
-      </div>
     </>
   );
 }

--- a/src/routes/_authenticated/settings/route.tsx
+++ b/src/routes/_authenticated/settings/route.tsx
@@ -7,7 +7,15 @@ import {
   NavItem,
 } from "@/components";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
-import { CircleUser, Database } from "lucide-react";
+import {
+  Bug,
+  CircleUser,
+  Database,
+  DatabaseZap,
+  FileClock,
+  MessageCircleQuestion,
+  Snail,
+} from "lucide-react";
 
 export const Route = createFileRoute("/_authenticated/settings")({
   component: SettingsRoute,
@@ -24,6 +32,48 @@ function SettingsRoute() {
             </NavItem>
             <NavItem icon={Database} href={{ to: "/settings/data" }}>
               Data
+            </NavItem>
+          </NavGroup>
+          <NavGroup label="Help">
+            <NavItem
+              icon={Snail}
+              href="https://namesake.fyi"
+              target="_blank"
+              rel="noreferrer"
+            >
+              About Namesake
+            </NavItem>
+            <NavItem
+              icon={FileClock}
+              href="https://github.com/namesakefyi/namesake/releases"
+              target="_blank"
+              rel="noreferrer"
+            >
+              View Changelog (v{APP_VERSION})
+            </NavItem>
+            <NavItem
+              href="https://github.com/namesakefyi/namesake/issues/new/choose"
+              target="_blank"
+              rel="noreferrer"
+              icon={Bug}
+            >
+              Report an Issue
+            </NavItem>
+            <NavItem
+              icon={DatabaseZap}
+              href="https://status.namesake.fyi"
+              target="_blank"
+              rel="noreferrer"
+            >
+              System Status
+            </NavItem>
+            <NavItem
+              href="https://namesake.fyi/chat"
+              target="_blank"
+              rel="noreferrer"
+              icon={MessageCircleQuestion}
+            >
+              Discord Community
             </NavItem>
           </NavGroup>
         </Nav>

--- a/src/utils/useTheme.ts
+++ b/src/utils/useTheme.ts
@@ -1,0 +1,24 @@
+import { api } from "@convex/_generated/api";
+import type { Theme } from "@convex/constants";
+import { useMutation } from "convex/react";
+import { useTheme as useNextTheme } from "next-themes";
+import type { Selection } from "react-aria-components";
+
+export function useTheme() {
+  const { theme: nextTheme, setTheme: setNextTheme } = useNextTheme();
+
+  const updateTheme = useMutation(api.users.setUserTheme);
+
+  const theme = (nextTheme ?? "system") as Theme;
+  const themeSelection = new Set([theme]);
+
+  const setTheme = (theme: Selection) => {
+    const newTheme = [...theme][0] as Theme;
+    // Update the theme in the database
+    updateTheme({ theme: newTheme });
+    // Update the theme in next-themes
+    setNextTheme(newTheme);
+  };
+
+  return { theme, themeSelection, setTheme };
+}


### PR DESCRIPTION
## What changed?
Resolves #181. Create new components to display settings. Relocate all external link menu items from the account menu in the bottom left to a new "Help" section within settings.

| Before | After |
|--------|--------|
| ![CleanShot 2024-11-25 at 10 42 33@2x](https://github.com/user-attachments/assets/9bc03b2a-17e3-42a0-bedc-b432953679fb) | ![CleanShot 2024-11-25 at 10 41 17@2x](https://github.com/user-attachments/assets/72514434-68d3-4a3c-b9a7-b3c3283dd478) | 

## Why?
Make it simpler to navigate and configure settings.

## How was this tested?
Manual visual testing.

## Anything else?
Filed several tickets related to settings management.