### PR TITLE
fix: `RichText` should not display focus ring when non-editable

### DIFF
--- a/.changeset/wild-jeans-raise.md
+++ b/.changeset/wild-jeans-raise.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix a bug where a focus ring would display on non-editable rich text fields

--- a/src/components/common/RichText/RichText.tsx
+++ b/src/components/common/RichText/RichText.tsx
@@ -94,7 +94,7 @@ export function RichText({
     variants: {
       editable: {
         true: "px-3.5 py-3 [&_.tiptap]:outline-none",
-        false: "ring-0 rounded-none bg-transparent",
+        false: "ring-0 rounded-none bg-transparent focus-within:!outline-none",
       },
     },
   });


### PR DESCRIPTION
## What changed?
Do not display a focus ring on `RichText` component when the component is not editable. Resolves #353 

| Before | After |
|--------|--------|
| ![CleanShot 2025-02-13 at 17 16 38@2x](https://github.com/user-attachments/assets/155f0f88-160c-4747-9508-c38a1ae2aace) | ![CleanShot 2025-02-13 at 17 15 51@2x](https://github.com/user-attachments/assets/bd4b547d-857c-4282-aeeb-5467dfc66d5d) | 

## Why?
A focus ring should only display for the text area when it's in an editable state.

## How was this change made?
Apply `focus-within` styles.

## How was this tested?
Visual testing.