### PR TITLE
chore: Remove unnecessary fields from survey creator

### DIFF
--- a/src/routes/_authenticated/admin_/quests.$questId.form.tsx
+++ b/src/routes/_authenticated/admin_/quests.$questId.form.tsx
@@ -2,6 +2,10 @@ import "survey-core/defaultV2.min.css";
 import "survey-creator-core/survey-creator-core.min.css";
 
 import { Badge, Button } from "@/components/common";
+import {
+  configureSurveyCreatorToolbox,
+  surveyCreatorConfig,
+} from "@/utils/surveyCreatorConfig";
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 import { createFileRoute, useRouter } from "@tanstack/react-router";
@@ -27,46 +31,8 @@ function AdminQuestSurveyRoute() {
 
   const setFormSchema = useMutation(api.quests.setFormSchema);
 
-  const creator = new SurveyCreator({
-    showLogicTab: true,
-    isAutoSave: false,
-    maxNestedPanels: 1,
-    showJSONEditorTab: false,
-    showSurveyTitle: false,
-    questionTypes: [
-      // https://surveyjs.io/form-library/documentation/api-reference/question#getType
-      "boolean",
-      "checkbox",
-      // "comment",
-      "dropdown",
-      "tagbox",
-      // "expression",
-      // "file",
-      // "html",
-      // "image",
-      // "imagepicker",
-      // "matrix",
-      // "matrixdropdown",
-      // "matrixdynamic",
-      "multipletext",
-      "panel",
-      "paneldynamic",
-      "radiogroup",
-      // "rating",
-      // "ranking",
-      "signaturepad",
-      "text",
-    ],
-    allowEditExpressionsInTextEditor: false,
-    allowChangeThemeInPreview: false,
-  });
-
-  const textToolboxItem = creator.toolbox.getItemByName("text");
-  textToolboxItem.removeSubitem("color");
-  textToolboxItem.removeSubitem("month");
-  textToolboxItem.removeSubitem("week");
-  textToolboxItem.removeSubitem("time");
-  textToolboxItem.removeSubitem("range");
+  const creator = new SurveyCreator(surveyCreatorConfig);
+  configureSurveyCreatorToolbox(creator);
 
   useEffect(() => {
     if (quest?.formSchema) creator.text = quest.formSchema;

--- a/src/routes/_authenticated/admin_/quests.$questId.form.tsx
+++ b/src/routes/_authenticated/admin_/quests.$questId.form.tsx
@@ -30,8 +30,43 @@ function AdminQuestSurveyRoute() {
   const creator = new SurveyCreator({
     showLogicTab: true,
     isAutoSave: false,
+    maxNestedPanels: 1,
     showJSONEditorTab: false,
+    showSurveyTitle: false,
+    questionTypes: [
+      // https://surveyjs.io/form-library/documentation/api-reference/question#getType
+      "boolean",
+      "checkbox",
+      // "comment",
+      "dropdown",
+      "tagbox",
+      // "expression",
+      // "file",
+      // "html",
+      // "image",
+      // "imagepicker",
+      // "matrix",
+      // "matrixdropdown",
+      // "matrixdynamic",
+      "multipletext",
+      "panel",
+      "paneldynamic",
+      "radiogroup",
+      // "rating",
+      // "ranking",
+      "signaturepad",
+      "text",
+    ],
+    allowEditExpressionsInTextEditor: false,
+    allowChangeThemeInPreview: false,
   });
+
+  const textToolboxItem = creator.toolbox.getItemByName("text");
+  textToolboxItem.removeSubitem("color");
+  textToolboxItem.removeSubitem("month");
+  textToolboxItem.removeSubitem("week");
+  textToolboxItem.removeSubitem("time");
+  textToolboxItem.removeSubitem("range");
 
   useEffect(() => {
     if (quest?.formSchema) creator.text = quest.formSchema;

--- a/src/utils/surveyCreatorConfig.ts
+++ b/src/utils/surveyCreatorConfig.ts
@@ -4,7 +4,7 @@ import type { SurveyCreator } from "survey-creator-react";
 export const surveyCreatorConfig: ICreatorOptions = {
   showLogicTab: true,
   isAutoSave: false,
-  maxNestedPanels: 1,
+  maxNestedPanels: 0,
   showJSONEditorTab: false,
   showSurveyTitle: false,
   allowEditExpressionsInTextEditor: false,
@@ -13,14 +13,14 @@ export const surveyCreatorConfig: ICreatorOptions = {
   questionTypes: [
     "boolean",
     "checkbox",
-    "dropdown",
-    "tagbox",
-    "multipletext",
-    "panel",
-    "paneldynamic",
     "radiogroup",
+    "dropdown", // Single-select dropdown
+    "tagbox", // Multi-select dropdown
+    "text", // Single-line text
+    "comment", // Multi-line text
+    "multipletext", // Multiple text inputs for one question
+    "paneldynamic", // Repeated entries
     "signaturepad",
-    "text",
   ],
 };
 

--- a/src/utils/surveyCreatorConfig.ts
+++ b/src/utils/surveyCreatorConfig.ts
@@ -1,0 +1,31 @@
+import type { ICreatorOptions } from "survey-creator-core";
+import type { SurveyCreator } from "survey-creator-react";
+
+export const surveyCreatorConfig: ICreatorOptions = {
+  showLogicTab: true,
+  isAutoSave: false,
+  maxNestedPanels: 1,
+  showJSONEditorTab: false,
+  showSurveyTitle: false,
+  allowEditExpressionsInTextEditor: false,
+  allowChangeThemeInPreview: false,
+  questionTypes: [
+    "boolean",
+    "checkbox",
+    "dropdown",
+    "tagbox",
+    "multipletext",
+    "panel",
+    "paneldynamic",
+    "radiogroup",
+    "signaturepad",
+    "text",
+  ],
+};
+
+export const configureSurveyCreatorToolbox = (creator: SurveyCreator) => {
+  const textToolboxItem = creator.toolbox.getItemByName("text");
+  for (const subitem of ["color", "month", "week", "time", "range"]) {
+    textToolboxItem.removeSubitem(subitem);
+  }
+};

--- a/src/utils/surveyCreatorConfig.ts
+++ b/src/utils/surveyCreatorConfig.ts
@@ -9,6 +9,7 @@ export const surveyCreatorConfig: ICreatorOptions = {
   showSurveyTitle: false,
   allowEditExpressionsInTextEditor: false,
   allowChangeThemeInPreview: false,
+  // https://surveyjs.io/form-library/documentation/api-reference/question#getType
   questionTypes: [
     "boolean",
     "checkbox",
@@ -25,7 +26,9 @@ export const surveyCreatorConfig: ICreatorOptions = {
 
 export const configureSurveyCreatorToolbox = (creator: SurveyCreator) => {
   const textToolboxItem = creator.toolbox.getItemByName("text");
-  for (const subitem of ["color", "month", "week", "time", "range"]) {
+  // https://surveyjs.io/survey-creator/documentation/toolbox-customization#remove-subitems
+  const textItemExclude = ["color", "month", "week", "time", "range"];
+  for (const subitem of textItemExclude) {
     textToolboxItem.removeSubitem(subitem);
   }
 };


### PR DESCRIPTION
## What changed?
Add custom config to survey creator implementation to hide features and question types which are unnecessary. Resolves #267 

## Why?
Keep the UI focused and lean.

## How was this change made?
Created a new `surveyCreatorConfig` file and instantiated it during setup.

## How was this tested?
Manual testing to verify items display and hide.

## Anything else?
Filed an issue on the SurveyJS repo about a question type I couldn't locate: https://github.com/surveyjs/survey-creator/issues/6202