### PR TITLE
fix: Show red border when Field is invalid

### DIFF
--- a/.changeset/pretty-balloons-yell.md
+++ b/.changeset/pretty-balloons-yell.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix error borders for invalid fields

--- a/src/components/common/ComboBox/ComboBox.tsx
+++ b/src/components/common/ComboBox/ComboBox.tsx
@@ -45,25 +45,29 @@ export function ComboBox<T extends object>({
         "group flex flex-col gap-1",
       )}
     >
-      <Label>{label}</Label>
-      <FieldGroup>
-        <Input />
-        <Button
-          variant="icon"
-          className="w-7 h-7 p-0 mr-1 outline-offset-0"
-          icon={ChevronDown}
-        />
-      </FieldGroup>
-      {description && <FieldDescription>{description}</FieldDescription>}
-      <FieldError>{errorMessage}</FieldError>
-      <Popover title="Select an option" className="w-[--trigger-width]">
-        <ListBox
-          items={items}
-          className="outline-0 p-1 max-h-[inherit] overflow-auto [clip-path:inset(0_0_0_0_round_.75rem)]"
-        >
-          {children}
-        </ListBox>
-      </Popover>
+      {(renderProps) => (
+        <>
+          <Label>{label}</Label>
+          <FieldGroup {...renderProps}>
+            <Input />
+            <Button
+              variant="icon"
+              className="w-7 h-7 p-0 mr-1 outline-offset-0"
+              icon={ChevronDown}
+            />
+          </FieldGroup>
+          {description && <FieldDescription>{description}</FieldDescription>}
+          <FieldError>{errorMessage}</FieldError>
+          <Popover title="Select an option" className="w-[--trigger-width]">
+            <ListBox
+              items={items}
+              className="outline-0 p-1 max-h-[inherit] overflow-auto [clip-path:inset(0_0_0_0_round_.75rem)]"
+            >
+              {children}
+            </ListBox>
+          </Popover>
+        </>
+      )}
     </AriaComboBox>
   );
 }

--- a/src/components/common/DateField/DateField.tsx
+++ b/src/components/common/DateField/DateField.tsx
@@ -39,12 +39,16 @@ export function DateField<T extends DateValue>({
         "flex flex-col gap-1",
       )}
     >
-      {label && <Label size={size}>{label}</Label>}
-      <FieldGroup size={size}>
-        <DateInput size={size} />
-      </FieldGroup>
-      {description && <FieldDescription>{description}</FieldDescription>}
-      <FieldError>{errorMessage}</FieldError>
+      {(renderProps) => (
+        <>
+          {label && <Label size={size}>{label}</Label>}
+          <FieldGroup {...renderProps} size={size}>
+            <DateInput size={size} />
+          </FieldGroup>
+          {description && <FieldDescription>{description}</FieldDescription>}
+          <FieldError>{errorMessage}</FieldError>
+        </>
+      )}
     </AriaDateField>
   );
 }

--- a/src/components/common/DatePicker/DatePicker.tsx
+++ b/src/components/common/DatePicker/DatePicker.tsx
@@ -38,21 +38,25 @@ export function DatePicker<T extends DateValue>({
         "group flex flex-col gap-1",
       )}
     >
-      {label && <Label>{label}</Label>}
-      <FieldGroup className="min-w-[208px] w-auto">
-        <DateInput className="flex-1 min-w-[150px] px-3 py-2" />
-        <Button
-          variant="icon"
-          className="w-7 h-7 p-0 mr-1 outline-offset-0"
-          icon={CalendarIcon}
-          aria-label="Open date picker"
-        />
-      </FieldGroup>
-      {description && <FieldDescription>{description}</FieldDescription>}
-      <FieldError>{errorMessage}</FieldError>
-      <Popover title="Select a date">
-        <Calendar />
-      </Popover>
+      {(renderProps) => (
+        <>
+          {label && <Label>{label}</Label>}
+          <FieldGroup {...renderProps} className="min-w-[208px] w-auto">
+            <DateInput className="flex-1 min-w-[150px] px-3 py-2" />
+            <Button
+              variant="icon"
+              className="w-7 h-7 p-0 mr-1 outline-offset-0"
+              icon={CalendarIcon}
+              aria-label="Open date picker"
+            />
+          </FieldGroup>
+          {description && <FieldDescription>{description}</FieldDescription>}
+          <FieldError>{errorMessage}</FieldError>
+          <Popover title="Select a date">
+            <Calendar />
+          </Popover>
+        </>
+      )}
     </AriaDatePicker>
   );
 }

