### PR TITLE
fix: Image illustrations display and sizing

### DIFF
--- a/.changeset/lucky-houses-smash.md
+++ b/.changeset/lucky-houses-smash.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix broken images in quest headers

--- a/public/images/flower.png
+++ b/public/images/flower.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc08d9f528bc1dc3587695e62eb1d24aff39f123d417a1d3f7965f3cc1903ce3
-size 422446

--- a/public/images/gavel.png
+++ b/public/images/gavel.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5eb93aa66c5c4c731fbe800b5a17641f55030e1061daf55c72b6c181ed0708f
-size 262675

--- a/public/images/id.png
+++ b/public/images/id.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e99ea4364ad4ddf3b219fda0c879b65a86dbd3675d442447bec51dd6f4b4b78f
-size 448185

--- a/public/images/passport.png
+++ b/public/images/passport.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70c2c590d59a1ffe9b6f0c22a43c83d00fe89ebf77596d1d49306bedaa2a47c1
-size 570233

--- a/public/images/social-security.png
+++ b/public/images/social-security.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:21c8190c72ad6200ac1457c1dd6d924978b13e7db8142efdf82c96a073c33f98
-size 556148

--- a/src/components/quests/QuestPageHeader/QuestPageHeader.tsx
+++ b/src/components/quests/QuestPageHeader/QuestPageHeader.tsx
@@ -22,6 +22,11 @@ import { useState } from "react";
 import { Heading } from "react-aria-components";
 import { toast } from "sonner";
 import { StatusSelect } from "../StatusSelect/StatusSelect";
+import flowerImg from "./flower.png";
+import gavelImg from "./gavel.png";
+import idImg from "./id.png";
+import passportImg from "./passport.png";
+import socialSecurityImg from "./social-security.png";
 
 interface QuestPageHeaderProps extends Omit<PageHeaderProps, "title"> {
   quest?: Doc<"quests"> | null;
@@ -32,23 +37,23 @@ function CoreQuestIllustration({ category }: { category: CoreCategory }) {
   const illustration: Record<CoreCategory, { alt: string; src: string }> = {
     courtOrder: {
       alt: "A gavel with a snail on it",
-      src: "/images/gavel.png",
+      src: gavelImg,
     },
     passport: {
       alt: "A snail on a passport",
-      src: "/images/passport.png",
+      src: passportImg,
     },
     socialSecurity: {
       alt: "A snail on a social security card",
-      src: "/images/social-security.png",
+      src: socialSecurityImg,
     },
     stateId: {
       alt: "A snail on a Massachusetts ID card",
-      src: "/images/id.png",
+      src: idImg,
     },
     birthCertificate: {
       alt: "A snail on a flower",
-      src: "/images/flower.png",
+      src: flowerImg,
     },
   };
 

--- a/src/components/quests/QuestPageHeader/flower.png
+++ b/src/components/quests/QuestPageHeader/flower.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:198ea404960740f167cb604eedaade655184f40cdbb7e54b56ba028b281782b0
+size 225401

--- a/src/components/quests/QuestPageHeader/flower.png
+++ b/src/components/quests/QuestPageHeader/flower.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:198ea404960740f167cb604eedaade655184f40cdbb7e54b56ba028b281782b0
-size 225401
+oid sha256:b2f1ee6e9a0c199a3c3280695e92c97967913f40deb94ea3db82f97ce59be611
+size 98378

--- a/src/components/quests/QuestPageHeader/gavel.png
+++ b/src/components/quests/QuestPageHeader/gavel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:beddd51e89ff033a1d2e7ebdf1b83e4a175f145ed87a47b6be908f7ab267dac5
+size 241100

--- a/src/components/quests/QuestPageHeader/gavel.png
+++ b/src/components/quests/QuestPageHeader/gavel.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:beddd51e89ff033a1d2e7ebdf1b83e4a175f145ed87a47b6be908f7ab267dac5
-size 241100
+oid sha256:e73147410bc9f48a6d9d9543bb5f6c70ce9099c939c6ad660be83528454508f1
+size 105038

--- a/src/components/quests/QuestPageHeader/id.png
+++ b/src/components/quests/QuestPageHeader/id.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3b6d1e03d46aea464ddeafb500d45d3a543d08119ffea4e47eaba2252f11f10
-size 339175
+oid sha256:c7fa3b01fdb739f1a117e520091ad0fd159a54c43a2f5f48f48a92ecd19fb459
+size 168163

--- a/src/components/quests/QuestPageHeader/id.png
+++ b/src/components/quests/QuestPageHeader/id.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3b6d1e03d46aea464ddeafb500d45d3a543d08119ffea4e47eaba2252f11f10
+size 339175

--- a/src/components/quests/QuestPageHeader/passport.png
+++ b/src/components/quests/QuestPageHeader/passport.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f667546d2fbabfebd7d8ff307695d4b4c5a30139ce544e0b651331c90bd5129d
+size 268900

--- a/src/components/quests/QuestPageHeader/passport.png
+++ b/src/components/quests/QuestPageHeader/passport.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f667546d2fbabfebd7d8ff307695d4b4c5a30139ce544e0b651331c90bd5129d
-size 268900
+oid sha256:a9d3f7071c22fc3b8fc3f8703a538992604d8acb7120945154cf8cbb3360844b
+size 106958

--- a/src/components/quests/QuestPageHeader/social-security.png
+++ b/src/components/quests/QuestPageHeader/social-security.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:470cc8dcc18593b7d55de65ce8f59e6dc22c71136c7a76b4a27fd8451786b44f
+size 427219

--- a/src/components/quests/QuestPageHeader/social-security.png
+++ b/src/components/quests/QuestPageHeader/social-security.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:470cc8dcc18593b7d55de65ce8f59e6dc22c71136c7a76b4a27fd8451786b44f
-size 427219
+oid sha256:b668d283d0e598384c835b0b0d85c4f730d77ca1708f56025a6dc924bcbe7f4c
+size 213019


### PR DESCRIPTION
## What changed?
Optimize header images for quests. Import images with Vite so the final asset is compiled and displays properly in prod. Fixes #356 

## Why?
Images were broken and too large.

## How was this change made?
Resized and optimized images, relocated them within `src/` instead of `public/`.

## How was this tested?
Tested preview deploy to verify images display.