### PR TITLE
feat: Adjust user role assignment based on environment

### DIFF
--- a/.changeset/funny-roses-wink.md
+++ b/.changeset/funny-roses-wink.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Default the user role to admin during signup when the environment is set to development.

--- a/convex/auth.test.ts
+++ b/convex/auth.test.ts
@@ -1,0 +1,57 @@
+import { faker } from "@faker-js/faker";
+import { convexTest } from "convex-test";
+import { describe, expect, it, vi } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+import { modules } from "./test.setup";
+
+describe("auth roles", () => {
+  it("should set role to admin in development environment", async () => {
+    const t = convexTest(schema, modules);
+
+    const dummyUser = {
+      email: faker.internet.email(),
+      emailVerified: faker.datatype.boolean(),
+    };
+
+    // Set NODE_ENV to development
+    vi.stubEnv("NODE_ENV", "development");
+
+    await t.run(async (ctx) => {
+      return await ctx.db.insert("users", {
+        ...dummyUser,
+        role: process.env.NODE_ENV === "development" ? "admin" : "user",
+      });
+    });
+    const user = await t.query(api.users.getByEmail, {
+      email: dummyUser.email,
+    });
+
+    expect(user?.role).toBe("admin");
+    vi.unstubAllEnvs();
+  });
+
+  it("should set role to user in production environment", async () => {
+    const t = convexTest(schema, modules);
+
+    const dummyUser = {
+      email: faker.internet.email(),
+      emailVerified: faker.datatype.boolean(),
+    };
+
+    // Set NODE_ENV to production
+    vi.stubEnv("NODE_ENV", "production");
+    await t.run(async (ctx) => {
+      return await ctx.db.insert("users", {
+        ...dummyUser,
+        role: process.env.NODE_ENV === "development" ? "admin" : "user",
+      });
+    });
+    const user = await t.query(api.users.getByEmail, {
+      email: dummyUser.email,
+    });
+
+    expect(user?.role).toBe("user");
+    vi.unstubAllEnvs();
+  });
+});

--- a/convex/auth.test.ts
+++ b/convex/auth.test.ts
@@ -1,4 +1,3 @@
-import { faker } from "@faker-js/faker";
 import { convexTest } from "convex-test";
 import { describe, expect, it, vi } from "vitest";
 import { api } from "./_generated/api";
@@ -6,50 +5,46 @@ import { createOrUpdateUser } from "./auth";
 import schema from "./schema";
 import { modules } from "./test.setup";
 
