### PR TITLE
content: Add Terms and Privacy links

### DIFF
--- a/.changeset/gorgeous-colts-reply.md
+++ b/.changeset/gorgeous-colts-reply.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Add links to terms of service and privacy policy

--- a/src/routes/_authenticated/settings/route.tsx
+++ b/src/routes/_authenticated/settings/route.tsx
@@ -70,6 +70,22 @@ function SettingsRoute() {
               Discord Community
             </NavItem>
           </NavGroup>
+          <NavGroup label="Legal">
+            <NavItem
+              href="https://namesake.fyi/terms"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Terms of Service
+            </NavItem>
+            <NavItem
+              href="https://namesake.fyi/privacy"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Privacy Policy
+            </NavItem>
+          </NavGroup>
         </Nav>
       </AppSidebar>
       <AppContent>

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -142,9 +142,22 @@ const SignIn = () => {
             </Button>
             <p className="text-sm text-gray-dim text-center text-balance">
               By registering, you agree to Namesake’s{" "}
-              <Link href="https://namesake.fyi/terms">Terms of Service</Link>{" "}
+              <Link
+                href="https://namesake.fyi/terms"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Terms of Service
+              </Link>{" "}
               and{" "}
-              <Link href="https://namesake.fyi/privacy">Privacy Policy</Link>.
+              <Link
+                href="https://namesake.fyi/privacy"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Privacy Policy
+              </Link>
+              .
             </p>
           </Form>
         )}

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -140,6 +140,12 @@ const SignIn = () => {
             <Button type="submit" isDisabled={isSubmitting} variant="primary">
               {isSubmitting ? "Registering..." : "Register"}
             </Button>
+            <p className="text-sm text-gray-dim text-center text-balance">
+              By registering, you agree to Namesake’s{" "}
+              <Link href="https://namesake.fyi/terms">Terms of Service</Link>{" "}
+              and{" "}
+              <Link href="https://namesake.fyi/privacy">Privacy Policy</Link>.
+            </p>
           </Form>
         )}
       </TabPanel>


### PR DESCRIPTION
## What changed?
Resolves #245.

Adds links to terms of service and privacy policy from within settings and on the registration page.

## Why?
Legally: we gotta.