### PR TITLE
docs: remove unused dep in CONTRIBUTING.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 dist
 dist-ssr
 *.tsbuildinfo
+convex/README.md
 
 # Logs
 logs

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -93,7 +93,6 @@ Below are Namesake's core dependencies. The links below each lead to docs.
 | ----------------------------------------------------------------------------------- | -------------------------------------------------- |
 | [Convex](https://docs.convex.dev/)                                                  | Type-safe database, file storage, realtime updates |
 | [Convex Auth](https://labs.convex.dev/auth)                                         | User authentication                                |
-| [SurveyJS](https://surveyjs.io/documentation)                                       | Form building, validation, and display             |
 | [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview) | File-based routing                                 |
 | [React](https://react.dev/reference/react)                                          | Front-end web framework                            |
 | [React Aria](https://react-spectrum.adobe.com/react-aria)                           | Accessible components and design system            |


### PR DESCRIPTION
## What changed?

Removed SurveyJS from `docs/CONTRIBUTING.md` as it's no longer in the dep list

Also updated `.gitignore` to ignore the generated `convex/README.md` file that gets created whenever you initialize a convex deployment