### PR TITLE
feat: Encrypt user form data on client side

### DIFF
--- a/.changeset/nice-laws-cough.md
+++ b/.changeset/nice-laws-cough.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+adds encryption helper and placeholder ui for testing it

--- a/.changeset/nice-laws-cough.md
+++ b/.changeset/nice-laws-cough.md
@@ -2,4 +2,4 @@
 "namesake": minor
 ---
 
-adds encryption helper and placeholder ui for testing it
+Add end-to-end encryption of user form data

--- a/convex/userFormData.ts
+++ b/convex/userFormData.ts
@@ -1,6 +1,17 @@
 import { v } from "convex/values";
 import { userMutation, userQuery } from "./helpers";
 
+export const list = userQuery({
+  args: {},
+  handler: async (ctx, _args) => {
+    const userData = await ctx.db
+      .query("userFormData")
+      .withIndex("userId", (q) => q.eq("userId", ctx.userId))
+      .collect();
+    return userData;
+  },
+});
+
 export const get = userQuery({
   args: {},
   handler: async (ctx, _args) => {

--- a/src/components/settings/UserDataForm/UserDataForm.tsx
+++ b/src/components/settings/UserDataForm/UserDataForm.tsx
@@ -80,6 +80,8 @@ export function UserDataForm({ initialData }: UserDataFormProps) {
     return <LoaderCircle className="w-4 h-4 animate-spin" />;
   }
 
+  const isExistingField = initialData.field !== "";
+
   return (
     <Form onSubmit={handleSubmit}>
       <div className="flex gap-2 items-end">
@@ -89,6 +91,7 @@ export function UserDataForm({ initialData }: UserDataFormProps) {
           value={field}
           onChange={setField}
           placeholder="Enter field name"
+          isDisabled={isExistingField}
         />
         <TextField
           label="Value"

--- a/src/components/settings/UserDataForm/UserDataForm.tsx
+++ b/src/components/settings/UserDataForm/UserDataForm.tsx
@@ -24,9 +24,12 @@ export function UserDataForm({ initialData }: UserDataFormProps) {
   const save = useMutation(api.userFormData.set);
 
   useEffect(() => {
+    console.log("initialData", initialData);
     const loadEncryptionKey = async () => {
+      console.log("TRYING!")
       try {
         const key = await getEncryptionKey();
+        console.log("key", key);
         setEncryptionKey(key);
 
         if (!key) {

--- a/src/components/settings/UserDataForm/UserDataForm.tsx
+++ b/src/components/settings/UserDataForm/UserDataForm.tsx
@@ -1,0 +1,117 @@
+import { Button, Form, TextField } from "@/components/common";
+import { decryptData, encryptData, getEncryptionKey } from "@/utils/encryption";
+import { api } from "@convex/_generated/api";
+import { useMutation } from "convex/react";
+import { LoaderCircle } from "lucide-react";
+import posthog from "posthog-js";
+import { useEffect, useState } from "react";
+
+interface UserDataFormProps {
+  initialData: { field: string; value: string };
+}
+
+// Placeholder for allowing users to view and edit their form data
+// TODO: Replace this with a more robust implementation that manages draft state better.
+export function UserDataForm({ initialData }: UserDataFormProps) {
+  const [field, setField] = useState(initialData.field);
+  const [decryptedValue, setDecryptedValue] = useState<string>();
+  const [initialDecryptedValue, setInitialDecryptedValue] = useState<string>();
+  const [encryptionKey, setEncryptionKey] = useState<CryptoKey | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const isDirty =
+    field === initialData.field && decryptedValue === initialDecryptedValue;
+
+  const save = useMutation(api.userFormData.set);
+
+  useEffect(() => {
+    const loadEncryptionKey = async () => {
+      try {
+        const key = await getEncryptionKey();
+        setEncryptionKey(key);
+
+        if (!key) {
+          return;
+        }
+
+        if (initialData.value) {
+          try {
+            const decryptedValue = await decryptData(initialData.value, key);
+            setDecryptedValue(decryptedValue);
+            setInitialDecryptedValue(decryptedValue);
+          } catch (error: any) {
+            posthog.captureException(error);
+          }
+        } else {
+          setDecryptedValue("");
+          setInitialDecryptedValue("");
+        }
+      } catch (error: any) {
+        posthog.captureException(error);
+      }
+    };
+
+    loadEncryptionKey();
+  }, [initialData.value]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!encryptionKey || !decryptedValue) {
+      console.error("No encryption key or decrypted value available");
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      // Encrypt the value before saving
+      const encryptedValue = await encryptData(decryptedValue, encryptionKey);
+      await save({ field, value: encryptedValue });
+    } catch (error) {
+      console.error("Error saving encrypted data:", error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (encryptionKey === null || decryptedValue === undefined) {
+    return <LoaderCircle className="w-4 h-4 animate-spin" />;
+  }
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <div className="flex gap-2 items-end">
+        <TextField
+          label="Field"
+          name="field"
+          value={field}
+          onChange={setField}
+          placeholder="Enter field name"
+        />
+        <TextField
+          label="Value"
+          name="value"
+          value={decryptedValue}
+          onChange={setDecryptedValue}
+          placeholder="Enter field value"
+        />
+        <Button
+          type="submit"
+          variant="secondary"
+          className="w-fit"
+          isDisabled={
+            field === "" || decryptedValue === "" || isSaving || isDirty
+          }
+        >
+          {isSaving ? (
+            <>
+              <LoaderCircle className="w-4 h-4 animate-spin mr-2" />
+              Saving...
+            </>
+          ) : (
+            "Save"
+          )}
+        </Button>
+      </div>
+    </Form>
+  );
+}

--- a/src/components/settings/UserDataForm/UserDataForm.tsx
+++ b/src/components/settings/UserDataForm/UserDataForm.tsx
@@ -77,9 +77,7 @@ export function UserDataForm({ initialData }: UserDataFormProps) {
 
   if (didError) {
     return (
-      <Banner variant="danger">
-        Error decrypting {initialData.field}
-      </Banner>
+      <Banner variant="danger">Error decrypting {initialData.field}</Banner>
     );
   }
 

--- a/src/components/settings/UserDataForms/UserDataForms.tsx
+++ b/src/components/settings/UserDataForms/UserDataForms.tsx
@@ -31,6 +31,9 @@ export function UserDataForms() {
     setupEncryption();
   }, []);
 
+  // Check if we already have an empty form
+  const hasEmptyForm = formData.some((data) => data.field === "");
+
   return (
     <>
       <div className="mt-4 flex flex-col gap-4">
@@ -39,13 +42,15 @@ export function UserDataForms() {
           <UserDataForm key={idx} initialData={data} />
         ))}
       </div>
-      <Button
-        className="w-fit mt-4"
-        variant="secondary"
-        onPress={() => setFormData([...formData, { field: "", value: "" }])}
-      >
-        Add Value
-      </Button>
+      {!hasEmptyForm && (
+        <Button
+          className="w-fit mt-4"
+          variant="secondary"
+          onPress={() => setFormData([...formData, { field: "", value: "" }])}
+        >
+          Add Value
+        </Button>
+      )}
     </>
   );
 }

--- a/src/components/settings/UserDataForms/UserDataForms.tsx
+++ b/src/components/settings/UserDataForms/UserDataForms.tsx
@@ -1,0 +1,51 @@
+import { Button } from "@/components/common";
+import { initializeEncryption } from "@/utils/encryption";
+import { api } from "@convex/_generated/api";
+import { useQuery } from "convex/react";
+import posthog from "posthog-js";
+import { useEffect, useState } from "react";
+import { UserDataForm } from "../UserDataForm/UserDataForm";
+
+// Placeholder for allowing users to view and edit their form data
+export function UserDataForms() {
+  const userData = useQuery(api.userFormData.list);
+  const [formData, setFormData] = useState<{ field: string; value: string }[]>(
+    userData?.map((data) => ({ field: data.field, value: data.value })) ?? [],
+  );
+
+  useEffect(() => {
+    setFormData(
+      userData?.map((data) => ({ field: data.field, value: data.value })) ?? [],
+    );
+  }, [userData]);
+
+  useEffect(() => {
+    const setupEncryption = async () => {
+      try {
+        await initializeEncryption();
+      } catch (error: any) {
+        posthog.captureException(error);
+      }
+    };
+
+    setupEncryption();
+  }, []);
+
+  return (
+    <>
+      <div className="mt-4 flex flex-col gap-4">
+        {formData.map((data, idx) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: This is a form where order matters and items won't be reordered
+          <UserDataForm key={idx} initialData={data} />
+        ))}
+      </div>
+      <Button
+        className="w-fit mt-4"
+        variant="secondary"
+        onPress={() => setFormData([...formData, { field: "", value: "" }])}
+      >
+        Add Value
+      </Button>
+    </>
+  );
+}

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -7,3 +7,4 @@ export * from "./EditResidenceSetting/EditResidenceSetting";
 export * from "./EditThemeSetting/EditThemeSetting";
 export * from "./SettingsGroup/SettingsGroup";
 export * from "./SettingsItem/SettingsItem";
+export * from "./UserDataForms/UserDataForms";

--- a/src/routes/_authenticated/settings/data.tsx
+++ b/src/routes/_authenticated/settings/data.tsx
@@ -1,5 +1,6 @@
 import { PageHeader } from "@/components/app";
 import { Banner } from "@/components/common";
+import { UserDataForms } from "@/components/settings";
 import { createFileRoute } from "@tanstack/react-router";
 import { Lock } from "lucide-react";
 
@@ -14,6 +15,7 @@ function DataRoute() {
       <Banner variant="success" icon={Lock}>
         Data shown here is end-to-end encrypted. Only you can access it.
       </Banner>
+      <UserDataForms />
     </>
   );
 }

--- a/src/utils/encryption.test.ts
+++ b/src/utils/encryption.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  initializeEncryption,
+  getEncryptionKey,
+  encryptData,
+  decryptData,
+} from "./encryption";
+
+interface MockIDBRequest {
+  result: any;
+  error: Error | null;
+  source: any;
+  transaction: any;
+  readyState: "pending" | "done";
+  onerror: ((event: any) => void) | null;
+  onsuccess: ((event: any) => void) | null;
+  onupgradeneeded?: ((event: any) => void) | null;
+}
+
+describe("encryption", () => {
+  // Mock store data
+  const storeData = new Map<string, string>();
+
+  // Mock IDBRequest creator
+  function createMockIDBRequest<T>(result: T): MockIDBRequest {
+    const request: MockIDBRequest = {
+      result,
+      error: null,
+      source: null,
+      transaction: null,
+      readyState: "pending",
+      onerror: null,
+      onsuccess: null,
+    };
+
+    // Set a timeout to simulate the request being resolved
+    // The timeout is necessary because the request will
+    // hang otherwise.
+    setTimeout(() => {
+      if (request.onsuccess) {
+        request.onsuccess({ target: request } as any);
+      }
+    }, 0);
+
+    return request;
+  }
+
+  // Mock store
+  const mockStore = {
+    put: vi.fn((value: string, key: string) => {
+      storeData.set(key, value);
+      return createMockIDBRequest(undefined);
+    }),
+    get: vi.fn((key: string) => {
+      return createMockIDBRequest(storeData.get(key));
+    }),
+  };
+
+  // Mock transaction
+  const mockTransaction = {
+    objectStore: vi.fn().mockReturnValue(mockStore),
+  };
+
+  // Mock database
+  const mockDB = {
+    transaction: vi.fn().mockReturnValue(mockTransaction),
+    createObjectStore: vi.fn(),
+    objectStoreNames: {
+      contains: vi.fn().mockReturnValue(false),
+    },
+  };
+
+  beforeEach(() => {
+    // Clear store data
+    storeData.clear();
+
+    // Mock crypto.subtle as the test environment doesn't have a crypto implementation
+    // This test suite is only used to test round trips.
+    const mockSubtle = {
+      generateKey: vi.fn().mockImplementation(async (algorithm, extractable, keyUsages) => {
+        return {
+          type: "secret",
+          extractable,
+          algorithm,
+          usages: keyUsages,
+        };
+      }),
+      encrypt: vi.fn().mockImplementation(async () => new Uint8Array([1, 2, 3])),
+      decrypt: vi.fn().mockImplementation(async () => new Uint8Array([4, 5, 6])),
+      importKey: vi.fn().mockImplementation(async (_format, _keyData, algorithm, extractable, keyUsages) => {
+        return {
+          type: "secret",
+          extractable,
+          algorithm,
+          usages: keyUsages,
+        };
+      }),
+      exportKey: vi.fn().mockImplementation(async () => new Uint8Array([7, 8, 9])),
+      deriveKey: vi.fn().mockImplementation(async (_algorithm, _baseKey, derivedKeyAlgorithm, extractable, keyUsages) => {
+        return {
+          type: "secret",
+          extractable,
+          algorithm: derivedKeyAlgorithm,
+          usages: keyUsages,
+        };
+      }),
+    };
+
+    // Mock crypto
+    const mockCrypto = {
+      subtle: mockSubtle,
+      getRandomValues: vi.fn((array) => array),
+    };
+
+    // Mock window.crypto
+    vi.stubGlobal("crypto", mockCrypto);
+
+    // Mock IndexedDB
+    const mockIDB = {
+      open: vi.fn().mockImplementation(() => {
+        const request = createMockIDBRequest(mockDB);
+        setTimeout(() => {
+          if (request.onupgradeneeded) {
+            request.onupgradeneeded({ target: request } as any);
+          }
+        }, 0);
+        return request;
+      }),
+    };
+
+    vi.stubGlobal("indexedDB", mockIDB);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    storeData.clear();
+  });
+
+  describe("initialization", () => {
+    it("should initialize encryption and create necessary keys", async () => {
+      await initializeEncryption();
+
+      expect(mockStore.put).toHaveBeenCalledWith(
+        "AAAAAAAAAAAAAAAAAAAAAA==",
+        "device-salt",
+      );
+
+      expect(mockStore.put).toHaveBeenCalledWith(
+        "AAAAAAAAAAAAAAAAAQID",
+        "device-dek",
+      );
+    });
+
+    it("should not reinitialize if encryption is already set up", async () => {
+      // Set up existing DEK
+      storeData.set("device-dek", "existing-encrypted-dek");
+      
+      await initializeEncryption();
+      expect(mockStore.put).not.toHaveBeenCalled();
+
+      expect(mockStore.get).toHaveBeenCalledWith(
+        "device-dek",
+      );
+    });
+  });
+
+  describe("key management", () => {
+    it("should retrieve encryption key successfully", async () => {
+      // First initialize
+      await initializeEncryption();
+      
+      // Then get the key
+      const key = await getEncryptionKey();
+      expect(key).toBeDefined();
+      expect(key).toHaveProperty("type", "secret");
+    });
+
+    it("should return null if no encryption key exists", async () => {
+      const key = await getEncryptionKey();
+      expect(key).toBeNull();
+    });
+  });
+
+  describe("data encryption/decryption", () => {
+    it("should encrypt and decrypt data correctly", async () => {
+      await initializeEncryption();
+      const key = await getEncryptionKey();
+      expect(key).toBeDefined();
+      if (!key) throw new Error("Key should exist");
+
+      const originalData = "sensitive information";
+      const encrypted = await encryptData(originalData, key);
+      
+      expect(encrypted).toBeDefined();
+      expect(encrypted).not.toBe(originalData);
+      expect(typeof encrypted).toBe("string");
+
+      // Mock the decrypt operation to return our original data
+      const mockCrypto = window.crypto as any;
+      mockCrypto.subtle.decrypt.mockImplementationOnce(async () => 
+        new TextEncoder().encode(originalData)
+      );
+      
+      const decrypted = await decryptData(encrypted, key);
+      expect(decrypted).toBe(originalData);
+    });
+
+    // This is a sanity check to ensure that the encrypt is being called.
+    it("should encrypt different values to different ciphertexts", async () => {
+      await initializeEncryption();
+      const key = await getEncryptionKey();
+      expect(key).toBeDefined();
+      if (!key) throw new Error("Key should exist");
+
+      const data = "test data";
+      const encrypted1 = await encryptData(data, key);
+      
+      // Change mock implementation for second encryption
+      const mockCrypto = window.crypto as any;
+      mockCrypto.subtle.encrypt.mockImplementationOnce(async () => 
+        new Uint8Array([4, 5, 6])
+      );
+      
+      const encrypted2 = await encryptData(data, key);
+      expect(encrypted1).not.toBe(encrypted2);
+    });
+
+    it("should fail to decrypt with wrong key", async () => {
+      await initializeEncryption();
+      const key = await getEncryptionKey();
+      expect(key).toBeDefined();
+      if (!key) throw new Error("Key should exist");
+
+      const data = "test data";
+      const encrypted = await encryptData(data, key);
+
+      // Mock decrypt to throw error for wrong key
+      const mockCrypto = window.crypto as any;
+      mockCrypto.subtle.decrypt.mockRejectedValueOnce(new Error("Decryption failed"));
+
+      await expect(decryptData(encrypted, key)).rejects.toThrow();
+    });
+
+    it("should handle empty strings", async () => {
+      await initializeEncryption();
+      const key = await getEncryptionKey();
+      expect(key).toBeDefined();
+      if (!key) throw new Error("Key should exist");
+
+      const emptyString = "";
+      const encrypted = await encryptData(emptyString, key);
+
+      // Mock decrypt to return empty string
+      const mockCrypto = window.crypto as any;
+      mockCrypto.subtle.decrypt.mockImplementationOnce(async () => 
+        new TextEncoder().encode(emptyString)
+      );
+
+      const decrypted = await decryptData(encrypted, key);
+      expect(decrypted).toBe(emptyString);
+    });
+
+    it("should handle special characters", async () => {
+      await initializeEncryption();
+      const key = await getEncryptionKey();
+      expect(key).toBeDefined();
+      if (!key) throw new Error("Key should exist");
+
+      const specialChars = "!@#$%^&*()_+-=[]{}|;:,.<>?`~'\"\\";
+      const encrypted = await encryptData(specialChars, key);
+
+      // Mock decrypt to return special characters
+      const mockCrypto = window.crypto as any;
+      mockCrypto.subtle.decrypt.mockImplementationOnce(async () => 
+        new TextEncoder().encode(specialChars)
+      );
+      
+      const decrypted = await decryptData(encrypted, key);
+      expect(decrypted).toBe(specialChars);
+    });
+
+    it("should handle unicode characters", async () => {
+      await initializeEncryption();
+      const key = await getEncryptionKey();
+      expect(key).toBeDefined();
+      if (!key) throw new Error("Key should exist");
+
+      const unicode = "Hello, світ! 👋 🌍";
+      const encrypted = await encryptData(unicode, key);
+
+      // Mock decrypt to return unicode string
+      const mockCrypto = window.crypto as any;
+      mockCrypto.subtle.decrypt.mockImplementationOnce(async () => 
+        new TextEncoder().encode(unicode)
+      );
+      
+      const decrypted = await decryptData(encrypted, key);
+      expect(decrypted).toBe(unicode);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle IndexedDB errors gracefully", async () => {
+      const mockIDB = window.indexedDB as any;
+      mockIDB.open.mockImplementationOnce(() => {
+        const request = createMockIDBRequest(null);
+        setTimeout(() => {
+          if (request.onerror) {
+            const error = new Error("IndexedDB error");
+            Object.defineProperty(request, 'error', {
+              value: error,
+              writable: true
+            });
+            request.onerror({ target: request } as any);
+          }
+        }, 0);
+        return request;
+      });
+
+      await expect(initializeEncryption()).rejects.toThrow();
+    });
+
+    it("should handle invalid encrypted data", async () => {
+      await initializeEncryption();
+      const key = await getEncryptionKey();
+      expect(key).toBeDefined();
+      if (!key) throw new Error("Key should exist");
+
+      // Mock decrypt to throw error for invalid data
+      const mockCrypto = window.crypto as any;
+      mockCrypto.subtle.decrypt.mockRejectedValueOnce(new Error("Invalid data"));
+
+      await expect(decryptData("invalid-data", key)).rejects.toThrow();
+    });
+  });
+}); 

--- a/src/utils/encryption.test.ts
+++ b/src/utils/encryption.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  initializeEncryption,
-  getEncryptionKey,
-  encryptData,
   decryptData,
+  encryptData,
+  getEncryptionKey,
+  initializeEncryption,
 } from "./encryption";
 
 interface MockIDBRequest {
@@ -79,10 +79,27 @@ describe("encryption", () => {
         // Return 12 bytes IV + 16 bytes ciphertext
         return new Uint8Array([
           ...new Uint8Array(12), // IV
-          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 // ciphertext
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16, // ciphertext
         ]);
       }),
-      decrypt: vi.fn().mockImplementation(async () => new Uint8Array([4, 5, 6])),
+      decrypt: vi
+        .fn()
+        .mockImplementation(async () => new Uint8Array([4, 5, 6])),
       exportKey: vi.fn().mockImplementation(async () => new Uint8Array(32)), // 32 bytes for AES-256
       importKey: vi.fn().mockImplementation(async () => ({
         type: "secret",
@@ -119,7 +136,10 @@ describe("encryption", () => {
     it("should initialize encryption and store DEK", async () => {
       await initializeEncryption();
       expect(window.crypto.subtle.generateKey).toHaveBeenCalled();
-      expect(mockStore.put).toHaveBeenCalledWith(expect.any(String), "device-dek");
+      expect(mockStore.put).toHaveBeenCalledWith(
+        expect.any(String),
+        "device-dek",
+      );
     });
 
     it("should not reinitialize if DEK exists", async () => {
@@ -152,13 +172,13 @@ describe("encryption", () => {
       const encrypted = await encryptData(data, key);
       expect(encrypted).toBeDefined();
       expect(typeof encrypted).toBe("string");
-      
+
       // Verify it's valid base64
       expect(() => atob(encrypted)).not.toThrow();
 
       const mockCrypto = window.crypto as any;
       mockCrypto.subtle.decrypt.mockImplementationOnce(async () =>
-        new TextEncoder().encode(data)
+        new TextEncoder().encode(data),
       );
 
       const decrypted = await decryptData(encrypted, key);
@@ -176,7 +196,7 @@ describe("encryption", () => {
 
       const mockCrypto = window.crypto as any;
       mockCrypto.subtle.decrypt.mockImplementationOnce(async () =>
-        new TextEncoder().encode(data)
+        new TextEncoder().encode(data),
       );
 
       const decrypted = await decryptData(encrypted, key);
@@ -194,7 +214,7 @@ describe("encryption", () => {
 
       const mockCrypto = window.crypto as any;
       mockCrypto.subtle.decrypt.mockImplementationOnce(async () =>
-        new TextEncoder().encode(data)
+        new TextEncoder().encode(data),
       );
 
       const decrypted = await decryptData(encrypted, key);
@@ -225,7 +245,9 @@ describe("encryption", () => {
       if (!key) throw new Error("Key should exist");
 
       const mockCrypto = window.crypto as any;
-      mockCrypto.subtle.decrypt.mockRejectedValueOnce(new Error("Invalid data"));
+      mockCrypto.subtle.decrypt.mockRejectedValueOnce(
+        new Error("Invalid data"),
+      );
 
       // Use valid base64 but invalid encrypted data
       await expect(decryptData("AAAA", key)).rejects.toThrow();

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -1,0 +1,359 @@
+// Constants
+const DB_NAME = "namesake-encryption";
+const STORE_NAME = "encryption-keys";
+const DEK_KEY = "device-dek";
+const DEVICE_SALT_KEY = "device-salt";
+const KEK_SEED_KEY = "kek-seed";
+
+const IV_LENGTH = 12;
+const SALT_LENGTH = 16;
+const SEED_LENGTH = 32; // 256 bits of entropy for the KEK seed
+
+// 600K iterations is recommended by the OWASP for PBKDF2
+// https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2
+const KEK_ITERATIONS = 600000;
+
+/**
+ * Encryption module using AES-GCM with a two-key system:
+ * 
+ * - Data Encryption Key (DEK): Used to encrypt/decrypt actual data
+ * - Key Encryption Key (KEK): Protects the DEK
+ * 
+ * The encrypted DEK is stored in IndexedDB. The KEK is non-extractable 
+ * and derived from a device-specific salt (stored in IndexedDB) using PBKDF2.
+ */
+
+/**
+ * Security Considerations:
+ * 1. Data is encrypted at rest using AES-GCM
+ * 2. KEKs are isolated to the device
+ * 3. There are memory exposure risks here as this is a JavaScript client
+ * 4. Key-rotation is not implemented as it does not apply to this use case
+ */
+
+/**
+ * Encrypts data with the DEK
+ * @param data - The data to encrypt
+ * @param dek - The DEK to encrypt the data with
+ * @returns The encrypted data
+ */
+export async function encryptData(
+  data: string,
+  dek: CryptoKey,
+): Promise<string> {
+  const iv = window.crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+  const encodedData = new TextEncoder().encode(data);
+
+  const encryptedData = await window.crypto.subtle.encrypt(
+    {
+      name: "AES-GCM",
+      iv,
+    },
+    dek,
+    encodedData,
+  );
+
+  // Combine IV and encrypted data
+  const combined = new Uint8Array(iv.length + encryptedData.byteLength);
+  combined.set(iv);
+  combined.set(new Uint8Array(encryptedData), iv.length);
+
+  return arrayBufferToBase64(combined);
+}
+
+/**
+ * Decrypts data with the DEK
+ * @param encryptedDataString - The encrypted data to decrypt
+ * @param dek - The DEK to decrypt the data with
+ * @returns The decrypted data
+ */
+export async function decryptData(
+  encryptedDataString: string,
+  dek: CryptoKey,
+): Promise<string> {
+  const encryptedData = new Uint8Array(
+    base64ToArrayBuffer(encryptedDataString),
+  );
+  const iv = encryptedData.slice(0, IV_LENGTH);
+  const data = encryptedData.slice(IV_LENGTH);
+
+  const decryptedData = await window.crypto.subtle.decrypt(
+    {
+      name: "AES-GCM",
+      iv,
+    },
+    dek,
+    data,
+  );
+
+  return new TextDecoder().decode(decryptedData);
+}
+
+/**
+ * Initializes encryption for the device
+ * @returns The DEK
+ */
+export async function initializeEncryption(): Promise<void> {
+  // Check if encryption is already initialized
+  const existingDEK = await retrieveDEK();
+  if (existingDEK) return;
+
+  const kek = await generateKEK();
+  const dek = await generateDEK();
+  const encryptedDEK = await encryptDEK(kek, dek);
+
+  // Store encrypted DEK
+  await storeDEK(encryptedDEK);
+}
+
+/**
+ * Gets the encryption key. If one doesn't exist, create one.
+ * @returns The DEK
+ */
+export async function getEncryptionKey(): Promise<CryptoKey | null> {
+  const encryptedDEK = await retrieveDEK();
+  if (!encryptedDEK) return null;
+
+  const kek = await generateKEK();
+  const decryptedDEK = await decryptDEK(kek, encryptedDEK);
+  return decryptedDEK;
+}
+
+// Helper functions for base64 encoding/decoding
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+// Initialize IndexedDB
+async function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+  });
+}
+
+// Generate a device-specific salt
+async function generateDeviceSalt(): Promise<Uint8Array> {
+  return window.crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
+}
+
+// Store salt in IndexedDB
+async function storeSalt(salt: Uint8Array): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.put(arrayBufferToBase64(salt), DEVICE_SALT_KEY);
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve();
+  });
+}
+
+// Retrieve salt from IndexedDB
+async function retrieveSalt(): Promise<Uint8Array | null> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readonly");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.get(DEVICE_SALT_KEY);
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      if (!request.result) {
+        resolve(null);
+        return;
+      }
+      resolve(new Uint8Array(base64ToArrayBuffer(request.result)));
+    };
+  });
+}
+
+// Generate a deterministic KEK from the device salt and KEK seed
+async function generateKEK(): Promise<CryptoKey> {
+  let salt = await retrieveSalt();
+  if (!salt) {
+    salt = await generateDeviceSalt();
+    await storeSalt(salt);
+  }
+
+  // Get or generate KEK seed
+  let kekSeed = await retrieveKEKSeed();
+  if (!kekSeed) {
+    kekSeed = await generateKEKSeed();
+    await storeKEKSeed(kekSeed);
+  }
+
+  // Use the salt and KEK seed to derive a key
+  const baseKey = await window.crypto.subtle.importKey(
+    "raw",
+    kekSeed,
+    { name: "PBKDF2" },
+    false,
+    ["deriveBits", "deriveKey"]
+  );
+
+  return await window.crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: salt,
+      iterations: KEK_ITERATIONS,
+      hash: "SHA-256",
+    },
+    baseKey,
+    {
+      name: "AES-GCM",
+      length: 256,
+    },
+    false,
+    ["encrypt", "decrypt"]
+  );
+}
+
+// Generate a random KEK seed
+async function generateKEKSeed(): Promise<Uint8Array> {
+  return window.crypto.getRandomValues(new Uint8Array(SEED_LENGTH));
+}
+
+// Store KEK seed in IndexedDB
+async function storeKEKSeed(seed: Uint8Array): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.put(arrayBufferToBase64(seed), KEK_SEED_KEY);
+    
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve();
+  });
+}
+
+// Retrieve KEK seed from IndexedDB
+async function retrieveKEKSeed(): Promise<Uint8Array | null> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readonly");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.get(KEK_SEED_KEY);
+    
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      if (!request.result) {
+        resolve(null);
+        return;
+      }
+      resolve(new Uint8Array(base64ToArrayBuffer(request.result)));
+    };
+  });
+}
+
+// Generate a new data encryption key (DEK)
+async function generateDEK(): Promise<CryptoKey> {
+  return await window.crypto.subtle.generateKey(
+    {
+      name: "AES-GCM",
+      length: 256,
+    },
+    true, // extractable so it can be encrypted by the KEK
+    ["encrypt", "decrypt"],
+  );
+}
+
+// Encrypt the DEK with the KEK
+async function encryptDEK(
+  kek: CryptoKey,
+  dek: CryptoKey,
+): Promise<string> {
+  const iv = window.crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+  const exportedDEK = await window.crypto.subtle.exportKey("raw", dek);
+
+  const encryptedDEK = await window.crypto.subtle.encrypt(
+    {
+      name: "AES-GCM",
+      iv,
+    },
+    kek,
+    exportedDEK,
+  );
+
+  // Combine IV and encrypted DEK
+  const combined = new Uint8Array(iv.length + encryptedDEK.byteLength);
+  combined.set(iv);
+  combined.set(new Uint8Array(encryptedDEK), iv.length);
+
+  return arrayBufferToBase64(combined);
+}
+
+// Decrypt the DEK with the KEK
+async function decryptDEK(
+  kek: CryptoKey,
+  encryptedDEKString: string,
+): Promise<CryptoKey> {
+  const encryptedData = new Uint8Array(base64ToArrayBuffer(encryptedDEKString));
+  const iv = encryptedData.slice(0, IV_LENGTH);
+  const encryptedDEK = encryptedData.slice(IV_LENGTH);
+  const dekBuffer = await window.crypto.subtle.decrypt(
+    {
+      name: "AES-GCM",
+      iv,
+    },
+    kek,
+    encryptedDEK,
+  );
+  return await window.crypto.subtle.importKey(
+    "raw",
+    dekBuffer,
+    "AES-GCM",
+    true,
+    ["encrypt", "decrypt"],
+  );
+}
+
+// Store encrypted DEK in IndexedDB
+async function storeDEK(encryptedDEK: string): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.put(encryptedDEK, DEK_KEY);
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve();
+  });
+}
+
+// Retrieve encrypted DEK from IndexedDB
+async function retrieveDEK(): Promise<string | null> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readonly");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.get(DEK_KEY);
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+  });
+}

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -15,11 +15,11 @@ const KEK_ITERATIONS = 600000;
 
 /**
  * Encryption module using AES-GCM with a two-key system:
- * 
+ *
  * - Data Encryption Key (DEK): Used to encrypt/decrypt actual data
  * - Key Encryption Key (KEK): Protects the DEK
- * 
- * The encrypted DEK is stored in IndexedDB. The KEK is non-extractable 
+ *
+ * The encrypted DEK is stored in IndexedDB. The KEK is non-extractable
  * and derived from a device-specific salt (stored in IndexedDB) using PBKDF2.
  */
 
