### PR TITLE
fix: Truncate long names and emails

### DIFF
--- a/.changeset/nasty-dodos-sleep.md
+++ b/.changeset/nasty-dodos-sleep.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Truncate long usernames and emails within settings and the sidebar

--- a/src/components/app/AppSidebar/AppSidebar.tsx
+++ b/src/components/app/AppSidebar/AppSidebar.tsx
@@ -66,7 +66,7 @@ export const AppSidebar = ({ children }: AppSidebarProps) => {
               variant="ghost"
               icon={CircleUser}
             >
-              {user?.name}
+              <span className="truncate max-w-[16ch]">{user?.name}</span>
             </Button>
             <Menu placement="top start">
               <MenuItem href={{ to: "/settings/account" }} icon={Cog}>

--- a/src/components/browse/AddOrGoToQuestButton/AddOrGoToQuestButton.tsx
+++ b/src/components/browse/AddOrGoToQuestButton/AddOrGoToQuestButton.tsx
@@ -46,12 +46,9 @@ export function AddOrGoToQuestButton({
         size={size}
         variant={size === "small" ? "secondary" : "primary"}
         className={className}
+        icon={isAdding ? LoaderCircle : Plus}
+        iconProps={isAdding ? { className: "animate-spin" } : {}}
       >
-        {isAdding ? (
-          <LoaderCircle size={16} className="animate-spin" />
-        ) : (
-          <Plus size={16} />
-        )}
         Add
       </Button>
     );

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,5 +1,5 @@
 import { focusRing } from "@/components/utils";
-import type { LucideIcon } from "lucide-react";
+import type { LucideIcon, LucideProps } from "lucide-react";
 import {
   Button as AriaButton,
   type ButtonProps as AriaButtonProps,
@@ -9,7 +9,11 @@ import { tv } from "tailwind-variants";
 
 export interface ButtonProps extends AriaButtonProps {
   children?: React.ReactNode;
+  label?: string;
   icon?: LucideIcon;
+  iconProps?: LucideProps;
+  endIcon?: LucideIcon;
+  endIconProps?: LucideProps;
   variant?: "primary" | "secondary" | "destructive" | "icon" | "ghost";
   size?: "small" | "medium" | "large";
 }
@@ -59,6 +63,9 @@ export function Button({
   variant,
   size,
   icon: Icon,
+  iconProps,
+  endIcon: EndIcon,
+  endIconProps,
   className,
   children,
   ...props
@@ -79,9 +86,17 @@ export function Button({
         <Icon
           size={size === "large" ? 20 : 16}
           strokeWidth={size === "large" ? 2.5 : 2}
+          {...iconProps}
         />
       )}
       {children}
+      {EndIcon && (
+        <EndIcon
+          size={size === "large" ? 20 : 16}
+          strokeWidth={size === "large" ? 2.5 : 2}
+          {...endIconProps}
+        />
+      )}
     </AriaButton>
   );
 }

--- a/src/components/common/ComboBox/ComboBox.tsx
+++ b/src/components/common/ComboBox/ComboBox.tsx
@@ -50,9 +50,11 @@ export function ComboBox<T extends object>({
       <Label>{label}</Label>
       <FieldGroup>
         <Input />
-        <Button variant="icon" className="w-7 h-7 p-0 mr-1 outline-offset-0">
-          <ChevronDown aria-hidden className="w-4 h-4" />
-        </Button>
+        <Button
+          variant="icon"
+          className="w-7 h-7 p-0 mr-1 outline-offset-0"
+          icon={ChevronDown}
+        />
       </FieldGroup>
       {description && <FieldDescription>{description}</FieldDescription>}
       <FieldError>{errorMessage}</FieldError>

--- a/src/components/common/DatePicker/DatePicker.tsx
+++ b/src/components/common/DatePicker/DatePicker.tsx
@@ -36,9 +36,12 @@ export function DatePicker<T extends DateValue>({
       {label && <Label>{label}</Label>}
       <FieldGroup className="min-w-[208px] w-auto">
         <DateInput className="flex-1 min-w-[150px] px-3 py-2" />
-        <Button variant="icon" className="w-7 h-7 p-0 mr-1 outline-offset-0">
-          <CalendarIcon aria-hidden className="w-4 h-4" />
-        </Button>
+        <Button
+          variant="icon"
+          className="w-7 h-7 p-0 mr-1 outline-offset-0"
+          icon={CalendarIcon}
+          aria-label="Open date picker"
+        />
       </FieldGroup>
       {description && <FieldDescription>{description}</FieldDescription>}
       <FieldError>{errorMessage}</FieldError>

--- a/src/components/common/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/common/DateRangePicker/DateRangePicker.tsx
@@ -43,9 +43,12 @@ export function DateRangePicker<T extends DateValue>({
           –
         </span>
         <DateInput slot="end" className="flex-1 px-3 py-2" />
-        <Button variant="icon" className="w-7 h-7 p-0 mr-1 outline-offset-0">
-          <CalendarIcon aria-hidden className="w-4 h-4" />
-        </Button>
+        <Button
+          variant="icon"
+          className="w-7 h-7 p-0 mr-1 outline-offset-0"
+          icon={CalendarIcon}
+          aria-label="Open date picker"
+        />
       </FieldGroup>
       {description && <FieldDescription>{description}</FieldDescription>}
       <FieldError>{errorMessage}</FieldError>

--- a/src/components/common/Disclosure/Disclosure.tsx
+++ b/src/components/common/Disclosure/Disclosure.tsx
@@ -28,14 +28,14 @@ export function Disclosure({ title, children, ...props }: DisclosureProps) {
           className="w-full justify-start"
           slot="trigger"
           size="small"
-        >
-          <ChevronRight
-            size={16}
-            className={twMerge(
+          icon={ChevronRight}
+          iconProps={{
+            className: twMerge(
               "transition-transform opacity-60",
               "group-data-[expanded]:rotate-90",
-            )}
-          />
+            ),
+          }}
+        >
           {title}
         </Button>
       </Header>

--- a/src/components/common/Menu/Menu.stories.tsx
+++ b/src/components/common/Menu/Menu.stories.tsx
@@ -19,9 +19,7 @@ export default meta;
 
 export const Example = (args: any) => (
   <MenuTrigger>
-    <Button variant="secondary" className="px-2">
-      <Ellipsis className="w-5 h-5" />
-    </Button>
+    <Button variant="secondary" icon={Ellipsis} aria-label="Open menu" />
     <Menu {...args}>
       <MenuItem id="new">New…</MenuItem>
       <MenuItem id="open">Open…</MenuItem>
@@ -41,9 +39,7 @@ DisabledItems.args = {
 
 export const Sections = (args: any) => (
   <MenuTrigger>
-    <Button variant="secondary" className="px-2">
-      <Ellipsis className="w-5 h-5" />
-    </Button>
+    <Button variant="secondary" icon={Ellipsis} aria-label="Open menu" />
     <Menu {...args}>
       <MenuSection title="Your Content">
         <MenuItem id="repos">Repositories</MenuItem>
@@ -63,9 +59,7 @@ export const Sections = (args: any) => (
 
 export const Submenu = (args: any) => (
   <MenuTrigger>
-    <Button variant="secondary" className="px-2">
-      <Ellipsis className="w-5 h-5" />
-    </Button>
+    <Button variant="secondary" icon={Ellipsis} aria-label="Open menu" />
     <Menu {...args}>
       <MenuItem id="new">New…</MenuItem>
       <SubmenuTrigger>

--- a/src/components/common/Popover/Popover.stories.tsx
+++ b/src/components/common/Popover/Popover.stories.tsx
@@ -15,9 +15,7 @@ export default meta;
 
 export const Example = (args: any) => (
   <DialogTrigger>
-    <Button variant="icon" aria-label="Help">
-      <CircleHelp />
-    </Button>
+    <Button variant="icon" aria-label="Help" icon={CircleHelp} />
     <Popover {...args} className="max-w-[250px]">
       <p className="text-sm">
         For help accessing your account, please contact support.

--- a/src/components/common/SearchField/SearchField.tsx
+++ b/src/components/common/SearchField/SearchField.tsx
@@ -51,6 +51,7 @@ export function SearchField({
           className="mr-1 w-7 h-7 p-0 group-empty:invisible"
           size="small"
           icon={CircleX}
+          aria-label="Clear search"
         />
       </FieldGroup>
       {description && <FieldDescription>{description}</FieldDescription>}

--- a/src/components/common/Select/Select.tsx
+++ b/src/components/common/Select/Select.tsx
@@ -46,12 +46,16 @@ export function Select<T extends object>({
       )}
     >
       {label && <Label size={size}>{label}</Label>}
-      <Button className="text-left" size={size}>
+      <Button
+        className="text-left"
+        size={size}
+        endIcon={ChevronDown}
+        endIconProps={{
+          className:
+            "w-4 h-4 text-gray-dim forced-colors:text-[ButtonText] group-disabled:opacity-50 forced-colors:group-disabled:text-[GrayText] shrink-0",
+        }}
+      >
         <SelectValue className="flex-1 text-gray-normal placeholder-shown:font-normal placeholder-shown:text-gray-9 dark:placeholder-shown:text-graydark-9" />
-        <ChevronDown
-          aria-hidden
-          className="w-4 h-4 text-gray-dim forced-colors:text-[ButtonText] group-disabled:opacity-50 forced-colors:group-disabled:text-[GrayText] shrink-0"
-        />
       </Button>
       {description && <FieldDescription>{description}</FieldDescription>}
       <FieldError>{errorMessage}</FieldError>

--- a/src/components/common/TagGroup/TagGroup.tsx
+++ b/src/components/common/TagGroup/TagGroup.tsx
@@ -5,7 +5,6 @@ import {
   TagGroup as AriaTagGroup,
   type TagGroupProps as AriaTagGroupProps,
   type TagProps as AriaTagProps,
-  Button,
   TagList,
   type TagListProps,
   Text,
@@ -13,6 +12,7 @@ import {
 } from "react-aria-components";
 import { twMerge } from "tailwind-merge";
 import { tv } from "tailwind-variants";
+import { Button } from "../Button";
 import { FieldDescription, Label } from "../Field";
 
 const tagStyles = tv({
@@ -95,9 +95,14 @@ export function Tag({ children, ...props }: TagProps) {
         <>
           {defaultChildren}
           {allowsRemoving && (
-            <Button slot="remove" className={removeButtonStyles}>
-              <X aria-hidden className="w-3 h-3" />
-            </Button>
+            <Button
+              slot="remove"
+              size="small"
+              variant="icon"
+              className={removeButtonStyles}
+              icon={X}
+              aria-label="Remove tag"
+            />
           )}
         </>
       )}

--- a/src/components/common/Tooltip/Tooltip.stories.tsx
+++ b/src/components/common/Tooltip/Tooltip.stories.tsx
@@ -12,15 +12,11 @@ export default meta;
 export const Example = (args: any) => (
   <div className="flex gap-2">
     <TooltipTrigger>
-      <Button variant="secondary" className="px-2">
-        <Save />
-      </Button>
+      <Button variant="secondary" className="px-2" icon={Save} />
       <Tooltip {...args}>Save</Tooltip>
     </TooltipTrigger>
     <TooltipTrigger>
-      <Button variant="secondary" className="px-2">
-        <Printer />
-      </Button>
+      <Button variant="secondary" className="px-2" icon={Printer} />
       <Tooltip {...args}>Print</Tooltip>
     </TooltipTrigger>
   </div>

--- a/src/components/quests/StatGroup/StatGroup.tsx
+++ b/src/components/quests/StatGroup/StatGroup.tsx
@@ -15,9 +15,12 @@ export type StatPopoverProps = {
 export const StatPopover = ({ tooltip, children }: StatPopoverProps) => (
   <DialogTrigger>
     <TooltipTrigger>
-      <Button variant="icon" size="small" aria-label={tooltip}>
-        <CircleHelp />
-      </Button>
+      <Button
+        variant="icon"
+        size="small"
+        aria-label={tooltip}
+        icon={CircleHelp}
+      />
       <Tooltip>{tooltip}</Tooltip>
     </TooltipTrigger>
     <Popover title={tooltip} className="p-4">

--- a/src/components/quests/StatusSelect/StatusSelect.tsx
+++ b/src/components/quests/StatusSelect/StatusSelect.tsx
@@ -74,9 +74,8 @@ export function StatusSelect({ status, isCore, onChange }: StatusSelectProps) {
 
   return (
     <MenuTrigger>
-      <Button variant="ghost" className="px-2 gap-1">
+      <Button variant="ghost" className="px-2 gap-1" endIcon={ChevronDown}>
         <StatusBadge status={status} size="lg" />
-        <ChevronDown size={16} className="right-0" />
       </Button>
       <Menu
         placement="bottom end"

--- a/src/components/settings/EditEmailSetting/EditEmailSetting.test.tsx
+++ b/src/components/settings/EditEmailSetting/EditEmailSetting.test.tsx
@@ -33,6 +33,17 @@ describe("EditEmailSetting", () => {
     ).toBeInTheDocument();
   });
 
+  it("truncates very long emails", () => {
+    render(
+      <EditEmailSetting
+        user={{ ...mockUser, email: "evaaaaaaaaaaaaaaaaaaaa@gmail.com" }}
+      />,
+    );
+    expect(screen.getByText("evaaaaaaaaaaaaaaaaaaaa@gmail.com")).toHaveClass(
+      "truncate max-w-[24ch]",
+    );
+  });
+
   it("populates the correct email when the modal is opened", async () => {
     const user = userEvent.setup();
     render(<EditEmailSetting user={mockUser} />);

--- a/src/components/settings/EditEmailSetting/EditEmailSetting.tsx
+++ b/src/components/settings/EditEmailSetting/EditEmailSetting.tsx
@@ -108,7 +108,9 @@ export const EditEmailSetting = ({ user }: EditEmailSettingProps) => {
       description="What email would you like to use for Namesake?"
     >
       <Button icon={Pencil} onPress={() => setIsEmailModalOpen(true)}>
-        {user?.email ?? "Set email"}
+        <span className="truncate max-w-[24ch]">
+          {user?.email ?? "Set email"}
+        </span>
       </Button>
       <EditEmailModal
         isOpen={isEmailModalOpen}

--- a/src/components/settings/EditNameSetting/EditNameSetting.test.tsx
+++ b/src/components/settings/EditNameSetting/EditNameSetting.test.tsx
@@ -23,6 +23,17 @@ describe("EditNameSetting", () => {
     expect(screen.getByText("John Doe")).toBeInTheDocument();
   });
 
+  it("truncates very long names", () => {
+    render(
+      <EditNameSetting
+        user={{ ...mockUser, name: "Evaaaaaaaaaaaaaaaaaaaa" }}
+      />,
+    );
+    expect(screen.getByText("Evaaaaaaaaaaaaaaaaaaaa")).toHaveClass(
+      "truncate max-w-[24ch]",
+    );
+  });
+
   it("renders 'Set name' if name is not set", () => {
     render(<EditNameSetting user={{ ...mockUser, name: undefined }} />);
     expect(

--- a/src/components/settings/EditNameSetting/EditNameSetting.tsx
+++ b/src/components/settings/EditNameSetting/EditNameSetting.tsx
@@ -100,7 +100,9 @@ export const EditNameSetting = ({ user }: EditNameSettingProps) => {
   return (
     <SettingsItem label="Name" description="How should Namesake refer to you?">
       <Button icon={Pencil} onPress={() => setIsNameModalOpen(true)}>
-        {user?.name ?? "Set name"}
+        <span className="truncate max-w-[24ch]">
+          {user?.name ?? "Set name"}
+        </span>
       </Button>
       <EditNameModal
         isOpen={isNameModalOpen}

--- a/src/components/settings/SettingsGroup/SettingsGroup.tsx
+++ b/src/components/settings/SettingsGroup/SettingsGroup.tsx
@@ -9,7 +9,7 @@ type SettingsGroupProps = {
 export const SettingsGroup = ({ title, children }: SettingsGroupProps) => (
   <section className="flex flex-col gap-4 mb-8 last-of-type:mb-0">
     <Heading className="text-lg font-medium">{title}</Heading>
-    <Card className="flex flex-col p-0 divide-y divide-gray-dim">
+    <Card className="flex flex-col p-0 divide-gray-dim divide-y-[0.5px]">
       {children}
     </Card>
   </section>


### PR DESCRIPTION
## What changed?
Resolves #302. Adds truncation to select buttons within Namesake. Updates `Button` with support for `iconProps`, `endIcon`, and `endIconProps` to prevent needing to define icons as children.

## Why?
Prevent very long names and emails from overflowing the UI.

![CleanShot 2025-01-04 at 23 24 47@2x](https://github.com/user-attachments/assets/c1137685-f42f-489b-aab9-1bc4d0f5b3e2)

## How was this change made?
Moved all icons to the `icon` with `iconProps` if needed. Add a `span` with `truncate` and `max-w-[24ch]` to specific buttons.

## How was this tested?
Added unit tests for the name and email settings rows to check for truncation.

## Anything else?
Changed the dividing line for `SettingsGroup` to `0.5px`.