### PR TITLE
feat: `PasswordStrength` polish

### DIFF
--- a/.changeset/kind-peas-double.md
+++ b/.changeset/kind-peas-double.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Refine password strength transitions

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-aria-components": "^1.5.0",
     "react-dom": "^19.0.0",
     "react-helmet-async": "^2.0.5",
+    "react-random-reveal": "^2.0.1",
     "resend": "4.0.1",
     "sonner": "^1.7.1",
     "storybook": "^8.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       react-helmet-async:
         specifier: ^2.0.5
         version: 2.0.5(react@19.0.0)
+      react-random-reveal:
+        specifier: ^2.0.1
+        version: 2.0.1(react@19.0.0)
       resend:
         specifier: 4.0.1
         version: 4.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -225,7 +228,7 @@ importers:
         version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.6)(tsx@4.19.2)(yaml@2.6.1))
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@5.0.0)(@types/node@22.10.2)(@vitest/ui@2.1.8)(jsdom@25.0.0(canvas@2.11.2)))
       '@vitest/ui':
         specifier: ^2.1.8
         version: 2.1.8(vitest@2.1.8)
@@ -4628,6 +4631,11 @@ packages:
   react-promise-suspense@0.3.4:
     resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
 
+  react-random-reveal@2.0.1:
+    resolution: {integrity: sha512-FDxoD75CbPbtrfn/RoYM7Iq9syLB5n/JdPHPEaXV5lj7W5hH7XyJqMQXqTpgAr3GjoWfFxotqWfB+V2IW6GcYw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
   react-stately@3.34.0:
     resolution: {integrity: sha512-0N9tZ8qQ/CxpJH7ao0O6gr+8955e7VrOskg9N+TIxkFknPetwOCtgppMYhnTfteBV8WfM/vv4OC1NbkgYTqXJA==}
     peerDependencies:
@@ -5204,6 +5212,11 @@ packages:
     engines: {node: '>= 16.0.0'}
     peerDependencies:
       react: '*'
+
+  use-elapsed-time@3.0.2:
+    resolution: {integrity: sha512-2EY9lJ5DWbAvT8wWiEp6Ztnl46DjXz2j78uhWbXaz/bg3OfpbgVucCAlcN8Bih6hTJfFTdVYX9L6ySMn5py/wQ==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   use-sync-external-store@1.2.2:
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
@@ -7919,7 +7932,7 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitest/coverage-v8@2.1.8(vitest@2.1.8)':
+  '@vitest/coverage-v8@2.1.8(vitest@2.1.8(@edge-runtime/vm@5.0.0)(@types/node@22.10.2)(@vitest/ui@2.1.8)(jsdom@25.0.0(canvas@2.11.2)))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -10278,6 +10291,11 @@ snapshots:
     dependencies:
       fast-deep-equal: 2.0.1
 
+  react-random-reveal@2.0.1(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      use-elapsed-time: 3.0.2(react@19.0.0)
+
   react-stately@3.34.0(react@19.0.0):
     dependencies:
       '@react-stately/calendar': 3.6.0(react@19.0.0)
@@ -10948,6 +10966,10 @@ snapshots:
     optional: true
 
   use-debounce@10.0.4(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+
+  use-elapsed-time@3.0.2(react@19.0.0):
     dependencies:
       react: 19.0.0
 

--- a/src/components/app/PasswordStrength/PasswordStrength.test.tsx
+++ b/src/components/app/PasswordStrength/PasswordStrength.test.tsx
@@ -18,7 +18,7 @@ describe("PasswordStrength", () => {
       render(<PasswordStrength value={value} />);
 
       // Check strength label
-      const strengthLabel = screen.getByText(label);
+      const strengthLabel = screen.getByLabelText(label);
       expect(strengthLabel).toBeInTheDocument();
       expect(strengthLabel).toHaveClass(textClass);
 

--- a/src/components/app/PasswordStrength/PasswordStrength.tsx
+++ b/src/components/app/PasswordStrength/PasswordStrength.tsx
@@ -81,6 +81,7 @@ export function PasswordStrength({
     return (
       <span
         className={`text-sm uppercase font-medium font-mono tracking-wider transition-colors duration-500 ${strengthConfig[value].color.text}`}
+        aria-label={label}
       >
         {characters}
       </span>

--- a/src/components/app/PasswordStrength/PasswordStrength.tsx
+++ b/src/components/app/PasswordStrength/PasswordStrength.tsx
@@ -38,14 +38,14 @@ export const strengthConfig: Record<number, StrengthConfig> = {
   2: {
     label: "Okay",
     color: {
-      text: "text-gray-normal",
+      text: "text-gray-normal dark:text-amberdark-9",
       bg: "bg-amber-9 dark:bg-amberdark-9",
     },
   },
   3: {
     label: "Good",
     color: {
-      text: "text-gray-normal",
+      text: "text-grass-9 dark:text-grassdark-9",
       bg: "bg-grass-9 dark:bg-grassdark-9",
     },
   },

--- a/src/components/app/PasswordStrength/PasswordStrength.tsx
+++ b/src/components/app/PasswordStrength/PasswordStrength.tsx
@@ -4,6 +4,7 @@ import {
   Meter as AriaMeter,
   type MeterProps as AriaMeterProps,
 } from "react-aria-components";
+import { useRandomReveal } from "react-random-reveal";
 
 export interface MeterProps extends AriaMeterProps {
   value: number;
@@ -21,7 +22,7 @@ type StrengthConfig = {
 
 export const strengthConfig: Record<number, StrengthConfig> = {
   0: {
-    label: "Very weak",
+    label: "Very Weak",
     color: {
       text: "text-red-9 dark:text-reddark-9",
       bg: "bg-transparent",
@@ -30,8 +31,8 @@ export const strengthConfig: Record<number, StrengthConfig> = {
   1: {
     label: "Weak",
     color: {
-      text: "text-red-9 dark:text-reddark-9",
-      bg: "bg-red-9 dark:bg-reddark-9",
+      text: "text-orange-9 dark:text-orangedark-9",
+      bg: "bg-orange-9 dark:bg-orangedark-9",
     },
   },
   2: {
@@ -49,7 +50,7 @@ export const strengthConfig: Record<number, StrengthConfig> = {
     },
   },
   4: {
-    label: "Great!",
+    label: "Great :)",
     color: {
       text: "text-green-10 dark:text-greendark-10",
       bg: "bg-green-9 dark:bg-greendark-9",
@@ -67,6 +68,25 @@ export function PasswordStrength({
     throw new Error("Value must be between 0 and 4");
   }
 
+  const StrengthLabel = ({ label }: { label: string }) => {
+    const characters = useRandomReveal({
+      isPlaying: true,
+      duration: 0.7,
+      characters: label,
+      revealEasing: "linear",
+      revealDuration: 0.2,
+      updateInterval: 0.045,
+    });
+
+    return (
+      <span
+        className={`text-sm uppercase font-medium font-mono tracking-wider transition-colors duration-500 ${strengthConfig[value].color.text}`}
+      >
+        {characters}
+      </span>
+    );
+  };
+
   return (
     <div className="flex flex-col gap-3">
       <AriaMeter
@@ -81,20 +101,18 @@ export function PasswordStrength({
       >
         {({ percentage }) => (
           <>
-            <div className="w-full min-w-64 h-2 rounded-full bg-gray-4 dark:bg-graydark-4 outline outline-1 -outline-offset-1 outline-transparent relative overflow-hidden">
+            <div className="w-full min-w-64 h-1 rounded-full bg-gray-4 dark:bg-graydark-4 outline outline-1 -outline-offset-1 outline-transparent relative overflow-hidden">
               <div
-                className={`absolute top-0 left-0 h-full w-full rounded-full ${strengthConfig[value].color.bg} transition-all forced-colors:bg-[Highlight]`}
+                className={`absolute top-0 left-0 h-full w-full rounded-full ${strengthConfig[value].color.bg} transition-all duration-300 forced-colors:bg-[Highlight]`}
                 style={{ translate: `-${100 - percentage}%` }}
                 data-testid="meter-fill"
               />
             </div>
             <div className="flex justify-between gap-2">
-              <Label className="text-gray-dim">Password Strength</Label>
-              <span
-                className={`text-sm font-medium ${strengthConfig[value].color.text}`}
-              >
-                {strengthConfig[value].label}
-              </span>
+              <Label className="text-gray-dim font-mono">
+                Password Strength
+              </Label>
+              <StrengthLabel label={strengthConfig[value].label} />
             </div>
           </>
         )}


### PR DESCRIPTION
## What changed?
Add a scrambled text animation when changing strength. Make bar smaller and text monospace.

https://github.com/user-attachments/assets/48ae6cc9-df09-493b-ba6d-ee31bf8926f8

https://github.com/user-attachments/assets/c548697b-5c8a-4a67-8375-5d4cc18913ed

## Why?
✨

## How was this change made?
Installed a small library `react-random-reveal` to use its hook.

## How was this tested?
Tested in Storybook, made sure tests pass and accessibility is not affected.