### PR TITLE
feat: Add tables for `faqs` and `topics`

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type {
 } from "convex/server";
 import type * as auth from "../auth.js";
 import type * as constants from "../constants.js";
+import type * as faqs from "../faqs.js";
 import type * as forms from "../forms.js";
 import type * as helpers from "../helpers.js";
 import type * as http from "../http.js";
@@ -22,6 +23,7 @@ import type * as passwordReset from "../passwordReset.js";
 import type * as questFields from "../questFields.js";
 import type * as quests from "../quests.js";
 import type * as seed from "../seed.js";
+import type * as topics from "../topics.js";
 import type * as userEncryptedData from "../userEncryptedData.js";
 import type * as userQuests from "../userQuests.js";
 import type * as userSettings from "../userSettings.js";
@@ -39,6 +41,7 @@ import type * as validators from "../validators.js";
 declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   constants: typeof constants;
+  faqs: typeof faqs;
   forms: typeof forms;
   helpers: typeof helpers;
   http: typeof http;
@@ -46,6 +49,7 @@ declare const fullApi: ApiFromModules<{
   questFields: typeof questFields;
   quests: typeof quests;
   seed: typeof seed;
+  topics: typeof topics;
   userEncryptedData: typeof userEncryptedData;
   userQuests: typeof userQuests;
   userSettings: typeof userSettings;

--- a/convex/faqs.test.ts
+++ b/convex/faqs.test.ts
@@ -1,0 +1,131 @@
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+import { modules } from "./test.setup";
+
+describe("faqs", () => {
+  it("creates a FAQ", async () => {
+    const t = convexTest(schema, modules);
+
+    // Create a topic first
+    const topicId = await t.mutation(api.topics.createTopic, {
+      topic: "Costs",
+    });
+
+    // Create a FAQ
+    const faqId = await t.mutation(api.faqs.createFAQ, {
+      question: "How much does the process cost?",
+      answer: "It varies.",
+      topics: [topicId],
+    });
+
+    // Verify FAQ creation
+    const faqs = await t.query(api.faqs.getAllFAQs);
+    const createdFAQ = faqs.find((f) => f._id === faqId);
+    expect(createdFAQ).toBeTruthy();
+    expect(createdFAQ?.question).toBe("How much does the process cost?");
+    expect(createdFAQ?.answer).toBe("It varies.");
+    expect(createdFAQ?.topics).toContain(topicId);
+  });
+
+  it("updates a FAQ", async () => {
+    const t = convexTest(schema, modules);
+
+    // Create a topic first
+    const topicId = await t.mutation(api.topics.createTopic, {
+      topic: "Costs",
+    });
+
+    // Create a FAQ
+    const faqId = await t.mutation(api.faqs.createFAQ, {
+      question: "How much does the process cost?",
+      answer: "It varies.",
+      topics: [topicId],
+    });
+
+    // Update the FAQ
+    await t.mutation(api.faqs.updateFAQ, {
+      faqId,
+      faq: {
+        question: "How much does the process cost, exactly?",
+        answer: "It varies a lot.",
+        topics: [topicId],
+      },
+    });
+
+    // Verify FAQ update
+    const faqs = await t.query(api.faqs.getAllFAQs);
+    const updatedFAQ = faqs.find((f) => f._id === faqId);
+    expect(updatedFAQ).toBeTruthy();
+    expect(updatedFAQ?.question).toBe(
+      "How much does the process cost, exactly?",
+    );
+    expect(updatedFAQ?.answer).toBe("It varies a lot.");
+  });
+
+  it("gets all FAQs", async () => {
+    const t = convexTest(schema, modules);
+
+    // Create a topic first
+    const topicId = await t.mutation(api.topics.createTopic, {
+      topic: "Costs",
+    });
+
+    // Mock FAQs
+    await t.run(async (ctx) => {
+      await ctx.db.insert("faqs", {
+        question: "How much does the process cost?",
+        answer: "It varies.",
+        topics: [topicId],
+      });
+      await ctx.db.insert("faqs", {
+        question: "What documents do I need?",
+        answer: "You'll need passport, visa, and other supporting documents.",
+        topics: [topicId],
+      });
+    });
+
+    // Get all FAQs
+    const faqs = await t.query(api.faqs.getAllFAQs);
+
+    // Verify FAQs
+    expect(faqs.length).toBe(2);
+    expect(faqs[0].question).toBe("How much does the process cost?");
+    expect(faqs[1].question).toBe("What documents do I need?");
+  });
+
+  it("deletes a FAQ", async () => {
+    const t = convexTest(schema, modules);
+
+    // Create a topic first
+    const topicId = await t.mutation(api.topics.createTopic, {
+      topic: "Costs",
+    });
+
+    // Create a FAQ
+    const faqId = await t.mutation(api.faqs.createFAQ, {
+      question: "How much does the process cost?",
+      answer: "It varies.",
+      topics: [topicId],
+    });
+
+    // Verify FAQ creation
+    const faqs = await t.query(api.faqs.getAllFAQs);
+    const createdFAQ = faqs.find((f) => f._id === faqId);
+    expect(createdFAQ).toBeTruthy();
+    expect(createdFAQ?.question).toBe("How much does the process cost?");
+    expect(createdFAQ?.answer).toBe("It varies.");
+    expect(createdFAQ?.topics).toContain(topicId);
+
+    // Delete the FAQ
+    await t.mutation(api.faqs.deleteFAQ, {
+      faqId,
+    });
+
+    // Verify FAQ deletion
+    const faqsAfter = await t.query(api.faqs.getAllFAQs);
+    const deletedFAQ = faqsAfter.find((f) => f._id === faqId);
+    expect(deletedFAQ).toBeUndefined();
+  });
+});

--- a/convex/faqs.ts
+++ b/convex/faqs.ts
@@ -13,12 +13,14 @@ export const createFAQ = mutation({
     question: v.string(),
     answer: v.string(),
     topics: v.array(v.id("topics")),
+    relatedQuests: v.optional(v.array(v.id("quests"))),
   },
-  handler: async (ctx, { question, answer, topics }) => {
+  handler: async (ctx, { question, answer, topics, relatedQuests }) => {
     return await ctx.db.insert("faqs", {
       question,
       answer,
       topics,
+      relatedQuests,
     });
   },
 });

--- a/convex/faqs.ts
+++ b/convex/faqs.ts
@@ -1,0 +1,55 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+
+export const getAllFAQs = query({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db.query("faqs").collect();
+  },
+});
+
+export const createFAQ = mutation({
+  args: {
+    question: v.string(),
+    answer: v.string(),
+    topics: v.array(v.id("topics")),
+  },
+  handler: async (ctx, { question, answer, topics }) => {
+    return await ctx.db.insert("faqs", {
+      question,
+      answer,
+      topics,
+    });
+  },
+});
+
+export const updateFAQ = mutation({
+  args: {
+    faqId: v.id("faqs"),
+    faq: v.object({
+      question: v.string(),
+      answer: v.string(),
+      topics: v.array(v.id("topics")),
+      relatedQuests: v.optional(v.array(v.id("quests"))),
+    }),
+  },
+  handler: async (ctx, { faqId, faq }) => {
+    return await ctx.db.patch(faqId, {
+      ...faq,
+    });
+  },
+});
+
+export const deleteFAQ = mutation({
+  args: { faqId: v.id("faqs") },
+  handler: async (ctx, { faqId }) => {
+    const faq = await ctx.db.get(faqId);
+    if (faq === null) throw new Error("Question not found");
+    if (faq.relatedQuests && faq.relatedQuests.length > 0) {
+      throw new Error(
+        "There are related quests for this question. Please delete them first.",
+      );
+    }
+    return await ctx.db.delete(faqId);
+  },
+});

