### PR TITLE
test: Run tests when packages change

### DIFF
--- a/.changeset/smart-flowers-retire.md
+++ b/.changeset/smart-flowers-retire.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Ensure automatic tests run when upgrading packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     branches: main
     paths-ignore:
-      - "docs/**"
+      - ".changeset/**"
       - ".husky/**"
       - ".storybook/**"
       - ".vscode/**"
+      - "docs/**"
       - "public/**"
       - "CHANGELOG.md"
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,13 @@ name: CI
 on:
   pull_request:
     branches: main
-    paths:
-      - "convex/**"
-      - "tests/**"
-      - "src/**"
+    paths-ignore:
+      - "docs/**"
+      - ".husky/**"
+      - ".storybook/**"
+      - ".vscode/**"
+      - "public/**"
+      - "CHANGELOG.md"
   push:
     branches: main
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,10 +3,13 @@ name: Coverage
 on: 
   pull_request:
     branches: main
-    paths:
-      - "convex/**"
-      - "tests/**"
-      - "src/**"
+    paths-ignore:
+      - "docs/**"
+      - ".husky/**"
+      - ".storybook/**"
+      - ".vscode/**"
+      - "public/**"
+      - "CHANGELOG.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     branches: main
     paths-ignore:
-      - "docs/**"
+      - ".changeset/**"
       - ".husky/**"
       - ".storybook/**"
       - ".vscode/**"
+      - "docs/**"
       - "public/**"
       - "CHANGELOG.md"
 


### PR DESCRIPTION
## What changed?
Fixes #284. Change from paths _included_ to paths _excluded_ when choosing to run CI tests. Only ignore directories that do not need to have unit tests run.

## Why?
Increase confidence that upgrading packages (e.g. dependabot) will not break the build.

## How was this change made?
Replaced `paths` with `paths-ignore` in `ci.yml` and `coverage.yml` workflows.