### PR TITLE
fix: Wrap text correctly in `Disclosure` element

### DIFF
--- a/.changeset/twenty-parents-know.md
+++ b/.changeset/twenty-parents-know.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fixes layout issues with long questions

--- a/src/components/common/Disclosure/Disclosure.tsx
+++ b/src/components/common/Disclosure/Disclosure.tsx
@@ -26,7 +26,7 @@ export interface DisclosureProps
 
 const disclosureTriggerStyles = tv({
   extend: focusRing,
-  base: "group flex-1 flex rounded-lg transition-colors text-gray-dim hover:text-gray-normal justify-between min-h-10 text-lg font-medium text-left",
+  base: "group flex-1 flex rounded-lg transition-colors text-gray-dim hover:text-gray-normal justify-between text-lg font-medium text-left py-2",
 });
 
 const disclosurePanelStyles = tv({

--- a/src/components/common/Disclosure/Disclosure.tsx
+++ b/src/components/common/Disclosure/Disclosure.tsx
@@ -56,8 +56,8 @@ export function Disclosure({
           <ChevronDown
             size={20}
             className={twMerge(
-              "group-hover:bg-graya-3 dark:group-hover:bg-graydarka-3 group-hover:text-gray-normal rounded-full size-8 p-1.5",
-              "transition-transform opacity-60 shrink-0 ml-2",
+              "group-hover:bg-graya-3 dark:group-hover:bg-graydarka-3 group-hover:text-gray-normal rounded-full size-8 p-1.5 shrink-0 ml-2",
+              "transition-transform opacity-60",
               "group-data-[expanded]:rotate-180",
             )}
           />

--- a/src/components/common/Disclosure/Disclosure.tsx
+++ b/src/components/common/Disclosure/Disclosure.tsx
@@ -26,7 +26,7 @@ export interface DisclosureProps
 
 const disclosureTriggerStyles = tv({
   extend: focusRing,
-  base: "group flex-1 flex rounded-lg transition-colors text-gray-dim hover:text-gray-normal justify-between items-center min-h-10 text-lg font-medium text-left",
+  base: "group flex-1 flex rounded-lg transition-colors text-gray-dim hover:text-gray-normal justify-between min-h-10 text-lg font-medium text-left",
 });
 
 const disclosurePanelStyles = tv({
@@ -42,7 +42,7 @@ export function Disclosure({
 }: DisclosureProps) {
   return (
     <AriaDisclosure className={twMerge("group", className)} {...props}>
-      <Header className="flex items-center gap-1 w-full">
+      <Header className="flex items-start gap-1 w-full">
         <AriaButton
           className={composeRenderProps(className, (className, renderProps) =>
             disclosureTriggerStyles({

--- a/src/components/common/Disclosure/Disclosure.tsx
+++ b/src/components/common/Disclosure/Disclosure.tsx
@@ -52,7 +52,7 @@ export function Disclosure({
           )}
           slot="trigger"
         >
-          {title}
+          <span className="my-0.5">{title}</span>
           <ChevronDown
             size={20}
             className={twMerge(

--- a/src/components/common/Disclosure/Disclosure.tsx
+++ b/src/components/common/Disclosure/Disclosure.tsx
@@ -26,7 +26,7 @@ export interface DisclosureProps
 
 const disclosureTriggerStyles = tv({
   extend: focusRing,
-  base: "group flex-1 flex rounded-lg transition-colors text-gray-dim hover:text-gray-normal justify-between items-center h-10 text-lg font-medium",
+  base: "group flex-1 flex rounded-lg transition-colors text-gray-dim hover:text-gray-normal justify-between items-center min-h-10 text-lg font-medium text-left",
 });
 
 const disclosurePanelStyles = tv({
@@ -57,7 +57,7 @@ export function Disclosure({
             size={20}
             className={twMerge(
               "group-hover:bg-graya-3 dark:group-hover:bg-graydarka-3 group-hover:text-gray-normal rounded-full size-8 p-1.5",
-              "transition-transform opacity-60",
+              "transition-transform opacity-60 shrink-0 ml-2",
               "group-data-[expanded]:rotate-180",
             )}
           />

--- a/src/components/common/Disclosure/Disclosure.tsx
+++ b/src/components/common/Disclosure/Disclosure.tsx
@@ -62,7 +62,7 @@ export function Disclosure({
             )}
           />
         </AriaButton>
-        {actions}
+        {actions && <div className="shrink-0 mt-2">{actions}</div>}
       </Header>
       <AnimateChangeInHeight className="w-full">
         <AriaDisclosurePanel className={disclosurePanelStyles()}>


### PR DESCRIPTION
## What changed?

* Adjusted disclouse from height 10 to min-height 10
* Added `text-left` to align the button’s text to the left
* Added `shrink-0 ml-2` to the caret to prevent shrinking and make sure there’s always some space in the layout between the text and the disclousure arrow
* Top aligns controls with the question title

| Before | After  |
|--------|--------|
| ![Before Image](https://github.com/user-attachments/assets/7e3b4bf5-8c90-4571-9f97-432a70c0ae71) |   ![CleanShot 2025-02-09 at 16 07 53@2x](https://github.com/user-attachments/assets/308eb7e0-004b-487c-8a49-bb7eccdc86e5)  |


Fixes https://github.com/namesakefyi/namesake/issues/378.

## Why?
This fixes layout bugs with longer questions.

## How was this change made?
This is my first commit on the project, so I wanted something very localized and not dangerous. I started with a `span` around the title, but then tried just adding `text-left` to the `disclosureTriggerStyles` and that seemed nicer.

## How was this tested?
I reproduced the bug with Lorem Ipsum text for long questions and answers, and tested the fix by scaling my browser text size up and down to make sure the layout remained legible.

## Anything else?