--- a/convex/quests.test.ts
+++ b/convex/quests.test.ts
@@ -1,14 +1,13 @@
 import { convexTest } from "convex-test";
-import { expect, test } from "vitest";
+import { describe, expect, it } from "vitest";
 import { api } from "./_generated/api";
 import schema from "./schema";
-
-// TODO: Remove this import and this file;
-// shouldn't need to use it since everything is in the default location
 import { modules } from "./test.setup";
 
-test("get all quests", async () => {
-  const t = convexTest(schema, modules);
-  const quests = await t.query(api.quests.getAllQuests);
-  expect(quests).toMatchObject([]);
+describe("quests", () => {
+  it("gets all quests", async () => {
+    const t = convexTest(schema, modules);
+    const quests = await t.query(api.quests.getAllQuests);
+    expect(quests).toMatchObject([]);
+  });
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -12,23 +12,52 @@ import {
   timeRequiredUnit,
 } from "./validators";
 
+// ----------------------------------------------
+// FAQs
+// ----------------------------------------------
+
 /**
- * Represents a collection of steps and forms for a user to complete.
- * @param title - The title of the quest. (e.g. "Court Order")
- * @param category - The category of the quest. (e.g. "Social")
- * @param creationUser - The user who created the quest.
- * @param jurisdiction - The US State the quest applies to. (e.g. "MA")
- * @param costs - The costs of the quest in USD.
- * @param timeRequired - The estimated time required to complete the quest.
- * @param urls - Links to official documentation about changing names for this quest.
- * @param deletionTime - Time in ms since epoch when the quest was deleted.
- * @param content - Text written in markdown comprising the contents of the quest.
+ * A shared topic used to tag and organize faqs.
+ */
+const topics = defineTable({
+  /** The name of the topic. Should be short and unique. */
+  topic: v.string(),
+});
+
+/**
+ * A frequently asked question and its answer.
+ */
+const faqs = defineTable({
+  /** A frequently asked question. */
+  question: v.string(),
+  /** The rich text answer to the question, stored as HTML. */
+  answer: v.string(),
+  /** One or more topics related to the question. */
+  topics: v.array(v.id("topics")),
+  /** Optional quests related to the question. */
+  relatedQuests: v.optional(v.array(v.id("quests"))),
+})
+  .index("topics", ["topics"])
+  .index("relatedQuests", ["relatedQuests"]);
+
+// ----------------------------------------------
+// Quests
+// ----------------------------------------------
+
+/**
+ * A series of steps and documents which guides users through
+ * changing their name for a single location / entity.
  */
 const quests = defineTable({
+  /** The title of the quest. (e.g. "Court Order") */
   title: v.string(),
+  /** The category of the quest. (e.g. "Core", "Social") */
   category: v.optional(category),
+  /** The user who created the quest. */
   creationUser: v.id("users"),
+  /** The US State the quest applies to. */
   jurisdiction: v.optional(jurisdiction),
+  /** The costs of the quest in USD. */
   costs: v.optional(
     v.array(
       v.object({
@@ -37,80 +66,87 @@ const quests = defineTable({
       }),
     ),
   ),
+  /** The estimated time required to complete the quest. */
   timeRequired: v.object({
     min: v.number(),
     max: v.number(),
     unit: timeRequiredUnit,
     description: v.optional(v.string()),
   }),
+  /** Links to official documentation about changing names for this quest. */
   urls: v.optional(v.array(v.string())),
+  /** Time in ms since epoch when the quest was deleted. */
   deletionTime: v.optional(v.number()),
+  /** Rich text comprising the contents of the quest, stored as HTML. */
   content: v.optional(v.string()),
 }).index("category", ["category"]);
 
 /**
- * Represents a single input field which may be shared across multiple quests
- * or steps. Data entered into these fields are end-to-end encrypted and used
- * to pre-fill fields that point to the same data in future quests.
- * @param type - The type of field. (e.g. "text", "select")
- * @param label - The label for the field. (e.g. "First Name")
- * @param slug - A unique identifier for the field, camel cased. (e.g. "firstName")
- * @param helpText - Additional help text for the field.
- * @param deletionTime - Time in ms since epoch when the field was deleted.
+ * A single input field which may be shared across multiple quests.
  */
 const questFields = defineTable({
+  /** The type of field. (e.g. "text", "select") */
   type: field,
+  /** The label for the field. (e.g. "First Name") */
   label: v.string(),
+  /** A unique identifier for the field, camel cased. (e.g. "firstName") */
   slug: v.string(),
+  /** Additional help text for the field. */
   helpText: v.optional(v.string()),
+  /** Time in ms since epoch when the field was deleted. */
   deletionTime: v.optional(v.number()),
 });
 
 /**
- * Represents a PDF form that can be filled out by users.
- * @param questId - The ID of the quest this form belongs to.
- * @param title - The title of the form. (e.g. "Petition to Change Name of Adult")
- * @param formCode - The legal code for the form. (e.g. "CJP 27")
- * @param creationUser - The user who created the form.
- * @param file - The storageId for the PDF file.
- * @param jurisdiction - The US State the form applies to. (e.g. "MA")
- * @param deletionTime - Time in ms since epoch when the form was deleted.
+ * A PDF form that can be filled out by users.
  */
 const forms = defineTable({
+  /** The quest this form belongs to. */
   questId: v.id("quests"),
+  /** The title of the form. (e.g. "Petition to Change Name of Adult") */
   title: v.string(),
+  /** The legal code for the form. (e.g. "CJP 27") */
   formCode: v.optional(v.string()),
+  /** The user who created the form. */
   creationUser: v.id("users"),
+  /** The storageId for the PDF file. */
   file: v.optional(v.id("_storage")),
+  /** The US State the form applies to. */
   jurisdiction: jurisdiction,
+  /** Time in ms since epoch when the form was deleted. */
   deletionTime: v.optional(v.number()),
 }).index("quest", ["questId"]);
 
+// ----------------------------------------------
+// Users
+// ----------------------------------------------
+
 /**
- * Represents a user of Namesake's identity.
- * @param name - The user's preferred first name.
- * @param role - The user's role: "admin", "editor", or "user".
- * @param image - A URL to the user's profile picture.
- * @param email - The user's email address.
- * @param emailVerified - Denotes whether the user has verified their email.
- * @param residence - The US State the user lives in.
- * @param birthplace - The US State the user was born in.
- * @param isMinor - Denotes users under 18.
+ * A Namesake user's identity.
  */
 const users = defineTable({
+  /** The user's name. */
   name: v.optional(v.string()),
+  /** The user's role. */
   role: role,
+  /** The user's profile image. */
   image: v.optional(v.string()),
+  /** The user's email address. */
   email: v.optional(v.string()),
+  /** Whether the user's email address has been verified. */
   emailVerified: v.boolean(),
+  /** The US State where the user resides. */
   residence: v.optional(jurisdiction),
+  /** The US State where the user was born. */
   birthplace: v.optional(jurisdiction),
+  /** Whether the user is a minor. */
   isMinor: v.optional(v.boolean()),
 }).index("email", ["email"]);
 
 /**
- * Pre-fillable user data entered throughout quests.
- * All data in this table is end-to-end encrypted.
+ * A unique piece of user data that has been enteed through filling a form.
+ * End-to-end encrypted.
+ * TODO: Implement
  */
 const userEncryptedData = defineTable({
   userId: v.id("users"),
@@ -119,28 +155,28 @@ const userEncryptedData = defineTable({
 }).index("userId", ["userId"]);
 
 /**
- * Store user preferences.
- * @param userId
- * @param theme - The user's preferred color scheme.
- * @param groupQuestsBy - The user's preferred way to group quests.
+ * A user's preferences.
  */
 const userSettings = defineTable({
+  /** The user who owns the settings. */
   userId: v.id("users"),
+  /** The user's preferred color scheme. (e.g. "system", "light", "dark") */
   theme: v.optional(theme),
+  /** The user's preferred way to group quests. (e.g. "dateAdded", "category") */
   groupQuestsBy: v.optional(groupQuestsBy),
 }).index("userId", ["userId"]);
 
 /**
- * Represents a user's unique progress in completing a quest.
- * @param userId
- * @param questId
- * @param status - The status of the quest.
- * @param completionTime - Time in ms since epoch when the user marked the quest as complete.
+ * A user's unique progress in completing a quest.
  */
 const userQuests = defineTable({
+  /** The user who is working on the quest. */
   userId: v.id("users"),
+  /** The quest that the user is working on. */
   questId: v.id("quests"),
+  /** The status of the quest. */
   status: status,
+  /** Time in ms since epoch when the user marked the quest as complete. */
   completionTime: v.optional(v.number()),
 })
   .index("userId", ["userId"])
@@ -148,6 +184,8 @@ const userQuests = defineTable({
 
 export default defineSchema({
   ...authTables,
+  faqs,
+  topics,
   forms,
   quests,
   questFields,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -67,12 +67,14 @@ const quests = defineTable({
     ),
   ),
   /** The estimated time required to complete the quest. */
-  timeRequired: v.object({
-    min: v.number(),
-    max: v.number(),
-    unit: timeRequiredUnit,
-    description: v.optional(v.string()),
-  }),
+  timeRequired: v.optional(
+    v.object({
+      min: v.number(),
+      max: v.number(),
+      unit: timeRequiredUnit,
+      description: v.optional(v.string()),
+    }),
+  ),
   /** Links to official documentation about changing names for this quest. */
   urls: v.optional(v.array(v.string())),
   /** Time in ms since epoch when the quest was deleted. */
@@ -134,7 +136,7 @@ const users = defineTable({
   /** The user's email address. */
   email: v.optional(v.string()),
   /** Whether the user's email address has been verified. */
-  emailVerified: v.boolean(),
+  emailVerified: v.optional(v.boolean()),
   /** The US State where the user resides. */
   residence: v.optional(jurisdiction),
   /** The US State where the user was born. */

--- a/convex/topics.test.ts
+++ b/convex/topics.test.ts
@@ -82,4 +82,27 @@ describe("topics", () => {
     expect(topics[1].topic).toBe("Adoption");
     expect(topics[2].topic).toBe("Costs");
   });
+
+  it("errors if attempting to delete a topic with faqs", async () => {
+    const t = convexTest(schema, modules);
+
+    // Create a topic first
+    const topicId = await t.mutation(api.topics.createTopic, {
+      topic: "Costs",
+    });
+
+    // Create a FAQ
+    await t.mutation(api.faqs.createFAQ, {
+      question: "How much does the process cost?",
+      answer: "It varies.",
+      topics: [topicId],
+    });
+
+    // Attempt to delete the topic
+    await expect(
+      t.mutation(api.topics.deleteTopic, {
+        topicId,
+      }),
+    ).rejects.toThrowError("Cannot delete topic with faqs");
+  });
 });

--- a/convex/topics.test.ts
+++ b/convex/topics.test.ts
@@ -1,0 +1,85 @@
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+import { modules } from "./test.setup";
+
+describe("topics", () => {
+  it("creates a topic", async () => {
+    const t = convexTest(schema, modules);
+    // Create a topic
+    const topicId = await t.mutation(api.topics.createTopic, {
+      topic: "Immigration",
+    });
+
+    // Verify topic creation
+    const topics = await t.query(api.topics.getAllTopics);
+    const createdTopic = topics.find((t) => t._id === topicId);
+    expect(createdTopic).toBeTruthy();
+    expect(createdTopic?.topic).toBe("Immigration");
+  });
+
+  it("updates a topic", async () => {
+    const t = convexTest(schema, modules);
+    // Create a topic
+    const topicId = await t.mutation(api.topics.createTopic, {
+      topic: "Immigration",
+    });
+
+    // Update the topic
+    await t.mutation(api.topics.updateTopic, {
+      topicId,
+      topic: "Adoption",
+    });
+
+    // Verify topic update
+    const topics = await t.query(api.topics.getAllTopics);
+    const updatedTopic = topics.find((t) => t._id === topicId);
+    expect(updatedTopic).toBeTruthy();
+    expect(updatedTopic?.topic).toBe("Adoption");
+  });
+
+  it("deletes a topic", async () => {
+    const t = convexTest(schema, modules);
+    // Create a topic
+    const topicId = await t.mutation(api.topics.createTopic, {
+      topic: "Immigration",
+    });
+
+    // Verify topic creation
+    const topics = await t.query(api.topics.getAllTopics);
+    const createdTopic = topics.find((t) => t._id === topicId);
+    expect(createdTopic).toBeTruthy();
+    expect(createdTopic?.topic).toBe("Immigration");
+
+    // Delete the topic
+    await t.mutation(api.topics.deleteTopic, {
+      topicId,
+    });
+
+    // Verify topic deletion
+    const topicsAfter = await t.query(api.topics.getAllTopics);
+    const deletedTopic = topicsAfter.find((t) => t._id === topicId);
+    expect(deletedTopic).toBeUndefined();
+  });
+
+  it("gets all topics", async () => {
+    const t = convexTest(schema, modules);
+
+    // Mock topics
+    await t.run(async (ctx) => {
+      await ctx.db.insert("topics", { topic: "Immigration" });
+      await ctx.db.insert("topics", { topic: "Adoption" });
+      await ctx.db.insert("topics", { topic: "Costs" });
+    });
+
+    // Get all topics
+    const topics = await t.query(api.topics.getAllTopics);
+
+    // Verify topics
+    expect(topics.length).toBe(3);
+    expect(topics[0].topic).toBe("Immigration");
+    expect(topics[1].topic).toBe("Adoption");
+    expect(topics[2].topic).toBe("Costs");
+  });
+});

--- a/convex/topics.ts
+++ b/convex/topics.ts
@@ -1,0 +1,42 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+
+export const getAllTopics = query({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db.query("topics").collect();
+  },
+});
+
+export const createTopic = mutation({
+  args: { topic: v.string() },
+  handler: async (ctx, { topic }) => {
+    return await ctx.db.insert("topics", {
+      topic,
+    });
+  },
+});
+
+export const updateTopic = mutation({
+  args: { topicId: v.id("topics"), topic: v.string() },
+  handler: async (ctx, { topicId, topic }) => {
+    return await ctx.db.patch(topicId, {
+      topic,
+    });
+  },
+});
+
+export const deleteTopic = mutation({
+  args: { topicId: v.id("topics") },
+  handler: async (ctx, { topicId }) => {
+    // If there are any faqs with this topic, throw an error
+    const faqs = await ctx.db
+      .query("faqs")
+      .withIndex("topics", (q) => q.eq("topics", [topicId]))
+      .collect();
+    if (faqs.length > 0) {
+      throw new Error("Cannot delete topic with faqs");
+    }
+    return await ctx.db.delete(topicId);
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,10 @@ export default defineConfig({
       ["convex/**", "edge-runtime"],
       ["**", "jsdom"],
     ],
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    include: [
+      "src/**/*.{test,spec}.{ts,tsx}",
+      "convex/**/*.{test,spec}.{ts,tsx}",
+    ],
     exclude: [...configDefaults.exclude, "e2e/**"],
     coverage: {
       reporter: ["text", "json-summary", "json"],


### PR DESCRIPTION
## What changed?
Resolves #238. Creates new tables for `faqs` and `topics` to handle storing knowledge base content. Adds basic get/set/update/delete functions and tests for both tables.

## Why?
Support creating a knowledge base and displaying questions/answers alongside quests.

## How was this tested?
Wrote new tests for the new functions.

## Anything else?
Updated and reorganized the comments and structure of `schema.ts`.