### PR TITLE
fix: Show error when signing in with unregistered email

### DIFF
--- a/.changeset/polite-monkeys-travel.md
+++ b/.changeset/polite-monkeys-travel.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+fix: Show error when signing in with unregistered email

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -30,63 +30,21 @@ export const Route = createFileRoute("/_unauthenticated/signin")({
 });
 
 const SignIn = () => {
-  const { signIn} = useAuthActions();
+  const { signIn } = useAuthActions();
   const [flow, setFlow] = useState<Key>("signIn");
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | React.ReactNode | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate({ from: "/signin" });
   const isClosed = process.env.NODE_ENV === "production";
 
-  const checkUserExists = async (email: string): Promise<boolean> => {
-    try {
-      const response = await convex.query('checkUserExists', { email });
-  
-      return response.exists;
-    } catch (err) {
-      if (err instanceof ConvexError && err.message === 'User does not exist') {
-        return false; 
-      }
-      console.error(err);
-      return false;
-    }
-  };
-  
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setIsSubmitting(true);
     setError(null);
 
     try {
-      if (flow === "signIn") {
-        const userExists = await checkUserExists(email);
-        if (!userExists) {
-          setError(
-            <>
-              There isn't an account for this email. Would you like to{" "}
-              <button
-                type="button"
-                onClick={() => setFlow("signUp")}
-                style={{
-                  color: "blue",
-                  textDecoration: "underline",
-                  background: "none",
-                  border: "none",
-                  padding: 0,
-                  cursor: "pointer",
-                }}
-              >
-                register a new account
-              </button>
-              ?
-            </>
-          );
-          setIsSubmitting(false);
-          return;
-        }
-      }
-
       await signIn("password", {
         flow,
         email,
@@ -94,10 +52,11 @@ const SignIn = () => {
         redirectTo: "/quests",
       });
       navigate({ to: "/" });
-    } catch (err) {
-      setError('An unexpected error occurred. Please try again.');
+    } catch (error) {
+      setError("Couldn't sign in. Check your information and try again.");
+      console.error(error);
+    } finally {
       setIsSubmitting(false);
-      console.error(err);
     }
   };
 

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -54,7 +54,6 @@ const SignIn = () => {
       navigate({ to: "/" });
     } catch (error) {
       setError("Couldn't sign in. Check your information and try again.");
-      console.error(error);
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
### What changed?
- Added a check to verify if the email exists before attempting the sign-in process.
- Display an error message if the email is not registered, prompting users to register a new account.
- If the email is not found, users are provided with a link to the registration tab for account creation.
- Fixes #296
### Why?
<!-- Explain the rationale behind this change -->
- This change was implemented to improve the user experience by notifying users immediately when they attempt to sign in with an unregistered email.
- Users no longer need to guess why they can't log in or be confused by no feedback, leading to better usability and fewer failed attempts.

## Screencast: 


https://github.com/user-attachments/assets/0354c7b0-7a4e-47c6-a60a-b697a66a3e88


