### PR TITLE
chore: Do not run RelativeCI workflow on pull requests

### DIFF
--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -3,8 +3,7 @@ name: Bundle Size
 on: 
   push:
     branches: main
-  pull_request:
-    branches: main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## What changed?
Only run the RelativeCI workflow when code is merged into `main` or when the workflow is run manually. Do not run the workflow on pull requests.

## Why?
Bundle size reporting is [failing](https://github.com/namesakefyi/namesake/actions/runs/13792430087/job/38575595610) on PRs like #403 from external contributors because GitHub does not make the API key for the workflow available.

## How was this change made?
Updated the workflow.

## How was this tested?
N/A