@@ -213,7 +213,7 @@ async function generateKEK(): Promise<CryptoKey> {
     kekSeed,
     { name: "PBKDF2" },
     false,
-    ["deriveBits", "deriveKey"]
+    ["deriveBits", "deriveKey"],
   );
 
   return await window.crypto.subtle.deriveKey(
@@ -229,7 +229,7 @@ async function generateKEK(): Promise<CryptoKey> {
       length: 256,
     },
     false,
-    ["encrypt", "decrypt"]
+    ["encrypt", "decrypt"],
   );
 }
 
@@ -245,7 +245,7 @@ async function storeKEKSeed(seed: Uint8Array): Promise<void> {
     const transaction = db.transaction(STORE_NAME, "readwrite");
     const store = transaction.objectStore(STORE_NAME);
     const request = store.put(arrayBufferToBase64(seed), KEK_SEED_KEY);
-    
+
     request.onerror = () => reject(request.error);
     request.onsuccess = () => resolve();
   });
@@ -258,7 +258,7 @@ async function retrieveKEKSeed(): Promise<Uint8Array | null> {
     const transaction = db.transaction(STORE_NAME, "readonly");
     const store = transaction.objectStore(STORE_NAME);
     const request = store.get(KEK_SEED_KEY);
-    
+
     request.onerror = () => reject(request.error);
     request.onsuccess = () => {
       if (!request.result) {
@@ -283,10 +283,7 @@ async function generateDEK(): Promise<CryptoKey> {
 }
 
 // Encrypt the DEK with the KEK
-async function encryptDEK(
-  kek: CryptoKey,
-  dek: CryptoKey,
-): Promise<string> {
+async function encryptDEK(kek: CryptoKey, dek: CryptoKey): Promise<string> {
   const iv = window.crypto.getRandomValues(new Uint8Array(IV_LENGTH));
   const exportedDEK = await window.crypto.subtle.exportKey("raw", dek);
 

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -2,135 +2,81 @@
 const DB_NAME = "namesake-encryption";
 const STORE_NAME = "encryption-keys";
 const DEK_KEY = "device-dek";
-
 const IV_LENGTH = 12;
 
 /**
- * Encryption module using AES-GCM with a single non-extractable key:
- * 
+ * Encryption module using AES-GCM with a single key:
  * - Data Encryption Key (DEK): Used to encrypt/decrypt data
- * 
- * The DEK is generated as a non-extractable key and stored in IndexedDB.
  */
 
-/**
- * Security Considerations:
- * 1. Data is encrypted at rest using AES-GCM
- * 2. DEK is non-extractable and isolated to the device
- * 3. There are memory exposure risks here as this is a JavaScript client
- * 4. Key-rotation is not implemented as it does not apply to this use case
- */
-
-/**
- * Encrypts data with the DEK
- * @param data - The data to encrypt
- * @param dek - The DEK to encrypt the data with
- * @returns The encrypted data
- */
 export async function encryptData(
   data: string,
   dek: CryptoKey,
 ): Promise<string> {
   const iv = window.crypto.getRandomValues(new Uint8Array(IV_LENGTH));
   const encodedData = new TextEncoder().encode(data);
-
   const encryptedData = await window.crypto.subtle.encrypt(
-    {
-      name: "AES-GCM",
-      iv,
-    },
+    { name: "AES-GCM", iv },
     dek,
     encodedData,
   );
 
-  // Combine IV and encrypted data
   const combined = new Uint8Array(iv.length + encryptedData.byteLength);
   combined.set(iv);
   combined.set(new Uint8Array(encryptedData), iv.length);
-
   return arrayBufferToBase64(combined);
 }
 
-/**
- * Decrypts data with the DEK
- * @param encryptedDataString - The encrypted data to decrypt
- * @param dek - The DEK to decrypt the data with
- * @returns The decrypted data
- */
 export async function decryptData(
   encryptedDataString: string,
   dek: CryptoKey,
 ): Promise<string> {
-  const encryptedData = new Uint8Array(
-    base64ToArrayBuffer(encryptedDataString),
-  );
+  const encryptedData = new Uint8Array(base64ToArrayBuffer(encryptedDataString));
   const iv = encryptedData.slice(0, IV_LENGTH);
   const data = encryptedData.slice(IV_LENGTH);
-
   const decryptedData = await window.crypto.subtle.decrypt(
-    {
-      name: "AES-GCM",
-      iv,
-    },
+    { name: "AES-GCM", iv },
     dek,
     data,
   );
-
   return new TextDecoder().decode(decryptedData);
 }
 
-/**
- * Initializes encryption for the device
- */
 export async function initializeEncryption(): Promise<void> {
-  // Check if encryption is already initialized
   const existingDEK = await retrieveDEK();
   if (existingDEK) return;
 
-  // Generate a non-extractable DEK
   const dek = await generateDEK();
   const serializedDEK = await serializeDEK(dek);
   await storeDEK(serializedDEK);
 }
 
-/**
- * Gets the encryption key. If one doesn't exist, create one.
- * @returns The DEK
- */
 export async function getEncryptionKey(): Promise<CryptoKey | null> {
   const serializedDEK = await retrieveDEK();
   if (!serializedDEK) return null;
-
   return await deserializeDEK(serializedDEK);
 }
 
-// Helper functions for base64 encoding/decoding
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);
-  let binary = "";
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
+  const binary = Array.from(bytes).map(byte => String.fromCharCode(byte)).join('');
   return btoa(binary);
 }
 
 function base64ToArrayBuffer(base64: string): ArrayBuffer {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
+  const binaryString = atob(base64);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
   }
   return bytes.buffer;
 }
 
-// Initialize IndexedDB
 async function openDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, 1);
-
     request.onerror = () => reject(request.error);
     request.onsuccess = () => resolve(request.result);
-
     request.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result;
       if (!db.objectStoreNames.contains(STORE_NAME)) {
@@ -140,60 +86,47 @@ async function openDB(): Promise<IDBDatabase> {
   });
 }
 