-describe("auth roles", () => {
-  it("should set role to admin in development environment", async () => {
-    const t = convexTest(schema, modules);
+describe("auth", () => {
+  describe("createOrUpdateUser", () => {
+    it("should set role to admin in development environment", async () => {
+      const t = convexTest(schema, modules);
 
-    const email = faker.internet.email();
-
-    // Set NODE_ENV to development
-    vi.stubEnv("NODE_ENV", "development");
-    await t.run(async (ctx) => {
-      return await createOrUpdateUser(ctx, {
-        profile: {
-          email,
-        },
+      vi.stubEnv("NODE_ENV", "development");
+      await t.run(async (ctx) => {
+        return await createOrUpdateUser(ctx, {
+          profile: {
+            email: "devUser@test.com",
+          },
+        });
       });
-    });
 
-    const user = await t.query(api.users.getByEmail, {
-      email,
-    });
-
-    expect(user?.role).toBe("admin");
-    vi.unstubAllEnvs();
-  });
-
-  it("should set role to user in production environment", async () => {
-    const t = convexTest(schema, modules);
-
-    const email = faker.internet.email();
-
-    // Set NODE_ENV to production
-    vi.stubEnv("NODE_ENV", "production");
-    await t.run(async (ctx) => {
-      return await createOrUpdateUser(ctx, {
-        profile: {
-          email,
-        },
+      const user = await t.query(api.users.getByEmail, {
+        email: "devUser@test.com",
       });
+
+      expect(user?.role).toBe("admin");
+      vi.unstubAllEnvs();
     });
 
-    const user = await t.query(api.users.getByEmail, {
-      email,
-    });
+    it("should set role to user in production environment", async () => {
+      const t = convexTest(schema, modules);
 
-    expect(user?.role).toBe("user");
-    vi.unstubAllEnvs();
+      vi.stubEnv("NODE_ENV", "production");
+      await t.run(async (ctx) => {
+        return await createOrUpdateUser(ctx, {
+          profile: {
+            email: "prodUser@test.com",
+          },
+        });
+      });
+
+      const user = await t.query(api.users.getByEmail, {
+        email: "prodUser@test.com",
+      });
+
+      expect(user?.role).toBe("user");
+      vi.unstubAllEnvs();
+    });
   });
 });

--- a/convex/auth.test.ts
+++ b/convex/auth.test.ts
@@ -2,6 +2,7 @@ import { faker } from "@faker-js/faker";
 import { convexTest } from "convex-test";
 import { describe, expect, it, vi } from "vitest";
 import { api } from "./_generated/api";
+import { createOrUpdateUser } from "./auth";
 import schema from "./schema";
 import { modules } from "./test.setup";
 
@@ -9,22 +10,20 @@ describe("auth roles", () => {
   it("should set role to admin in development environment", async () => {
     const t = convexTest(schema, modules);
 
-    const dummyUser = {
-      email: faker.internet.email(),
-      emailVerified: faker.datatype.boolean(),
-    };
+    const email = faker.internet.email();
 
     // Set NODE_ENV to development
     vi.stubEnv("NODE_ENV", "development");
-
     await t.run(async (ctx) => {
-      return await ctx.db.insert("users", {
-        ...dummyUser,
-        role: process.env.NODE_ENV === "development" ? "admin" : "user",
+      return await createOrUpdateUser(ctx, {
+        profile: {
+          email,
+        },
       });
     });
+
     const user = await t.query(api.users.getByEmail, {
-      email: dummyUser.email,
+      email,
     });
 
     expect(user?.role).toBe("admin");
@@ -34,21 +33,20 @@ describe("auth roles", () => {
   it("should set role to user in production environment", async () => {
     const t = convexTest(schema, modules);
 
-    const dummyUser = {
-      email: faker.internet.email(),
-      emailVerified: faker.datatype.boolean(),
-    };
+    const email = faker.internet.email();
 
     // Set NODE_ENV to production
     vi.stubEnv("NODE_ENV", "production");
     await t.run(async (ctx) => {
-      return await ctx.db.insert("users", {
-        ...dummyUser,
-        role: process.env.NODE_ENV === "development" ? "admin" : "user",
+      return await createOrUpdateUser(ctx, {
+        profile: {
+          email,
+        },
       });
     });
+
     const user = await t.query(api.users.getByEmail, {
-      email: dummyUser.email,
+      email,
     });
 
     expect(user?.role).toBe("user");

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -4,41 +4,42 @@ import type { MutationCtx } from "./_generated/server";
 import { ResendOTPPasswordReset } from "./passwordReset";
 import { getByEmail } from "./users";
 
+export const createOrUpdateUser = async (ctx: MutationCtx, args: any) => {
+  // Handle merging updated fields into existing user
+  if (args.existingUserId) {
+    return args.existingUserId;
+  }
+
+  // Handle account linking
+  if (args.profile.email) {
+    const existingUser = await getByEmail(ctx, {
+      email: args.profile.email,
+    });
+    if (existingUser) return existingUser._id;
+  }
+
+  // Create a new user with defaults
+  return ctx.db
+    .insert("users", {
+      email: args.profile.email,
+      emailVerified: args.profile.emailVerified ?? false,
+      role: process.env.NODE_ENV === "development" ? "admin" : "user",
+    })
+    .then((userId) => {
+      ctx.db.insert("userSettings", {
+        userId,
+        theme: "system",
+        groupQuestsBy: "dateAdded",
+      });
+      return userId;
+    });
+};
+
 export const { auth, signIn, signOut, store } = convexAuth({
   providers: [Password({ reset: ResendOTPPasswordReset })],
 
   callbacks: {
-    async createOrUpdateUser(ctx: MutationCtx, args) {
-      // Handle merging updated fields into existing user
-      if (args.existingUserId) {
-        return args.existingUserId;
-      }
-
-      // Handle account linking
-      if (args.profile.email) {
-        const existingUser = await getByEmail(ctx, {
-          email: args.profile.email,
-        });
-        if (existingUser) return existingUser._id;
-      }
-
-      // Create a new user with defaults
-      return ctx.db
-        .insert("users", {
-          email: args.profile.email,
-          emailVerified: args.profile.emailVerified ?? false,
-          role: process.env.NODE_ENV === "development" ? "admin" : "user",
-        })
-        .then((userId) => {
-          ctx.db.insert("userSettings", {
-            userId,
-            theme: "system",
-            groupQuestsBy: "dateAdded",
-          });
-          return userId;
-        });
-    },
-
+    createOrUpdateUser,
     async redirect({ redirectTo }) {
       return redirectTo;
     },

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -27,7 +27,7 @@ export const { auth, signIn, signOut, store } = convexAuth({
         .insert("users", {
           email: args.profile.email,
           emailVerified: args.profile.emailVerified ?? false,
-          role: "user",
+          role: process.env.NODE_ENV === "development" ? "admin" : "user",
         })
         .then((userId) => {
           ctx.db.insert("userSettings", {


### PR DESCRIPTION
## What changed?
Resolves #260 : The user role is now defaulted to "admin" during signup when the environment is set to "development."

## Why?
This change helps new developers by granting access to admin-only settings and allowing them to modify data directly from the UI.

## How was this change made?

- Added a conditional check during the signup process to assign the "admin" role if the environment is set to development.
- Kept the default role as “user” for production environments.

## How was this tested?
Manual testing by verifying admin-only features are accessible after signup in development mode.

## Anything else?
Documentation updates may be needed to inform developers about this behavior during local setup.