### PR TITLE
feat: Redesign settings to allow inline editing

### DIFF
--- a/.changeset/mean-trains-protect.md
+++ b/.changeset/mean-trains-protect.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Allow editing user settings inline instead of opening a dialog window

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -29,7 +29,7 @@ export const buttonStyles = tv({
       secondary:
         "bg-white dark:bg-graydark-3 hover:bg-white dark:hover:bg-graydark-4 hover:border-gray-7 dark:hover:border-graydark-7 text-gray-normal shadow-sm",
       destructive: "bg-red-solid",
-      icon: "bg-transparent hover:bg-graya-3 dark:hover:bg-graydarka-3 text-gray-dim hover:text-gray-normal border-0 flex items-center justify-center rounded-full",
+      icon: "bg-transparent hover:bg-graya-3 dark:hover:bg-graydarka-3 text-gray-dim hover:text-gray-normal border-0 flex shrink-0 items-center justify-center rounded-full",
       ghost:
         "bg-transparent hover:bg-graya-3 dark:hover:bg-graydarka-3 text-gray-dim hover:text-gray-normal border-0",
     },

--- a/src/components/settings/EditBirthplaceSetting/EditBirthplaceSetting.tsx
+++ b/src/components/settings/EditBirthplaceSetting/EditBirthplaceSetting.tsx
@@ -1,40 +1,35 @@
-import {
-  Banner,
-  Button,
-  Form,
-  Modal,
-  ModalFooter,
-  ModalHeader,
-  Select,
-  SelectItem,
-} from "@/components/common";
+import { Banner, Button, Form, Select, SelectItem } from "@/components/common";
 import { SettingsItem } from "@/components/settings";
 import { api } from "@convex/_generated/api";
 import type { Doc } from "@convex/_generated/dataModel";
 import { JURISDICTIONS, type Jurisdiction } from "@convex/constants";
 import { useMutation } from "convex/react";
-import { Pencil } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
-type EditBirthplaceModalProps = {
-  defaultBirthplace: Jurisdiction;
-  isOpen: boolean;
-  onOpenChange: (isOpen: boolean) => void;
-  onSubmit: () => void;
+type EditBirthplaceSettingProps = {
+  user: Doc<"users">;
 };
 
-const EditBirthplaceModal = ({
-  defaultBirthplace,
-  isOpen,
-  onOpenChange,
-  onSubmit,
-}: EditBirthplaceModalProps) => {
-  const [birthplace, setBirthplace] = useState<Jurisdiction>(defaultBirthplace);
+export const EditBirthplaceSetting = ({ user }: EditBirthplaceSettingProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [birthplace, setBirthplace] = useState<Jurisdiction>(
+    user.birthplace as Jurisdiction,
+  );
   const [error, setError] = useState<string>();
   const [isSubmitting, setIsSubmitting] = useState(false);
-
   const updateBirthplace = useMutation(api.users.setBirthplace);
+
+  useEffect(() => {
+    if (birthplace !== user.birthplace) {
+      setIsEditing(true);
+    }
+  }, [birthplace, user.birthplace]);
+
+  const handleCancel = () => {
+    setBirthplace(user.birthplace as Jurisdiction);
+    setIsEditing(false);
+  };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -48,8 +43,8 @@ const EditBirthplaceModal = ({
     try {
       setIsSubmitting(true);
       await updateBirthplace({ birthplace });
-      onSubmit();
       toast.success("Birthplace updated.");
+      setIsEditing(false);
     } catch (err) {
       setError("Failed to update birthplace. Please try again.");
     } finally {
@@ -58,15 +53,13 @@ const EditBirthplaceModal = ({
   };
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalHeader
-        title="Edit birthplace"
-        description="Where were you born? This location is used to select the forms for your birth certificate."
-      />
-      <Form onSubmit={handleSubmit} className="w-full">
-        {error && <Banner variant="danger">{error}</Banner>}
+    <SettingsItem
+      label="Birthplace"
+      description="Where were you born? This location is used to select the forms for your birth certificate."
+    >
+      <Form onSubmit={handleSubmit} className="gap-2 items-end">
         <Select
-          label="State"
+          aria-label="State"
           name="birthplace"
           selectedKey={birthplace}
           onSelectionChange={(key) => {
@@ -74,8 +67,8 @@ const EditBirthplaceModal = ({
             setError(undefined);
           }}
           isRequired
-          className="w-full"
           placeholder="Select state"
+          isDisabled={isSubmitting}
         >
           {Object.entries(JURISDICTIONS).map(([value, label]) => (
             <SelectItem key={value} id={value}>
@@ -83,46 +76,28 @@ const EditBirthplaceModal = ({
             </SelectItem>
           ))}
         </Select>
-        <ModalFooter>
-          <Button
-            variant="secondary"
-            onPress={() => onOpenChange(false)}
-            isDisabled={isSubmitting}
-          >
-            Cancel
-          </Button>
-          <Button type="submit" variant="primary" isDisabled={isSubmitting}>
-            Save
-          </Button>
-        </ModalFooter>
+        {isEditing && (
+          <div className="flex gap-1 justify-end">
+            <Button
+              variant="secondary"
+              isDisabled={isSubmitting}
+              size="small"
+              onPress={handleCancel}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              isDisabled={isSubmitting}
+              size="small"
+            >
+              Save
+            </Button>
+          </div>
+        )}
+        {error && <Banner variant="danger">{error}</Banner>}
       </Form>
-    </Modal>
-  );
-};
-
-type EditBirthplaceSettingProps = {
-  user: Doc<"users">;
-};
-
-export const EditBirthplaceSetting = ({ user }: EditBirthplaceSettingProps) => {
-  const [isBirthplaceModalOpen, setIsBirthplaceModalOpen] = useState(false);
-
-  return (
-    <SettingsItem
-      label="Birthplace"
-      description="Where were you born? This location is used to select the forms for your birth certificate."
-    >
-      <Button icon={Pencil} onPress={() => setIsBirthplaceModalOpen(true)}>
-        {user?.birthplace
-          ? JURISDICTIONS[user.birthplace as Jurisdiction]
-          : "Set birthplace"}
-      </Button>
-      <EditBirthplaceModal
-        defaultBirthplace={user.birthplace as Jurisdiction}
-        isOpen={isBirthplaceModalOpen}
-        onOpenChange={setIsBirthplaceModalOpen}
-        onSubmit={() => setIsBirthplaceModalOpen(false)}
-      />
     </SettingsItem>
   );
 };

--- a/src/components/settings/EditEmailSetting/EditEmailSetting.test.tsx
+++ b/src/components/settings/EditEmailSetting/EditEmailSetting.test.tsx
@@ -23,7 +23,9 @@ describe("EditEmailSetting", () => {
 
   it("renders the correct email if it exists", () => {
     render(<EditEmailSetting user={mockUser} />);
-    expect(screen.getByText("testuser@example.com")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "testuser@example.com" }),
+    ).toBeInTheDocument();
   });
 
   it("renders 'Set email' if email is not set", () => {
@@ -44,21 +46,24 @@ describe("EditEmailSetting", () => {
     );
   });
 
-  it("populates the correct email when the modal is opened", async () => {
+  it("shows edit form with current email when edit button is clicked", async () => {
     const user = userEvent.setup();
     render(<EditEmailSetting user={mockUser} />);
+
     await user.click(
       screen.getByRole("button", { name: "testuser@example.com" }),
     );
-    expect(screen.getByRole("textbox", { name: /email/i })).toHaveValue(
+
+    expect(screen.getByRole("textbox", { name: "Email" })).toHaveValue(
       "testuser@example.com",
     );
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
   it("displays an error for an invalid email address", async () => {
     const user = userEvent.setup();
     const mockError = new ConvexError(INVALID_EMAIL);
-
     const updateEmail = vi.fn().mockRejectedValue(mockError);
     (useMutation as ReturnType<typeof vi.fn>).mockReturnValue(updateEmail);
 
@@ -67,20 +72,19 @@ describe("EditEmailSetting", () => {
       screen.getByRole("button", { name: "testuser@example.com" }),
     );
 
-    const input = screen.getByRole("textbox", { name: /email/i });
+    const input = screen.getByRole("textbox", { name: "Email" });
     await user.clear(input);
     await user.type(input, "newuser@zmail");
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(
-      await screen.findByText("Please enter a valid email address."),
+      screen.getByText("Please enter a valid email address."),
     ).toBeInTheDocument();
   });
 
   it("displays an error when the email is already in use", async () => {
     const user = userEvent.setup();
     const mockError = new ConvexError(DUPLICATE_EMAIL);
-
     const updateEmail = vi.fn().mockRejectedValue(mockError);
     (useMutation as ReturnType<typeof vi.fn>).mockReturnValue(updateEmail);
 
@@ -89,22 +93,19 @@ describe("EditEmailSetting", () => {
       screen.getByRole("button", { name: "testuser@example.com" }),
     );
 
-    const input = screen.getByRole("textbox", { name: /email/i });
+    const input = screen.getByRole("textbox", { name: "Email" });
     await user.clear(input);
     await user.type(input, "newuser@example.com");
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(
-      await screen.findByText(
-        "This email is currently in use. Try another one.",
-      ),
+      screen.getByText("This email is currently in use. Try another one."),
     ).toBeInTheDocument();
   });
 
   it("displays a fallback error when an unknown ConvexError is received", async () => {
     const user = userEvent.setup();
     const mockError = new ConvexError("UNKNOWN_ERROR");
-
     const updateEmail = vi.fn().mockRejectedValue(mockError);
     (useMutation as ReturnType<typeof vi.fn>).mockReturnValue(updateEmail);
 
@@ -113,13 +114,13 @@ describe("EditEmailSetting", () => {
       screen.getByRole("button", { name: "testuser@example.com" }),
     );
 
-    const input = screen.getByRole("textbox", { name: /email/i });
+    const input = screen.getByRole("textbox", { name: "Email" });
     await user.clear(input);
     await user.type(input, "newuser@example.com");
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(
-      await screen.findByText("Something went wrong. Please try again later."),
+      screen.getByText("Something went wrong. Please try again later."),
     ).toBeInTheDocument();
   });
 
@@ -127,9 +128,7 @@ describe("EditEmailSetting", () => {
     const user = userEvent.setup();
     const updateEmail = vi
       .fn()
-      .mockRejectedValue(
-        new Error("Failed to update email. Please try again."),
-      );
+      .mockRejectedValue(new Error("Failed to update email"));
     (useMutation as ReturnType<typeof vi.fn>).mockReturnValue(updateEmail);
 
     render(<EditEmailSetting user={mockUser} />);
@@ -137,13 +136,13 @@ describe("EditEmailSetting", () => {
       screen.getByRole("button", { name: "testuser@example.com" }),
     );
 
-    const input = screen.getByRole("textbox", { name: /email/i });
+    const input = screen.getByRole("textbox", { name: "Email" });
     await user.clear(input);
     await user.type(input, "newuser@example.com");
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(
-      await screen.findByText("Failed to update email. Please try again."),
+      screen.getByText("Failed to update email. Please try again."),
     ).toBeInTheDocument();
   });
 
@@ -157,7 +156,7 @@ describe("EditEmailSetting", () => {
       screen.getByRole("button", { name: "testuser@example.com" }),
     );
 
-    const input = screen.getByRole("textbox", { name: /email/i });
+    const input = screen.getByRole("textbox", { name: "Email" });
     await user.clear(input);
     await user.type(input, "newuser@example.com");
     await user.click(screen.getByRole("button", { name: "Save" }));
@@ -168,9 +167,12 @@ describe("EditEmailSetting", () => {
       }),
     );
     expect(toast.success).toHaveBeenCalledWith("Email updated.");
+
+    // Should return to view mode
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 
-  it("closes the modal without saving when the cancel button is clicked", async () => {
+  it("resets to original value when cancel is clicked", async () => {
     const user = userEvent.setup();
 
     render(<EditEmailSetting user={mockUser} />);
@@ -178,12 +180,15 @@ describe("EditEmailSetting", () => {
       screen.getByRole("button", { name: "testuser@example.com" }),
     );
 
-    const input = screen.getByRole("textbox", { name: /email/i });
+    const input = screen.getByRole("textbox", { name: "Email" });
     await user.clear(input);
     await user.type(input, "newuser@example.com");
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
-    expect(screen.queryByText("Email address")).not.toBeInTheDocument();
-    expect(screen.getByText("testuser@example.com")).toBeInTheDocument();
+    // Should return to view mode with original value
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "testuser@example.com" }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/settings/EditEmailSetting/EditEmailSetting.test.tsx
+++ b/src/components/settings/EditEmailSetting/EditEmailSetting.test.tsx
@@ -54,6 +54,9 @@ describe("EditEmailSetting", () => {
       screen.getByRole("button", { name: "testuser@example.com" }),
     );
 
+    // Autofocus input
+    expect(screen.getByRole("textbox", { name: "Email" })).toHaveFocus();
+
     expect(screen.getByRole("textbox", { name: "Email" })).toHaveValue(
       "testuser@example.com",
     );

--- a/src/components/settings/EditEmailSetting/EditEmailSetting.tsx
+++ b/src/components/settings/EditEmailSetting/EditEmailSetting.tsx
@@ -1,37 +1,21 @@
-import {
-  Banner,
-  Button,
-  Form,
-  Modal,
-  ModalFooter,
-  ModalHeader,
-  TextField,
-} from "@/components/common";
+import { Banner, Button, Form, TextField } from "@/components/common";
 import { SettingsItem } from "@/components/settings";
 import { api } from "@convex/_generated/api";
 import type { Doc } from "@convex/_generated/dataModel";
 import { DUPLICATE_EMAIL, INVALID_EMAIL } from "@convex/errors";
 import { useMutation } from "convex/react";
 import { ConvexError } from "convex/values";
-import { Pencil } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
-type EditEmailModalProps = {
-  defaultEmail: string;
-  isOpen: boolean;
-  onOpenChange: (isOpen: boolean) => void;
-  onSubmit: () => void;
+type EditEmailSettingProps = {
+  user: Doc<"users">;
 };
 
-const EditEmailModal = ({
-  defaultEmail,
-  isOpen,
-  onOpenChange,
-  onSubmit,
-}: EditEmailModalProps) => {
+export const EditEmailSetting = ({ user }: EditEmailSettingProps) => {
+  const [isEditing, setIsEditing] = useState(false);
   const updateEmail = useMutation(api.users.setEmail);
-  const [email, setEmail] = useState(defaultEmail);
+  const [email, setEmail] = useState(user.email ?? "");
   const [error, setError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -42,8 +26,8 @@ const EditEmailModal = ({
     try {
       setIsSubmitting(true);
       await updateEmail({ email: email.trim() });
-      onSubmit();
       toast.success("Email updated.");
+      setIsEditing(false);
     } catch (err) {
       if (err instanceof ConvexError) {
         if (err.data === INVALID_EMAIL) {
@@ -62,62 +46,49 @@ const EditEmailModal = ({
   };
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalHeader
-        title="Email address"
-        description="Your account email is used for sign-in and communication."
-      />
-      <Form onSubmit={handleSubmit} className="w-full">
-        {error && <Banner variant="danger">{error}</Banner>}
-        <TextField
-          label="Email"
-          name="email"
-          type="email"
-          value={email}
-          onChange={(value) => setEmail(value)}
-          className="w-full"
-          isRequired
-        />
-        <ModalFooter>
-          <Button
-            variant="secondary"
-            isDisabled={isSubmitting}
-            onPress={() => onOpenChange(false)}
-          >
-            Cancel
-          </Button>
-          <Button type="submit" variant="primary" isDisabled={isSubmitting}>
-            Save
-          </Button>
-        </ModalFooter>
-      </Form>
-    </Modal>
-  );
-};
-
-type EditEmailSettingProps = {
-  user: Doc<"users">;
-};
-
-export const EditEmailSetting = ({ user }: EditEmailSettingProps) => {
-  const [isEmailModalOpen, setIsEmailModalOpen] = useState(false);
-
-  return (
     <SettingsItem
-      label="Edit email address"
+      label="Email address"
       description="What email would you like to use for Namesake?"
     >
-      <Button icon={Pencil} onPress={() => setIsEmailModalOpen(true)}>
-        <span className="truncate max-w-[24ch]">
-          {user?.email ?? "Set email"}
-        </span>
-      </Button>
-      <EditEmailModal
-        isOpen={isEmailModalOpen}
-        onOpenChange={setIsEmailModalOpen}
-        defaultEmail={user.email ?? ""}
-        onSubmit={() => setIsEmailModalOpen(false)}
-      />
+      {!isEditing ? (
+        <Button onPress={() => setIsEditing(true)}>
+          <span className="truncate max-w-[24ch]">
+            {user?.email ?? "Set email"}
+          </span>
+        </Button>
+      ) : (
+        <Form onSubmit={handleSubmit} className="gap-2">
+          <TextField
+            aria-label="Email"
+            name="email"
+            type="email"
+            value={email}
+            onChange={(value) => setEmail(value)}
+            className="w-60 max-w-full"
+            isRequired
+            autoFocus
+          />
+          <div className="flex gap-1 justify-end">
+            <Button
+              variant="secondary"
+              isDisabled={isSubmitting}
+              size="small"
+              onPress={() => setIsEditing(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              size="small"
+              isDisabled={isSubmitting}
+            >
+              Save
+            </Button>
+          </div>
+          {error && <Banner variant="danger">{error}</Banner>}
+        </Form>
+      )}
     </SettingsItem>
   );
 };

--- a/src/components/settings/EditNameSetting/EditNameSetting.test.tsx
+++ b/src/components/settings/EditNameSetting/EditNameSetting.test.tsx
@@ -20,7 +20,9 @@ describe("EditNameSetting", () => {
 
   it("renders correct username if exists", () => {
     render(<EditNameSetting user={mockUser} />);
-    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "John Doe" }),
+    ).toBeInTheDocument();
   });
 
   it("truncates very long names", () => {
@@ -41,24 +43,32 @@ describe("EditNameSetting", () => {
     ).toBeInTheDocument();
   });
 
-  it("populates correct username when modal is opened", async () => {
+  it("shows edit form when edit button is clicked", async () => {
     const user = userEvent.setup();
     render(<EditNameSetting user={mockUser} />);
+
     await user.click(screen.getByRole("button", { name: "John Doe" }));
-    expect(screen.getByRole("textbox")).toHaveValue("John Doe");
+
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue(
+      "John Doe",
+    );
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
   it("displays an error when the name is too long", async () => {
     const user = userEvent.setup();
     render(<EditNameSetting user={mockUser} />);
-    await user.click(screen.getByRole("button", { name: "John Doe" }));
-    const input = screen.getByLabelText("Name");
 
+    await user.click(screen.getByRole("button", { name: "John Doe" }));
+    const input = screen.getByRole("textbox", { name: "Name" });
+
+    await user.clear(input);
     await user.type(input, "a".repeat(101));
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(
-      await screen.findByText("Name must be less than 100 characters."),
+      screen.getByText("Name must be less than 100 characters."),
     ).toBeInTheDocument();
   });
 
@@ -67,10 +77,11 @@ describe("EditNameSetting", () => {
 
     const updateName = vi.fn();
     (useMutation as ReturnType<typeof vi.fn>).mockReturnValue(updateName);
+
     render(<EditNameSetting user={mockUser} />);
     await user.click(screen.getByRole("button", { name: "John Doe" }));
 
-    const input = screen.getByLabelText("Name");
+    const input = screen.getByRole("textbox", { name: "Name" });
     await user.clear(input);
     await user.type(input, "Jane Doe");
     await user.click(screen.getByRole("button", { name: "Save" }));
@@ -79,6 +90,9 @@ describe("EditNameSetting", () => {
       expect(updateName).toHaveBeenCalledWith({ name: "Jane Doe" }),
     );
     expect(toast.success).toHaveBeenCalledWith("Name updated.");
+
+    // Should return to view mode
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 
   it("displays an error when the form submission fails", async () => {
@@ -88,29 +102,35 @@ describe("EditNameSetting", () => {
       .fn()
       .mockRejectedValue(new Error("Failed to update name"));
     (useMutation as ReturnType<typeof vi.fn>).mockReturnValue(updateName);
+
     render(<EditNameSetting user={mockUser} />);
     await user.click(screen.getByRole("button", { name: "John Doe" }));
 
-    const input = screen.getByLabelText("Name");
+    const input = screen.getByRole("textbox", { name: "Name" });
     await user.clear(input);
     await user.type(input, "Jane Doe");
     await user.click(screen.getByRole("button", { name: "Save" }));
+
     expect(
-      await screen.findByText("Failed to update name. Please try again."),
+      screen.getByText("Failed to update name. Please try again."),
     ).toBeInTheDocument();
   });
 
-  it("closes the modal without saving when the cancel button is clicked", async () => {
+  it("resets to original value when cancel is clicked", async () => {
     const user = userEvent.setup();
 
     render(<EditNameSetting user={mockUser} />);
     await user.click(screen.getByRole("button", { name: "John Doe" }));
-    const input = screen.getByLabelText("Name");
+
+    const input = screen.getByRole("textbox", { name: "Name" });
     await user.clear(input);
     await user.type(input, "Jane Doe");
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
-    expect(screen.queryByText("Edit name")).not.toBeInTheDocument();
-    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    // Should return to view mode with original value
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "John Doe" }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/settings/EditNameSetting/EditNameSetting.test.tsx
+++ b/src/components/settings/EditNameSetting/EditNameSetting.test.tsx
@@ -49,6 +49,9 @@ describe("EditNameSetting", () => {
 
     await user.click(screen.getByRole("button", { name: "John Doe" }));
 
+    // Autofocus input
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveFocus();
+
     expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue(
       "John Doe",
     );

--- a/src/components/settings/EditNameSetting/EditNameSetting.tsx
+++ b/src/components/settings/EditNameSetting/EditNameSetting.tsx
@@ -1,37 +1,26 @@
-import {
-  Banner,
-  Button,
-  Form,
-  Modal,
-  ModalFooter,
-  ModalHeader,
-  TextField,
-} from "@/components/common";
+import { Banner, Button, Form, TextField } from "@/components/common";
 import { SettingsItem } from "@/components/settings";
 import { api } from "@convex/_generated/api";
 import type { Doc } from "@convex/_generated/dataModel";
 import { useMutation } from "convex/react";
-import { Pencil } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
-type EditNameModalProps = {
-  defaultName: string;
-  isOpen: boolean;
-  onOpenChange: (isOpen: boolean) => void;
-  onSubmit: () => void;
+type EditNameSettingProps = {
+  user: Doc<"users">;
 };
 
-const EditNameModal = ({
-  defaultName,
-  isOpen,
-  onOpenChange,
-  onSubmit,
-}: EditNameModalProps) => {
+export const EditNameSetting = ({ user }: EditNameSettingProps) => {
   const updateName = useMutation(api.users.setName);
-  const [name, setName] = useState(defaultName);
+  const [isEditing, setIsEditing] = useState(false);
+  const [name, setName] = useState(user.name ?? "");
   const [error, setError] = useState<string>();
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setName(user.name ?? "");
+  };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -45,8 +34,8 @@ const EditNameModal = ({
     try {
       setIsSubmitting(true);
       await updateName({ name: name.trim() });
-      onSubmit();
       toast.success("Name updated.");
+      setIsEditing(false);
     } catch (err) {
       setError("Failed to update name. Please try again.");
     } finally {
@@ -55,61 +44,50 @@ const EditNameModal = ({
   };
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalHeader
-        title="Edit name"
-        description="How should Namesake refer to you? This can be different from your legal name."
-      />
-      <Form onSubmit={handleSubmit} className="w-full">
-        {error && <Banner variant="danger">{error}</Banner>}
-        <TextField
-          label="Name"
-          name="name"
-          value={name}
-          onChange={(value) => {
-            setName(value);
-            setError(undefined);
-          }}
-          className="w-full"
-          isRequired
-        />
-        <ModalFooter>
-          <Button
-            variant="secondary"
-            isDisabled={isSubmitting}
-            onPress={() => onOpenChange(false)}
-          >
-            Cancel
-          </Button>
-          <Button type="submit" variant="primary" isDisabled={isSubmitting}>
-            Save
-          </Button>
-        </ModalFooter>
-      </Form>
-    </Modal>
-  );
-};
-
-type EditNameSettingProps = {
-  user: Doc<"users">;
-};
-
-export const EditNameSetting = ({ user }: EditNameSettingProps) => {
-  const [isNameModalOpen, setIsNameModalOpen] = useState(false);
-
-  return (
-    <SettingsItem label="Name" description="How should Namesake refer to you?">
-      <Button icon={Pencil} onPress={() => setIsNameModalOpen(true)}>
-        <span className="truncate max-w-[24ch]">
-          {user?.name ?? "Set name"}
-        </span>
-      </Button>
-      <EditNameModal
-        isOpen={isNameModalOpen}
-        onOpenChange={setIsNameModalOpen}
-        defaultName={user.name ?? ""}
-        onSubmit={() => setIsNameModalOpen(false)}
-      />
+    <SettingsItem
+      label="Display name"
+      description="How should Namesake refer to you? This can be different from your legal name."
+    >
+      {!isEditing ? (
+        <Button onPress={() => setIsEditing(true)}>
+          <span className="truncate max-w-[24ch]">
+            {user?.name ?? "Set name"}
+          </span>
+        </Button>
+      ) : (
+        <Form onSubmit={handleSubmit} className="gap-2">
+          <TextField
+            aria-label="Name"
+            name="name"
+            value={name}
+            onChange={(value) => {
+              setName(value);
+              setError(undefined);
+            }}
+            className="w-full"
+            isRequired
+            autoFocus
+          />
+          <div className="flex gap-1 justify-end">
+            <Button
+              size="small"
+              isDisabled={isSubmitting}
+              onPress={handleCancel}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              isDisabled={isSubmitting}
+              size="small"
+            >
+              Save
+            </Button>
+          </div>
+          {error && <Banner variant="danger">{error}</Banner>}
+        </Form>
+      )}
     </SettingsItem>
   );
 };

--- a/src/components/settings/EditResidenceSetting/EditResidenceSetting.tsx
+++ b/src/components/settings/EditResidenceSetting/EditResidenceSetting.tsx
@@ -1,42 +1,36 @@
-import {
-  Banner,
-  Button,
-  Form,
-  Modal,
-  ModalFooter,
-  ModalHeader,
-  Select,
-  SelectItem,
-} from "@/components/common";
+import { Banner, Button, Form, Select, SelectItem } from "@/components/common";
 import { SettingsItem } from "@/components/settings";
 import { api } from "@convex/_generated/api";
 import type { Doc } from "@convex/_generated/dataModel";
 import { JURISDICTIONS, type Jurisdiction } from "@convex/constants";
 import { useMutation } from "convex/react";
-import { Pencil } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
-type EditResidenceModalProps = {
-  defaultResidence: Jurisdiction | undefined;
-  isOpen: boolean;
-  onOpenChange: (isOpen: boolean) => void;
-  onSubmit: () => void;
+type EditResidenceSettingProps = {
+  user: Doc<"users">;
 };
 
-const EditResidenceModal = ({
-  defaultResidence,
-  isOpen,
-  onOpenChange,
-  onSubmit,
-}: EditResidenceModalProps) => {
+export const EditResidenceSetting = ({ user }: EditResidenceSettingProps) => {
+  const [isEditing, setIsEditing] = useState(false);
   const [residence, setResidence] = useState<Jurisdiction | undefined>(
-    defaultResidence,
+    user.residence as Jurisdiction,
   );
   const [error, setError] = useState<string>();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const updateResidence = useMutation(api.users.setResidence);
+
+  useEffect(() => {
+    if (residence !== user.residence) {
+      setIsEditing(true);
+    }
+  }, [residence, user.residence]);
+
+  const handleCancel = () => {
+    setResidence(user.residence as Jurisdiction);
+    setIsEditing(false);
+  };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -50,8 +44,8 @@ const EditResidenceModal = ({
     try {
       setIsSubmitting(true);
       await updateResidence({ residence });
-      onSubmit();
       toast.success("Residence updated.");
+      setIsEditing(false);
     } catch (err) {
       setError("Failed to update residence. Please try again.");
     } finally {
@@ -60,15 +54,13 @@ const EditResidenceModal = ({
   };
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalHeader
-        title="Edit residence"
-        description="Where do you live? This location is used to select the forms for your court order and state ID."
-      />
-      <Form onSubmit={handleSubmit} className="w-full">
-        {error && <Banner variant="danger">{error}</Banner>}
+    <SettingsItem
+      label="Residence"
+      description="Where do you live? This location is used to select the forms for your court order and state ID."
+    >
+      <Form onSubmit={handleSubmit} className="gap-2 items-end">
         <Select
-          label="State"
+          aria-label="State"
           name="residence"
           selectedKey={residence}
           onSelectionChange={(key) => {
@@ -76,8 +68,8 @@ const EditResidenceModal = ({
             setError(undefined);
           }}
           isRequired
-          className="w-full"
           placeholder="Select state"
+          isDisabled={isSubmitting}
         >
           {Object.entries(JURISDICTIONS).map(([value, label]) => (
             <SelectItem key={value} id={value}>
@@ -85,46 +77,28 @@ const EditResidenceModal = ({
             </SelectItem>
           ))}
         </Select>
-        <ModalFooter>
-          <Button
-            variant="secondary"
-            onPress={() => onOpenChange(false)}
-            isDisabled={isSubmitting}
-          >
-            Cancel
-          </Button>
-          <Button type="submit" variant="primary" isDisabled={isSubmitting}>
-            Save
-          </Button>
-        </ModalFooter>
+        {isEditing && (
+          <div className="flex gap-1 justify-end">
+            <Button
+              variant="secondary"
+              onPress={handleCancel}
+              isDisabled={isSubmitting}
+              size="small"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              size="small"
+              isDisabled={isSubmitting}
+            >
+              Save
+            </Button>
+          </div>
+        )}
+        {error && <Banner variant="danger">{error}</Banner>}
       </Form>
-    </Modal>
-  );
-};
-
-type EditResidenceSettingProps = {
-  user: Doc<"users">;
-};
-
-export const EditResidenceSetting = ({ user }: EditResidenceSettingProps) => {
-  const [isResidenceModalOpen, setIsResidenceModalOpen] = useState(false);
-
-  return (
-    <SettingsItem
-      label="Residence"
-      description="Where do you live? This location is used to select the forms for your court order and state ID."
-    >
-      <Button icon={Pencil} onPress={() => setIsResidenceModalOpen(true)}>
-        {user?.residence
-          ? JURISDICTIONS[user.residence as Jurisdiction]
-          : "Set residence"}
-      </Button>
-      <EditResidenceModal
-        isOpen={isResidenceModalOpen}
-        onOpenChange={setIsResidenceModalOpen}
-        defaultResidence={user.residence as Jurisdiction}
-        onSubmit={() => setIsResidenceModalOpen(false)}
-      />
     </SettingsItem>
   );
 };

--- a/src/components/settings/EditResidenceSetting/EditResidenceSetting.tsx
+++ b/src/components/settings/EditResidenceSetting/EditResidenceSetting.tsx
@@ -36,6 +36,7 @@ export const EditResidenceSetting = ({ user }: EditResidenceSettingProps) => {
     e.preventDefault();
     setError(undefined);
 
+    // This shouldn't be possible, but just in case
     if (!residence) {
       setError("Please select a state.");
       return;


### PR DESCRIPTION
## What changed?
[Remove modals](https://modalzmodalzmodalz.com/) and allow inline editing of user settings.

https://github.com/user-attachments/assets/14f4df50-3957-4dc9-801e-10cff4a852cf

## Why?
Fewer clicks and keeps users in the flow of the document. Also less code!

## How was this change made?
Moved forms and related logic into the core component, deleted all Modal subcomponents.

## How was this tested?
Updated all unit tests.

## Anything else?
Death to modals!