### PR TITLE
feat: Allow user to set residence and birthplace from settings

### DIFF
--- a/.changeset/fifty-planets-sing.md
+++ b/.changeset/fifty-planets-sing.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Allow setting and modifying user state of residence and state of birth

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -22,8 +22,9 @@ import type * as passwordReset from "../passwordReset.js";
 import type * as questFields from "../questFields.js";
 import type * as quests from "../quests.js";
 import type * as seed from "../seed.js";
-import type * as userData from "../userData.js";
+import type * as userEncryptedData from "../userEncryptedData.js";
 import type * as userQuests from "../userQuests.js";
+import type * as userSettings from "../userSettings.js";
 import type * as users from "../users.js";
 import type * as validators from "../validators.js";
 
@@ -45,8 +46,9 @@ declare const fullApi: ApiFromModules<{
   questFields: typeof questFields;
   quests: typeof quests;
   seed: typeof seed;
-  userData: typeof userData;
+  userEncryptedData: typeof userEncryptedData;
   userQuests: typeof userQuests;
+  userSettings: typeof userSettings;
   users: typeof users;
   validators: typeof validators;
 }>;

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -23,13 +23,20 @@ export const { auth, signIn, signOut, store } = convexAuth({
       }
 
       // Create a new user with defaults
-      return ctx.db.insert("users", {
-        email: args.profile.email,
-        emailVerified: args.profile.emailVerified ?? false,
-        role: "user",
-        theme: "system",
-        groupQuestsBy: "dateAdded",
-      });
+      return ctx.db
+        .insert("users", {
+          email: args.profile.email,
+          emailVerified: args.profile.emailVerified ?? false,
+          role: "user",
+        })
+        .then((userId) => {
+          ctx.db.insert("userSettings", {
+            userId,
+            theme: "system",
+            groupQuestsBy: "dateAdded",
+          });
+          return userId;
+        });
     },
 
     async redirect({ redirectTo }) {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -84,15 +84,15 @@ const forms = defineTable({
 });
 
 /**
- * Represents a user of Namesake.
+ * Represents a user of Namesake's identity.
  * @param name - The user's preferred first name.
  * @param role - The user's role: "admin", "editor", or "user".
  * @param image - A URL to the user's profile picture.
  * @param email - The user's email address.
- * @param emailVerificationTime - Time in ms since epoch when the user verified their email.
- * @param isAnonymous - Denotes anonymous/unauthenticated users.
+ * @param emailVerified - Denotes whether the user has verified their email.
+ * @param residence - The US State the user lives in.
+ * @param birthplace - The US State the user was born in.
  * @param isMinor - Denotes users under 18.
- * @param preferredTheme - The user's preferred color scheme.
  */
 const users = defineTable({
   name: v.optional(v.string()),
@@ -100,11 +100,32 @@ const users = defineTable({
   image: v.optional(v.string()),
   email: v.optional(v.string()),
   emailVerified: v.boolean(),
-  jurisdiction: v.optional(jurisdiction),
+  residence: v.optional(jurisdiction),
+  birthplace: v.optional(jurisdiction),
   isMinor: v.optional(v.boolean()),
-  theme: theme,
-  groupQuestsBy: v.optional(groupQuestsBy),
 }).index("email", ["email"]);
+
+/**
+ * Pre-fillable user data entered throughout quests.
+ * All data in this table is end-to-end encrypted.
+ */
+const userEncryptedData = defineTable({
+  userId: v.id("users"),
+  fieldId: v.id("questFields"),
+  value: v.string(),
+}).index("userId", ["userId"]);
+
+/**
+ * Store user preferences.
+ * @param userId
+ * @param theme - The user's preferred color scheme.
+ * @param groupQuestsBy - The user's preferred way to group quests.
+ */
+const userSettings = defineTable({
+  userId: v.id("users"),
+  theme: v.optional(theme),
+  groupQuestsBy: v.optional(groupQuestsBy),
+}).index("userId", ["userId"]);
 
 /**
  * Represents a user's unique progress in completing a quest.
@@ -122,22 +143,13 @@ const userQuests = defineTable({
   .index("userId", ["userId"])
   .index("questId", ["questId"]);
 
-/**
- * Pre-fillable user data entered throughout quests.
- * All data in this table is end-to-end encrypted.
- */
-const userData = defineTable({
-  userId: v.id("users"),
-  fieldId: v.id("questFields"),
-  value: v.string(),
-}).index("userId", ["userId"]);
-
 export default defineSchema({
   ...authTables,
   forms,
   quests,
   questFields,
   users,
+  userEncryptedData,
+  userSettings,
   userQuests,
-  userData,
 });

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -32,8 +32,6 @@ const seed = internalMutation(async (ctx) => {
         image: faker.image.avatar(),
         role: "admin",
         emailVerified: faker.datatype.boolean(),
-        theme: faker.helpers.arrayElement(["system", "light", "dark"]),
-        groupQuestsBy: "dateAdded",
       });
       console.log(`Created user ${firstName} ${lastName}`);
 

--- a/convex/userEncryptedData.ts
+++ b/convex/userEncryptedData.ts
@@ -4,7 +4,7 @@ export const getUserData = userQuery({
   args: {},
   handler: async (ctx, _args) => {
     const userData = await ctx.db
-      .query("userData")
+      .query("userEncryptedData")
       .withIndex("userId", (q) => q.eq("userId", ctx.userId))
       .first();
 

--- a/convex/userSettings.ts
+++ b/convex/userSettings.ts
@@ -1,0 +1,30 @@
+import { userMutation } from "./helpers";
+import { groupQuestsBy, theme } from "./validators";
+
+export const setTheme = userMutation({
+  args: { theme: theme },
+  handler: async (ctx, args) => {
+    const userSettings = await ctx.db
+      .query("userSettings")
+      .withIndex("userId", (q) => q.eq("userId", ctx.userId))
+      .first();
+
+    if (!userSettings) throw new Error("User settings not found");
+
+    await ctx.db.patch(userSettings._id, { theme: args.theme });
+  },
+});
+
+export const setGroupQuestsBy = userMutation({
+  args: { groupQuestsBy: groupQuestsBy },
+  handler: async (ctx, args) => {
+    const userSettings = await ctx.db
+      .query("userSettings")
+      .withIndex("userId", (q) => q.eq("userId", ctx.userId))
+      .first();
+
+    if (!userSettings) throw new Error("User settings not found");
+
+    await ctx.db.patch(userSettings._id, { groupQuestsBy: args.groupQuestsBy });
+  },
+});

--- a/src/routes/_authenticated/_home.tsx
+++ b/src/routes/_authenticated/_home.tsx
@@ -94,21 +94,6 @@ function IndexRoute() {
 
     if (groupedQuests === undefined) return;
 
-    if (groupedQuests === null || Object.keys(groupedQuests).length === 0)
-      return (
-        <Empty
-          title="No quests"
-          icon={Milestone}
-          link={{
-            children: "Add quest",
-            button: {
-              variant: "primary",
-            },
-            href: { to: "/browse" },
-          }}
-        />
-      );
-
     return (
       <AppSidebar>
         <div className="flex items-center mb-4 bg-gray-app z-10">
@@ -150,46 +135,63 @@ function IndexRoute() {
           </TooltipTrigger>
         </div>
         <Nav>
-          {Object.entries(groupedQuests)
-            .sort(([groupA], [groupB]) =>
-              sortGroupedQuests(groupA, groupB, groupByValue),
-            )
-            .map(([group, quests]) => {
-              if (quests.length === 0) return null;
-              let groupDetails: GroupDetails;
-              switch (groupByValue) {
-                case "category":
-                  groupDetails = CATEGORIES[group as keyof typeof CATEGORIES];
-                  break;
-                case "status":
-                  groupDetails = STATUS[group as keyof typeof STATUS];
-                  break;
-                case "dateAdded":
-                  groupDetails = DATE_ADDED[group as keyof typeof DATE_ADDED];
-                  break;
-              }
-              const { label } = groupDetails;
+          {Object.keys(groupedQuests).length === 0 ? (
+            <Empty
+              title="No quests"
+              icon={Milestone}
+              link={{
+                children: "Add quest",
+                button: {
+                  variant: "primary",
+                },
+                href: { to: "/browse" },
+              }}
+            />
+          ) : (
+            Object.entries(groupedQuests)
+              .sort(([groupA], [groupB]) =>
+                sortGroupedQuests(groupA, groupB, groupByValue),
+              )
+              .map(([group, quests]) => {
+                if (quests.length === 0) return null;
+                let groupDetails: GroupDetails;
+                switch (groupByValue) {
+                  case "category":
+                    groupDetails = CATEGORIES[group as keyof typeof CATEGORIES];
+                    break;
+                  case "status":
+                    groupDetails = STATUS[group as keyof typeof STATUS];
+                    break;
+                  case "dateAdded":
+                    groupDetails = DATE_ADDED[group as keyof typeof DATE_ADDED];
+                    break;
+                }
+                const { label } = groupDetails;
 
-              return (
-                <NavGroup key={label} label={label} count={quests.length}>
-                  {quests.map((quest) => (
-                    <NavItem
-                      key={quest._id}
-                      href={{
-                        to: "/quests/$questId",
-                        params: { questId: quest.questId },
-                      }}
-                    >
-                      <StatusBadge status={quest.status as Status} condensed />
-                      {quest.title}
-                      {quest.jurisdiction && (
-                        <Badge size="xs">{quest.jurisdiction}</Badge>
-                      )}
-                    </NavItem>
-                  ))}
-                </NavGroup>
-              );
-            })}
+                return (
+                  <NavGroup key={label} label={label} count={quests.length}>
+                    {quests.map((quest) => (
+                      <NavItem
+                        key={quest._id}
+                        href={{
+                          to: "/quests/$questId",
+                          params: { questId: quest.questId },
+                        }}
+                      >
+                        <StatusBadge
+                          status={quest.status as Status}
+                          condensed
+                        />
+                        {quest.title}
+                        {quest.jurisdiction && (
+                          <Badge size="xs">{quest.jurisdiction}</Badge>
+                        )}
+                      </NavItem>
+                    ))}
+                  </NavGroup>
+                );
+              })
+          )}
         </Nav>
       </AppSidebar>
     );

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -4,6 +4,8 @@ import {
   Form,
   Modal,
   PageHeader,
+  Select,
+  SelectItem,
   Switch,
   TextField,
   ToggleButton,
@@ -12,7 +14,7 @@ import {
 import { useTheme } from "@/utils/useTheme";
 import { useAuthActions } from "@convex-dev/auth/react";
 import { api } from "@convex/_generated/api";
-import { THEMES } from "@convex/constants";
+import { JURISDICTIONS, type Jurisdiction, THEMES } from "@convex/constants";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { Pencil, Trash } from "lucide-react";
@@ -71,10 +73,11 @@ const EditNameDialog = ({
   onOpenChange: (isOpen: boolean) => void;
   onSubmit: () => void;
 }) => {
-  const updateName = useMutation(api.users.setCurrentUserName);
+  const updateName = useMutation(api.users.setName);
   const [name, setName] = useState(defaultName);
 
-  const handleSubmit = () => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     updateName({ name });
     onSubmit();
   };
@@ -84,6 +87,106 @@ const EditNameDialog = ({
       <Form onSubmit={handleSubmit} className="w-full">
         Edit name
         <TextField name="name" label="Name" value={name} onChange={setName} />
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onPress={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary">
+            Save
+          </Button>
+        </div>
+      </Form>
+    </Modal>
+  );
+};
+
+const EditResidenceDialog = ({
+  defaultResidence,
+  isOpen,
+  onOpenChange,
+  onSubmit,
+}: {
+  defaultResidence: Jurisdiction;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onSubmit: () => void;
+}) => {
+  const updateResidence = useMutation(api.users.setResidence);
+  const [residence, setResidence] = useState(defaultResidence);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    updateResidence({ residence });
+    onSubmit();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+      <Form onSubmit={handleSubmit} className="w-full">
+        Edit residence
+        <Select
+          aria-label="Residence"
+          name="residence"
+          selectedKey={residence}
+          onSelectionChange={(key) => setResidence(key as Jurisdiction)}
+          placeholder="Select state"
+        >
+          {Object.entries(JURISDICTIONS).map(([value, label]) => (
+            <SelectItem key={value} id={value}>
+              {label}
+            </SelectItem>
+          ))}
+        </Select>
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onPress={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary">
+            Save
+          </Button>
+        </div>
+      </Form>
+    </Modal>
+  );
+};
+
+const EditBirthplaceDialog = ({
+  defaultBirthplace,
+  isOpen,
+  onOpenChange,
+  onSubmit,
+}: {
+  defaultBirthplace: Jurisdiction;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onSubmit: () => void;
+}) => {
+  const updateBirthplace = useMutation(api.users.setBirthplace);
+  const [birthplace, setBirthplace] = useState(defaultBirthplace);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    updateBirthplace({ birthplace });
+    onSubmit();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+      <Form onSubmit={handleSubmit} className="w-full">
+        Edit birthplace
+        <Select
+          aria-label="Birthplace"
+          name="birthplace"
+          selectedKey={birthplace}
+          onSelectionChange={(key) => setBirthplace(key as Jurisdiction)}
+          placeholder="Select state"
+        >
+          {Object.entries(JURISDICTIONS).map(([value, label]) => (
+            <SelectItem key={value} id={value}>
+              {label}
+            </SelectItem>
+          ))}
+        </Select>
         <div className="flex justify-end gap-2">
           <Button variant="secondary" onPress={() => onOpenChange(false)}>
             Cancel
@@ -140,7 +243,8 @@ function SettingsAccountRoute() {
   const [isNameDialogOpen, setIsNameDialogOpen] = useState(false);
   const [isDeleteAccountDialogOpen, setIsDeleteAccountDialogOpen] =
     useState(false);
-
+  const [isResidenceDialogOpen, setIsResidenceDialogOpen] = useState(false);
+  const [isBirthplaceDialogOpen, setIsBirthplaceDialogOpen] = useState(false);
   const updateIsMinor = useMutation(api.users.setCurrentUserIsMinor);
 
   return (
@@ -158,7 +262,7 @@ function SettingsAccountRoute() {
               description="How should Namesake refer to you? This can be different from your legal name."
             >
               <Button icon={Pencil} onPress={() => setIsNameDialogOpen(true)}>
-                {user?.name}
+                {user?.name ?? "Set name"}
               </Button>
               <EditNameDialog
                 isOpen={isNameDialogOpen}
@@ -178,6 +282,44 @@ function SettingsAccountRoute() {
               >
                 <span className="sr-only">Is minor</span>
               </Switch>
+            </SettingsItem>
+            <SettingsItem
+              label="Residence"
+              description="Where do you live? This location is used to select the forms for your court order and state ID."
+            >
+              <Button
+                icon={Pencil}
+                onPress={() => setIsResidenceDialogOpen(true)}
+              >
+                {user?.residence
+                  ? JURISDICTIONS[user.residence as Jurisdiction]
+                  : "Set residence"}
+              </Button>
+              <EditResidenceDialog
+                isOpen={isResidenceDialogOpen}
+                onOpenChange={setIsResidenceDialogOpen}
+                defaultResidence={user.residence as Jurisdiction}
+                onSubmit={() => setIsResidenceDialogOpen(false)}
+              />
+            </SettingsItem>
+            <SettingsItem
+              label="Birthplace"
+              description="Where were you born? This location is used to select the forms for your birth certificate."
+            >
+              <Button
+                icon={Pencil}
+                onPress={() => setIsBirthplaceDialogOpen(true)}
+              >
+                {user?.birthplace
+                  ? JURISDICTIONS[user.birthplace as Jurisdiction]
+                  : "Set birthplace"}
+              </Button>
+              <EditBirthplaceDialog
+                isOpen={isBirthplaceDialogOpen}
+                onOpenChange={setIsBirthplaceDialogOpen}
+                defaultBirthplace={user.birthplace as Jurisdiction}
+                onSubmit={() => setIsBirthplaceDialogOpen(false)}
+              />
             </SettingsItem>
           </SettingsSection>
           <SettingsSection title="Appearance">

--- a/src/utils/useTheme.ts
+++ b/src/utils/useTheme.ts
@@ -7,7 +7,7 @@ import type { Selection } from "react-aria-components";
 export function useTheme() {
   const { theme: nextTheme, setTheme: setNextTheme } = useNextTheme();
 
-  const updateTheme = useMutation(api.users.setUserTheme);
+  const updateTheme = useMutation(api.userSettings.setTheme);
 
   const theme = (nextTheme ?? "system") as Theme;
   const themeSelection = new Set([theme]);


### PR DESCRIPTION
## What changed?
- Resolves #216 
- Rename `userData` table to `userEncryptedData`
- Create new `userSettings` table for preferences like `theme` and `groupQuestsBy` to keep business logic separate from identity
- Rename `jurisdiction` field to `residence` and add new `birthplace` field
- Update relevant query functions

![CleanShot 2024-11-26 at 00 04 58@2x](https://github.com/user-attachments/assets/82e7c960-992b-407f-86a9-faf0c8164256)