### PR TITLE
fix: Align `AppSidebar` to edge of browser

### DIFF
--- a/.changeset/thirty-pillows-greet.md
+++ b/.changeset/thirty-pillows-greet.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Reconfigure app layout for mobile support

--- a/src/components/app/AppContent/AppContent.tsx
+++ b/src/components/app/AppContent/AppContent.tsx
@@ -3,5 +3,9 @@ type AppContentProps = {
 };
 
 export const AppContent = ({ children }: AppContentProps) => {
-  return <main className="flex-1 w-full app-padding">{children}</main>;
+  return (
+    <main className="flex-1 w-full max-w-[960px] mx-auto app-padding">
+      {children}
+    </main>
+  );
 };

--- a/src/components/app/AppSidebar/AppSidebar.tsx
+++ b/src/components/app/AppSidebar/AppSidebar.tsx
@@ -33,8 +33,8 @@ export const AppSidebar = ({ children }: AppSidebarProps) => {
   };
 
   return (
-    <div className="w-72 lg:w-80 xl:w-[22rem] flex flex-col shrink-0 sticky top-0 h-screen overflow-y-auto border-r border-gray-dim">
-      <div className="app-padding h-header flex gap-2 items-center shrink-0 sticky top-0 bg-gray-1 dark:bg-graydark-2 z-20">
+    <div className="w-72 lg:w-80 xl:w-[22rem] flex flex-col shrink-0 sticky top-0 h-screen overflow-y-auto bg-white dark:bg-graydark-1 border-r border-gray-dim">
+      <div className="app-padding h-header flex gap-2 items-center shrink-0 sticky top-0 bg-white dark:bg-graydark-1 z-20">
         <Link href={{ to: "/" }} className="p-1 -m-1">
           <Logo className="h-5 lg:h-[1.35rem]" />
         </Link>
@@ -43,7 +43,7 @@ export const AppSidebar = ({ children }: AppSidebarProps) => {
         </Badge>
       </div>
       <div className="app-padding flex-1">{children}</div>
-      <div className="app-padding h-header -ml-3 shrink-0 flex items-center sticky bottom-0 bg-gray-1 dark:bg-graydark-2">
+      <div className="app-padding h-header -ml-3 shrink-0 flex items-center sticky bottom-0 bg-white dark:bg-graydark-1">
         <Authenticated>
           <MenuTrigger>
             <Button

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -52,6 +52,7 @@ const NotFoundComponent = () => (
 const router = createRouter({
   routeTree,
   context: {
+    convex: undefined!,
     title: undefined!,
     auth: undefined!,
     role: undefined!,
@@ -90,7 +91,7 @@ const InnerApp = () => {
   return (
     <RouterProvider
       router={router}
-      context={{ title, auth: authClient, role, residence, birthplace }}
+      context={{ convex, title, auth: authClient, role, residence, birthplace }}
     />
   );
 };

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,7 +7,7 @@ import {
   useLocation,
   useRouter,
 } from "@tanstack/react-router";
-import type { ConvexAuthState } from "convex/react";
+import type { ConvexAuthState, ConvexReactClient } from "convex/react";
 import {
   AlertTriangle,
   Check,
@@ -44,6 +44,7 @@ function PostHogPageView() {
 }
 
 interface RouterContext {
+  convex: ConvexReactClient;
   title: string;
   auth: Promise<ConvexAuthState>;
   role: Role;

--- a/src/routes/_authenticated/_home.tsx
+++ b/src/routes/_authenticated/_home.tsx
@@ -1,7 +1,6 @@
 import { AppSidebar } from "@/components/app";
 import {
   Badge,
-  Container,
   Nav,
   NavGroup,
   NavItem,
@@ -169,9 +168,9 @@ function IndexRoute() {
   };
 
   return (
-    <Container className="flex">
+    <div className="flex">
       <MyQuests />
       <Outlet />
-    </Container>
+    </div>
   );
 }

--- a/src/routes/_authenticated/admin/route.tsx
+++ b/src/routes/_authenticated/admin/route.tsx
@@ -1,5 +1,5 @@
 import { AppContent, AppSidebar } from "@/components/app";
-import { Container, Nav, NavGroup, NavItem } from "@/components/common";
+import { Nav, NavGroup, NavItem } from "@/components/common";
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 import { FileText, FlaskConical, Milestone } from "lucide-react";
 
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/_authenticated/admin")({
 
 function AdminRoute() {
   return (
-    <Container className="flex">
+    <div className="flex">
       <AppSidebar>
         <Nav>
           <NavGroup label="Content">
@@ -39,6 +39,6 @@ function AdminRoute() {
       <AppContent>
         <Outlet />
       </AppContent>
-    </Container>
+    </div>
   );
 }

--- a/src/routes/_authenticated/settings/route.tsx
+++ b/src/routes/_authenticated/settings/route.tsx
@@ -1,5 +1,5 @@
 import { AppContent, AppSidebar } from "@/components/app";
-import { Container, Nav, NavGroup, NavItem } from "@/components/common";
+import { Nav, NavGroup, NavItem } from "@/components/common";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
 import {
   Bug,
@@ -17,7 +17,7 @@ export const Route = createFileRoute("/_authenticated/settings")({
 
 function SettingsRoute() {
   return (
-    <Container className="flex">
+    <div className="flex">
       <AppSidebar>
         <Nav>
           <NavGroup label="Settings">
@@ -91,6 +91,6 @@ function SettingsRoute() {
       <AppContent>
         <Outlet />
       </AppContent>
-    </Container>
+    </div>
   );
 }


### PR DESCRIPTION
## What changed?
Shift the alignment of `AppSidebar` to the edge of the browser screen, instead of center aligning it with content. Change the background color to differentiate from main app.

Additionally, fix "No quest found" empty state to display the default 404 / empty page, since the `$questSlug` is at the main level.

| Before | After |
|--------|--------|
| ![CleanShot 2025-01-31 at 17 59 10@2x](https://github.com/user-attachments/assets/e5eeabe5-7c90-4f27-b006-e72d77420742) | ![CleanShot 2025-01-31 at 17 58 57@2x](https://github.com/user-attachments/assets/2de4db7b-ac93-4336-9dc5-401f9b0fae7e) | 

## Why?
Left-aligning the sidebar means we can use a different color to separate it from the main contents, and will make it easier to adapt to mobile. It also gives more breathing room to the content itself.

## How was this change made?
Added `convex` as a `context` object in TanStack Router so that it may be used within `loader` without a hook.

## How was this tested?
N/A