-// Generate a new data encryption key (DEK)
 async function generateDEK(): Promise<CryptoKey> {
   return await window.crypto.subtle.generateKey(
-    {
-      name: "AES-GCM",
-      length: 256,
-    },
-    true, // must be extractable to be serialized
+    { name: "AES-GCM", length: 256 },
+    true,
     ["encrypt", "decrypt"],
   );
 }
 
-// Serialize the DEK for storage
 async function serializeDEK(dek: CryptoKey): Promise<string> {
-  const jwk = await window.crypto.subtle.exportKey("jwk", dek);
-  return JSON.stringify(jwk);
+  const rawKey = await window.crypto.subtle.exportKey("raw", dek);
+  return arrayBufferToBase64(rawKey);
 }
 
-// Deserialize the DEK from storage
 async function deserializeDEK(serializedDEK: string): Promise<CryptoKey> {
-  const jwk = JSON.parse(serializedDEK);
+  const keyData = base64ToArrayBuffer(serializedDEK);
   return await window.crypto.subtle.importKey(
-    "jwk",
-    jwk,
-    {
-      name: "AES-GCM",
-      length: 256,
-    },
-    false, // non-extractable when in use
-    ["encrypt", "decrypt"],
+    "raw",
+    keyData,
+    { name: "AES-GCM", length: 256 },
+    true,
+    ["encrypt", "decrypt"]
   );
 }
 
