### PR TITLE
chore: Setup RelativeCI for bundle comparison

### DIFF
--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -48,30 +48,3 @@ jobs:
           webpackStatsFile: ./webpack-stats.json
           key: ${{ secrets.RELATIVE_CI_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
-
-  report-coverage:
-    needs: test-coverage
-    name: Report Coverage
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-  
-      - name: Download coverage (${{ github.head_ref }})
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-${{ github.head_ref }}
-          path: coverage
-
-      - name: Download coverage (main)
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-main
-          path: coverage-main
-
-      - name: Report coverage
-        if: always()
-        uses: davelosert/vitest-coverage-report-action@v2.8.0
-        with:
-          json-summary-compare-path: coverage-main/coverage-summary.json

--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -45,6 +45,6 @@ jobs:
       - name: Send bundle stats to RelativeCI
         uses: relative-ci/agent-action@v2
         with:
-          webpackStatsFile: ./webpack-stats.json
+          webpackStatsFile: ./dist/webpack-stats.json
           key: ${{ secrets.RELATIVE_CI_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -1,0 +1,77 @@
+name: Bundle Size
+
+on: 
+  push:
+    branches: main
+  pull_request:
+    branches: main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # Build and output bundle stats to webpack-stats.json
+      - name: Build
+        run: pnpm build -- --json webpack-stats.json
+
+      # Send bundle stats and build information to RelativeCI
+      - name: Send bundle stats to RelativeCI
+        uses: relative-ci/agent-action@v2
+        with:
+          webpackStatsFile: ./webpack-stats.json
+          key: ${{ secrets.RELATIVE_CI_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  report-coverage:
+    needs: test-coverage
+    name: Report Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+  
+      - name: Download coverage (${{ github.head_ref }})
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-${{ github.head_ref }}
+          path: coverage
+
+      - name: Download coverage (main)
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-main
+          path: coverage-main
+
+      - name: Report coverage
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@v2.8.0
+        with:
+          json-summary-compare-path: coverage-main/coverage-summary.json

--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    name: Build
+    name: Build and report bundle stats
     runs-on: ubuntu-latest
 
     steps:

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "lint-staged": "^15.2.10",
     "npm-run-all": "^4.1.5",
     "prop-types": "^15.8.1",
+    "rollup-plugin-webpack-stats": "^1.1.1",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-aria-attributes": "^2.0.1",
     "tailwindcss-radix-colors": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
+      rollup-plugin-webpack-stats:
+        specifier: ^1.1.1
+        version: 1.1.1(rollup@4.27.3)
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.5.5
@@ -5342,6 +5345,12 @@ packages:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
+
+  rollup-plugin-webpack-stats@1.1.1:
+    resolution: {integrity: sha512-omUl6WNXvini+SjG8gCHNNXeee5mJ9yXK9+cUi7xmFlHteAg5KQN2Os3T7aw62ET/1f50WJRjrLPe+9TOCbWNA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      rollup: ^3.0.0 || ^4.0.0
 
   rollup@4.27.3:
     resolution: {integrity: sha512-SLsCOnlmGt9VoZ9Ek8yBK8tAdmPHeppkw+Xa7yDlCEhDTvwYei03JlWo1fdc7YTfLZ4tD8riJCUyAgTbszk1fQ==}
@@ -12022,6 +12031,10 @@ snapshots:
     dependencies:
       glob: 7.2.3
     optional: true
+
+  rollup-plugin-webpack-stats@1.1.1(rollup@4.27.3):
+    dependencies:
+      rollup: 4.27.3
 
   rollup@4.27.3:
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,13 +4,30 @@ import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react-swc";
 import autoprefixer from "autoprefixer";
 import cssnano from "cssnano";
+import webpackStatsPlugin from "rollup-plugin-webpack-stats";
 import tailwindcss from "tailwindcss";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [TanStackRouterVite(), tsconfigPaths(), react()],
+  build: {
+    rollupOptions: {
+      output: {
+        // Use a supported file pattern for Vite 5/Rollup 4
+        // @doc https://relative-ci.com/documentation/guides/vite-config
+        assetFileNames: "assets/[name].[hash][extname]",
+        chunkFileNames: "assets/[name].[hash].js",
+        entryFileNames: "assets/[name].[hash].js",
+      },
+    },
+  },
+  plugins: [
+    TanStackRouterVite(),
+    tsconfigPaths(),
+    react(),
+    webpackStatsPlugin(),
+  ],
   define: {
     APP_VERSION: JSON.stringify(process.env.npm_package_version),
   },


### PR DESCRIPTION
## What changed?
Setup RelativeCI to compare bundle sizes between each branch and main.

## Why?
Help optimize bundle size and reduce dependencies.

## How was this change made?
Signed up for open source RelativeCI account, created new action and installed new package to send build data.