### PR TITLE
fix: Reconfigure redirect logic for auth users

### DIFF
--- a/.changeset/mighty-ducks-juggle.md
+++ b/.changeset/mighty-ducks-juggle.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix redirect logic for authenticated and unauthenticated users

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -1,15 +1,14 @@
-import { Navigate, Outlet, createFileRoute } from "@tanstack/react-router";
-import { useConvexAuth } from "convex/react";
+import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_authenticated")({
+  beforeLoad: async ({ context }) => {
+    const isAuthenticated = await context.auth;
+    if (!isAuthenticated) throw redirect({ to: "/signin" });
+  },
   component: AuthenticatedRoute,
 });
 
 function AuthenticatedRoute() {
-  const { isAuthenticated } = useConvexAuth();
-
-  if (!isAuthenticated) return <Navigate to="/signin" />;
-
   return (
     <main className="text-gray-normal">
       <Outlet />

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -4,7 +4,6 @@ import { Authenticated } from "convex/react";
 export const Route = createFileRoute("/_authenticated")({
   beforeLoad: async ({ context }) => {
     const { isAuthenticated, isLoading } = await context.auth;
-    console.log("isAuthenticated", isAuthenticated);
     if (!isLoading && !isAuthenticated) throw redirect({ to: "/signin" });
   },
   component: AuthenticatedRoute,

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -1,17 +1,21 @@
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
+import { Authenticated } from "convex/react";
 
 export const Route = createFileRoute("/_authenticated")({
   beforeLoad: async ({ context }) => {
-    const isAuthenticated = await context.auth;
-    if (!isAuthenticated) throw redirect({ to: "/signin" });
+    const { isAuthenticated, isLoading } = await context.auth;
+    console.log("isAuthenticated", isAuthenticated);
+    if (!isLoading && !isAuthenticated) throw redirect({ to: "/signin" });
   },
   component: AuthenticatedRoute,
 });
 
 function AuthenticatedRoute() {
   return (
-    <main className="text-gray-normal">
-      <Outlet />
-    </main>
+    <Authenticated>
+      <main className="text-gray-normal">
+        <Outlet />
+      </main>
+    </Authenticated>
   );
 }

--- a/src/routes/_authenticated/_home.tsx
+++ b/src/routes/_authenticated/_home.tsx
@@ -28,7 +28,7 @@ import {
   type Status,
 } from "@convex/constants";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
-import { Authenticated, Unauthenticated, useQuery } from "convex/react";
+import { useQuery } from "convex/react";
 import {
   History,
   List,
@@ -219,16 +219,9 @@ function IndexRoute() {
   };
 
   return (
-    <>
-      <Authenticated>
-        <Container className="flex">
-          <MyQuests />
-          <Outlet />
-        </Container>
-      </Authenticated>
-      <Unauthenticated>
-        <h1>Please log in</h1>
-      </Unauthenticated>
-    </>
+    <Container className="flex">
+      <MyQuests />
+      <Outlet />
+    </Container>
   );
 }

--- a/src/routes/_unauthenticated.tsx
+++ b/src/routes/_unauthenticated.tsx
@@ -1,14 +1,9 @@
-import { Navigate, Outlet, createFileRoute } from "@tanstack/react-router";
-import { useConvexAuth } from "convex/react";
+import { Outlet, createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_unauthenticated")({
   component: UnauthenticatedRoute,
 });
 
 function UnauthenticatedRoute() {
-  const { isAuthenticated } = useConvexAuth();
-
-  if (isAuthenticated) return <Navigate to="/" />;
-
   return <Outlet />;
 }

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -23,8 +23,8 @@ import type { Key } from "react-aria";
 
 export const Route = createFileRoute("/_unauthenticated/signin")({
   beforeLoad: async ({ context }) => {
-    const isAuthenticated = await context.auth;
-    if (isAuthenticated) throw redirect({ to: "/" });
+    const { isAuthenticated, isLoading } = await context.auth;
+    if (!isLoading && isAuthenticated) throw redirect({ to: "/" });
   },
   component: LoginRoute,
 });

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -15,13 +15,17 @@ import {
   TooltipTrigger,
 } from "@/components/common";
 import { useAuthActions } from "@convex-dev/auth/react";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 import { ConvexError } from "convex/values";
 import { ChevronLeft } from "lucide-react";
 import { useState } from "react";
 import type { Key } from "react-aria";
 
 export const Route = createFileRoute("/_unauthenticated/signin")({
+  beforeLoad: async ({ context }) => {
+    const isAuthenticated = await context.auth;
+    if (isAuthenticated) throw redirect({ to: "/" });
+  },
   component: LoginRoute,
 });
 


### PR DESCRIPTION
## What changed?
Allow authenticated users to access routes within `_unauthenticated` by relocating redirect to `/signin` for auth users. Move redirection out of the render and into `beforeLoad` for TanStack Router.

## Why?
Previously authenticated users would get a flash of the login screen when doing a hard refresh of a page, since the page was rendered before the hook finished loading the authentication status. Moving this to `beforeLoad` delays rendering slightly but avoids the flash.

Additionally, not including redirect logic within `_unauthenticated` opens us up to creating pages which are available to the public as well as authenticated users, improving accessibility of information.