-// Store serialized DEK in IndexedDB
 async function storeDEK(serializedDEK: string): Promise<void> {
   const db = await openDB();
   return new Promise((resolve, reject) => {
     const transaction = db.transaction(STORE_NAME, "readwrite");
     const store = transaction.objectStore(STORE_NAME);
     const request = store.put(serializedDEK, DEK_KEY);
-
     request.onerror = () => reject(request.error);
     request.onsuccess = () => resolve();
   });
 }
 
-// Retrieve serialized DEK from IndexedDB
 async function retrieveDEK(): Promise<string | null> {
   const db = await openDB();
   return new Promise((resolve, reject) => {
     const transaction = db.transaction(STORE_NAME, "readonly");
     const store = transaction.objectStore(STORE_NAME);
     const request = store.get(DEK_KEY);
-
     request.onerror = () => reject(request.error);
     request.onsuccess = () => resolve(request.result);
   });

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -6,7 +6,7 @@ const IV_LENGTH = 12;
 
 /**
  * Encryption module using AES-GCM with a single key:
- * - Data Encryption Key (DEK): Used to encrypt/decrypt data
+ * Data Encryption Key (DEK): Used to encrypt/decrypt data
  */
 
 export async function encryptData(

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -31,7 +31,9 @@ export async function decryptData(
   encryptedDataString: string,
   dek: CryptoKey,
 ): Promise<string> {
-  const encryptedData = new Uint8Array(base64ToArrayBuffer(encryptedDataString));
+  const encryptedData = new Uint8Array(
+    base64ToArrayBuffer(encryptedDataString),
+  );
   const iv = encryptedData.slice(0, IV_LENGTH);
   const data = encryptedData.slice(IV_LENGTH);
   const decryptedData = await window.crypto.subtle.decrypt(
@@ -59,7 +61,9 @@ export async function getEncryptionKey(): Promise<CryptoKey | null> {
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);
-  const binary = Array.from(bytes).map(byte => String.fromCharCode(byte)).join('');
+  const binary = Array.from(bytes)
+    .map((byte) => String.fromCharCode(byte))
+    .join("");
   return btoa(binary);
 }
 
@@ -106,7 +110,7 @@ async function deserializeDEK(serializedDEK: string): Promise<CryptoKey> {
     keyData,
     { name: "AES-GCM", length: 256 },
     true,
-    ["encrypt", "decrypt"]
+    ["encrypt", "decrypt"],
   );
 }
 


### PR DESCRIPTION
## What changed?

- Adds a set of encryption methods to encrypt user data before it is sent to the database (Convex)
- Adds a placeholder UI on the `/settings/data` page to help demonstrate how the feature works. The forms in the UI are basic and should be updated in the future to properly support intended use cases.
- Adds a `list` query to retrieve all `userFormData` for rendering

## Why?

Users of namesake should have there data protected -- external parties and operators of namesake should have a minimal amount of PII (Personally Identifiable Information) available to them

## How was this change made?

This PR implements a client-side encryption key, stored in IndexedDB in the browser, that is used to encrypt and decrypt data between the client and server.

I initially experimented with a two-key system (implementing a [Key Encrypting Key](https://csrc.nist.gov/glossary/term/key_encryption_key)), but found that implementation complicated and likely to not be completely secure. 

This simpler implementation is more streamlined, reducing the risk of vulnerability. However, there are some things to consider regarding security:
- To reduce the risk of XSS or other attacks where browser storage can be compromised, KEK could be implemented with a non-extractable key
- Other XSS prevention measure should exist in the application and be tested before 1.0

This implementation does not currently implement convenient portability of the key. If the user logs in from another device, a new key will be generated and data will not load. I recommend we merge this PR as a proof-of-concept and add the portability feature (e.g. allowing the user to download their key and re-enter it later) as a follow-up.

## How was this tested?

I added a basic test-suite to test round-trips -- encryption methods and IndexedDB are mocked. I also used the placeholder UI to test manually and confirm encrypted data is stored in Convex.

## Anything else?

Migrations! If, after launch, the key-generation / encryption patterns are changed in the future, we'll need to maintain the existing implementation and migrate the database to indicate which implementation was used to encrypt the data for backwards compatability