--- a/src/components/common/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/common/DateRangePicker/DateRangePicker.tsx
@@ -38,28 +38,32 @@ export function DateRangePicker<T extends DateValue>({
         "group flex flex-col gap-1",
       )}
     >
-      {label && <Label>{label}</Label>}
-      <FieldGroup className="min-w-[208px] w-auto">
-        <DateInput slot="start" className="px-3 py-2" />
-        <span
-          aria-hidden="true"
-          className="text-gray-10 dark:text-gray-2 forced-colors:text-[ButtonText] group-disabled:text-gray-2 group-disabled:dark:text-gray-6 group-disabled:forced-colors:text-[GrayText]"
-        >
-          –
-        </span>
-        <DateInput slot="end" className="flex-1 px-3 py-2" />
-        <Button
-          variant="icon"
-          className="w-7 h-7 p-0 mr-1 outline-offset-0"
-          icon={CalendarIcon}
-          aria-label="Open date picker"
-        />
-      </FieldGroup>
-      {description && <FieldDescription>{description}</FieldDescription>}
-      <FieldError>{errorMessage}</FieldError>
-      <Popover title="Select a date range">
-        <RangeCalendar />
-      </Popover>
+      {(renderProps) => (
+        <>
+          {label && <Label>{label}</Label>}
+          <FieldGroup {...renderProps} className="min-w-[208px] w-auto">
+            <DateInput slot="start" className="px-3 py-2" />
+            <span
+              aria-hidden="true"
+              className="text-gray-10 dark:text-gray-2 forced-colors:text-[ButtonText] group-disabled:text-gray-2 group-disabled:dark:text-gray-6 group-disabled:forced-colors:text-[GrayText]"
+            >
+              –
+            </span>
+            <DateInput slot="end" className="flex-1 px-3 py-2" />
+            <Button
+              variant="icon"
+              className="w-7 h-7 p-0 mr-1 outline-offset-0"
+              icon={CalendarIcon}
+              aria-label="Open date picker"
+            />
+          </FieldGroup>
+          {description && <FieldDescription>{description}</FieldDescription>}
+          <FieldError>{errorMessage}</FieldError>
+          <Popover title="Select a date range">
+            <RangeCalendar />
+          </Popover>
+        </>
+      )}
     </AriaDateRangePicker>
   );
 }

--- a/src/components/common/NumberField/NumberField.tsx
+++ b/src/components/common/NumberField/NumberField.tsx
@@ -38,40 +38,44 @@ export function NumberField({
         "group flex flex-col gap-1.5",
       )}
     >
-      {label && <Label>{label}</Label>}
-      <FieldGroup>
-        {(renderProps) => (
-          <>
-            {prefix && (
-              <span className="text-gray-9 dark:text-graydark-9 ml-2 -mr-2">
-                {prefix}
-              </span>
+      {(renderProps) => (
+        <>
+          {label && <Label>{label}</Label>}
+          <FieldGroup {...renderProps}>
+            {(renderProps) => (
+              <>
+                {prefix && (
+                  <span className="text-gray-9 dark:text-graydark-9 ml-2 -mr-2">
+                    {prefix}
+                  </span>
+                )}
+                <Input />
+                <div
+                  className={innerBorderStyles({
+                    ...renderProps,
+                    class: "flex flex-col border-s h-10",
+                  })}
+                >
+                  <StepperButton slot="increment">
+                    <ChevronUp aria-hidden className="w-4 h-4" />
+                  </StepperButton>
+                  <div
+                    className={innerBorderStyles({
+                      ...renderProps,
+                      class: "border-b",
+                    })}
+                  />
+                  <StepperButton slot="decrement">
+                    <ChevronDown aria-hidden className="w-4 h-4" />
+                  </StepperButton>
+                </div>
+              </>
             )}
-            <Input />
-            <div
-              className={innerBorderStyles({
-                ...renderProps,
-                class: "flex flex-col border-s h-10",
-              })}
-            >
-              <StepperButton slot="increment">
-                <ChevronUp aria-hidden className="w-4 h-4" />
-              </StepperButton>
-              <div
-                className={innerBorderStyles({
-                  ...renderProps,
-                  class: "border-b",
-                })}
-              />
-              <StepperButton slot="decrement">
-                <ChevronDown aria-hidden className="w-4 h-4" />
-              </StepperButton>
-            </div>
-          </>
-        )}
-      </FieldGroup>
-      {description && <FieldDescription>{description}</FieldDescription>}
-      <FieldError>{errorMessage}</FieldError>
+          </FieldGroup>
+          {description && <FieldDescription>{description}</FieldDescription>}
+          <FieldError>{errorMessage}</FieldError>
+        </>
+      )}
     </AriaNumberField>
   );
 }

