### PR TITLE
chore: Set up migrations

### DIFF
--- a/.changeset/good-jobs-switch.md
+++ b/.changeset/good-jobs-switch.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Set up migrations for future database updates

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,11 +8,6 @@
  * @module
  */
 
-import type {
-  ApiFromModules,
-  FilterApi,
-  FunctionReference,
-} from "convex/server";
 import type * as auth from "../auth.js";
 import type * as constants from "../constants.js";
 import type * as documents from "../documents.js";
@@ -20,6 +15,7 @@ import type * as earlyAccessCodes from "../earlyAccessCodes.js";
 import type * as errors from "../errors.js";
 import type * as helpers from "../helpers.js";
 import type * as http from "../http.js";
+import type * as migrations from "../migrations.js";
 import type * as passwordReset from "../passwordReset.js";
 import type * as questFaqs from "../questFaqs.js";
 import type * as questSteps from "../questSteps.js";
@@ -31,6 +27,11 @@ import type * as userSettings from "../userSettings.js";
 import type * as users from "../users.js";
 import type * as validators from "../validators.js";
 
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
 /**
  * A utility for referencing Convex functions in your app's API.
  *
@@ -47,6 +48,7 @@ declare const fullApi: ApiFromModules<{
   errors: typeof errors;
   helpers: typeof helpers;
   http: typeof http;
+  migrations: typeof migrations;
   passwordReset: typeof passwordReset;
   questFaqs: typeof questFaqs;
   questSteps: typeof questSteps;
@@ -58,11 +60,178 @@ declare const fullApi: ApiFromModules<{
   users: typeof users;
   validators: typeof validators;
 }>;
+declare const fullApiWithMounts: typeof fullApi;
+
 export declare const api: FilterApi<
-  typeof fullApi,
+  typeof fullApiWithMounts,
   FunctionReference<any, "public">
 >;
 export declare const internal: FilterApi<
-  typeof fullApi,
+  typeof fullApiWithMounts,
   FunctionReference<any, "internal">
 >;
+
+export declare const components: {
+  migrations: {
+    lib: {
+      cancel: FunctionReference<
+        "mutation",
+        "internal",
+        { name: string },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
+      cancelAll: FunctionReference<
+        "mutation",
+        "internal",
+        { sinceTs?: number },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      clearAll: FunctionReference<
+        "mutation",
+        "internal",
+        { before?: number },
+        null
+      >;
+      getStatus: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; names?: Array<string> },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      migrate: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          dryRun: boolean;
+          fnHandle: string;
+          name: string;
+          next?: Array<{ fnHandle: string; name: string }>;
+        },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
+    };
+    public: {
+      cancel: FunctionReference<
+        "mutation",
+        "internal",
+        { name: string },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
+      cancelAll: FunctionReference<
+        "mutation",
+        "internal",
+        { sinceTs?: number },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      getStatus: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; migrationNames?: Array<string> },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      runMigration: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          dryRun: boolean;
+          fnHandle: string;
+          name: string;
+          next?: Array<{ fnHandle: string; name: string }>;
+        },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
+    };
+  };
+};

--- a/convex/_generated/api.js
+++ b/convex/_generated/api.js
@@ -8,7 +8,7 @@
  * @module
  */
 
-import { anyApi } from "convex/server";
+import { anyApi, componentsGeneric } from "convex/server";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -20,3 +20,4 @@ import { anyApi } from "convex/server";
  */
 export const api = anyApi;
 export const internal = anyApi;
+export const components = componentsGeneric();

--- a/convex/_generated/server.d.ts
+++ b/convex/_generated/server.d.ts
@@ -10,6 +10,7 @@
 
 import {
   ActionBuilder,
+  AnyComponents,
   HttpActionBuilder,
   MutationBuilder,
   QueryBuilder,
@@ -18,8 +19,14 @@ import {
   GenericQueryCtx,
   GenericDatabaseReader,
   GenericDatabaseWriter,
+  FunctionReference,
 } from "convex/server";
 import type { DataModel } from "./dataModel.js";
+
+type GenericCtx =
+  | GenericActionCtx<DataModel>
+  | GenericMutationCtx<DataModel>
+  | GenericQueryCtx<DataModel>;
 
 /**
  * Define a query in this Convex app's public API.

--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -16,6 +16,7 @@ import {
   internalActionGeneric,
   internalMutationGeneric,
   internalQueryGeneric,
+  componentsGeneric,
 } from "convex/server";
 
 /**

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,0 +1,7 @@
+import migrations from "@convex-dev/migrations/convex.config";
+import { defineApp } from "convex/server";
+
+const app = defineApp();
+app.use(migrations);
+
+export default app;

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,0 +1,6 @@
+import { Migrations } from "@convex-dev/migrations";
+import { components } from "./_generated/api.js";
+import type { DataModel } from "./_generated/dataModel.js";
+
+export const migrations = new Migrations<DataModel>(components.migrations);
+export const run = migrations.runner();

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -212,5 +212,4 @@ export default defineSchema({
   userFormData,
   userSettings,
   userQuests,
-  migrations: defineTable({}),
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -212,4 +212,5 @@ export default defineSchema({
   userFormData,
   userSettings,
   userQuests,
+  migrations: defineTable({}),
 });

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@auth/core": "0.37.4",
     "@convex-dev/auth": "^0.0.80",
+    "@convex-dev/migrations": "^0.2.5",
     "@faker-js/faker": "^9.5.0",
     "@maskito/core": "^3.2.1",
     "@maskito/react": "^3.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@convex-dev/auth':
         specifier: ^0.0.80
         version: 0.0.80(@auth/core@0.37.4)(convex@1.19.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      '@convex-dev/migrations':
+        specifier: ^0.2.5
+        version: 0.2.5(convex@1.19.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@faker-js/faker':
         specifier: ^9.5.0
         version: 9.5.0
@@ -580,6 +583,11 @@ packages:
     peerDependenciesMeta:
       react:
         optional: true
+
+  '@convex-dev/migrations@0.2.5':
+    resolution: {integrity: sha512-qxIVTaIatOt4WbKygUZ1Wuu3e0EJ/hSxZVl5jrGCiLPlUjIQ9MpfstQquQmbcHtJOGkzt+CcVoJsISGXPciS/g==}
+    peerDependencies:
+      convex: ~1.16.5 || >=1.17.0 <1.25.0
 
   '@csstools/color-helpers@5.0.1':
     resolution: {integrity: sha512-MKtmkA0BX87PKaO1NFRTFH+UnkgnmySQOvNxJubsadusqPEC2aJ9MOQiMceZJJ6oitUl/i0L6u0M1IrmAOmgBA==}
@@ -5386,6 +5394,10 @@ snapshots:
       server-only: 0.0.1
     optionalDependencies:
       react: 19.0.0
+
+  '@convex-dev/migrations@0.2.5(convex@1.19.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+    dependencies:
+      convex: 1.19.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
   '@csstools/color-helpers@5.0.1': {}
 


### PR DESCRIPTION
## What changed?

- [x] Adds [Migrations Component](https://www.convex.dev/components/migrations) to handle stateful migrations.
- [x] Writes boilerplate `migrations.ts` and `convex.config.ts` to allow us to run migrations in a follow up PR.
- [x] Runs `pnpm dev` to regenerate models and saw migrations API created.

Fixes #71.

## Why?
We want the ability to migrate data in development and production to support future database changes inclduing #393.

## How was this change made?

- [x] Added the migrations package
- [x] Followd the steps in the [README](https://github.com/get-convex/migrations) up to the point of actually creating a migration

## How was this tested?

- [x] Ran tests
- [x] Smoke tested the app