--- a/src/components/common/SearchField/SearchField.tsx
+++ b/src/components/common/SearchField/SearchField.tsx
@@ -36,26 +36,30 @@ export function SearchField({
         "group flex flex-col gap-1 min-w-[40px]",
       )}
     >
-      {label && <Label>{label}</Label>}
-      <FieldGroup>
-        <Search
-          aria-hidden
-          className="w-4 h-4 ml-3 text-gray-dim forced-colors:text-[ButtonText] group-disabled:opacity-50 forced-colors:group-disabled:text-[GrayText]"
-        />
-        <Input
-          placeholder={placeholder}
-          className="[&::-webkit-search-cancel-button]:hidden"
-        />
-        <Button
-          variant="icon"
-          className="mr-1 w-7 h-7 p-0 group-empty:invisible"
-          size="small"
-          icon={CircleX}
-          aria-label="Clear search"
-        />
-      </FieldGroup>
-      {description && <FieldDescription>{description}</FieldDescription>}
-      <FieldError>{errorMessage}</FieldError>
+      {(renderProps) => (
+        <>
+          {label && <Label>{label}</Label>}
+          <FieldGroup {...renderProps}>
+            <Search
+              aria-hidden
+              className="w-4 h-4 ml-3 text-gray-dim forced-colors:text-[ButtonText] group-disabled:opacity-50 forced-colors:group-disabled:text-[GrayText]"
+            />
+            <Input
+              placeholder={placeholder}
+              className="[&::-webkit-search-cancel-button]:hidden"
+            />
+            <Button
+              variant="icon"
+              className="mr-1 w-7 h-7 p-0 group-empty:invisible"
+              size="small"
+              icon={CircleX}
+              aria-label="Clear search"
+            />
+          </FieldGroup>
+          {description && <FieldDescription>{description}</FieldDescription>}
+          <FieldError>{errorMessage}</FieldError>
+        </>
+      )}
     </AriaSearchField>
   );
 }

--- a/src/components/common/TextArea/TextArea.tsx
+++ b/src/components/common/TextArea/TextArea.tsx
@@ -34,12 +34,16 @@ export function TextArea({
         "flex flex-col gap-1.5",
       )}
     >
-      {label && <Label size={size}>{label}</Label>}
-      <FieldGroup size={size}>
-        <InputTextArea size={size} />
-      </FieldGroup>
-      {description && <FieldDescription>{description}</FieldDescription>}
-      <FieldError>{errorMessage}</FieldError>
+      {(renderProps) => (
+        <>
+          {label && <Label size={size}>{label}</Label>}
+          <FieldGroup {...renderProps} size={size}>
+            <InputTextArea size={size} />
+          </FieldGroup>
+          {description && <FieldDescription>{description}</FieldDescription>}
+          <FieldError>{errorMessage}</FieldError>
+        </>
+      )}
     </AriaTextField>
   );
 }

--- a/src/components/common/TextField/TextField.tsx
+++ b/src/components/common/TextField/TextField.tsx
@@ -56,38 +56,42 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         )}
         type={type === "password" && isPasswordVisible ? "text" : type}
       >
-        {label && <Label size={size}>{label}</Label>}
-        <FieldGroup size={size}>
-          {prefix}
-          <Input
-            className={twMerge(
-              type === "password" && "font-mono",
-              type === "tel" && "tabular-nums",
-            )}
-            size={size}
-            placeholder={placeholder}
-          />
-          {suffix}
-          {type === "password" && (
-            <TooltipTrigger>
-              <Button
-                variant="icon"
-                aria-label={
-                  isPasswordVisible ? "Hide password" : "Show password"
-                }
-                onPress={() => setIsPasswordVisible(!isPasswordVisible)}
-                size="small"
-                icon={isPasswordVisible ? Eye : EyeOff}
-                className="mr-1"
+        {(textFieldRenderProps) => (
+          <>
+            {label && <Label size={size}>{label}</Label>}
+            <FieldGroup {...textFieldRenderProps} size={size}>
+              {prefix}
+              <Input
+                className={twMerge(
+                  type === "password" && "font-mono",
+                  type === "tel" && "tabular-nums",
+                )}
+                size={size}
+                placeholder={placeholder}
               />
-              <Tooltip>
-                {isPasswordVisible ? "Hide password" : "Show password"}
-              </Tooltip>
-            </TooltipTrigger>
-          )}
-        </FieldGroup>
-        {description && <FieldDescription>{description}</FieldDescription>}
-        <FieldError>{errorMessage}</FieldError>
+              {suffix}
+              {type === "password" && (
+                <TooltipTrigger>
+                  <Button
+                    variant="icon"
+                    aria-label={
+                      isPasswordVisible ? "Hide password" : "Show password"
+                    }
+                    onPress={() => setIsPasswordVisible(!isPasswordVisible)}
+                    size="small"
+                    icon={isPasswordVisible ? Eye : EyeOff}
+                    className="mr-1"
+                  />
+                  <Tooltip>
+                    {isPasswordVisible ? "Hide password" : "Show password"}
+                  </Tooltip>
+                </TooltipTrigger>
+              )}
+            </FieldGroup>
+            {description && <FieldDescription>{description}</FieldDescription>}
+            <FieldError>{errorMessage}</FieldError>
+          </>
+        )}
       </AriaTextField>
     );
   },

--- a/src/components/common/TextField/TextField.tsx
+++ b/src/components/common/TextField/TextField.tsx
@@ -56,10 +56,10 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         )}
         type={type === "password" && isPasswordVisible ? "text" : type}
       >
-        {(textFieldRenderProps) => (
+        {(renderProps) => (
           <>
             {label && <Label size={size}>{label}</Label>}
-            <FieldGroup {...textFieldRenderProps} size={size}>
+            <FieldGroup {...renderProps} size={size}>
               {prefix}
               <Input
                 className={twMerge(

--- a/src/components/common/TimeField/TimeField.tsx
+++ b/src/components/common/TimeField/TimeField.tsx
@@ -34,12 +34,16 @@ export function TimeField<T extends TimeValue>({
         "flex flex-col gap-1",
       )}
     >
-      {label && <Label>{label}</Label>}
-      <FieldGroup>
-        <DateInput />
-      </FieldGroup>
-      {description && <FieldDescription>{description}</FieldDescription>}
-      <FieldError>{errorMessage}</FieldError>
+      {(renderProps) => (
+        <>
+          {label && <Label>{label}</Label>}
+          <FieldGroup {...renderProps}>
+            <DateInput />
+          </FieldGroup>
+          {description && <FieldDescription>{description}</FieldDescription>}
+          <FieldError>{errorMessage}</FieldError>
+        </>
+      )}
     </AriaTimeField>
   );
 }


### PR DESCRIPTION
## What changed?
Invalid fields will now be styled with the red border defined in `fieldBorderStyles.variants.isInvalid`. This should fix #244.

## Why?
By default, a React Aria `<Group>` component doesn't receive the context/render props of it's parent Field component. Because of this, our `fieldBorderStyles.variants.isInvalid` classes were never applied. To ensure the `<Group>` receives the render props we have to use a [render prop function](https://react-spectrum.adobe.com/react-aria/styling.html#render-props) at the root of the parent:

```tsx
<TextField>
  {(renderProps) => (
    <>
      <Group {...renderProps}>
        {/* ... */}
      </Group>
    </>
  )}
</TextField>
```

## How was this change made?
Each Field component (`TextField`, `SearchField`, etc) that uses a `<FieldGroup>` has been updated to use a render prop function that passes `{...renderProps}` to the `<FieldGroup>`.

## How was this tested?
Mostly by spamming `/signin`, but also clicking around after running `pnpm storybook`.

## Anything else?
Perhaps not all of these Field components need this? What's the best way to test/determine this?