### PR TITLE
chore: Add script to delete all dev data

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "npm-run-all --parallel dev:frontend dev:backend",
     "dev:frontend": "vite",
     "dev:backend": "convex dev",
+    "dev:erase": "bash scripts/eraseDevData.sh",
     "build": "tsc -b && vite build",
     "lint": "biome lint",
     "lint:fix": "biome lint --write",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "npm-run-all --parallel dev:frontend dev:backend",
     "dev:frontend": "vite",
     "dev:backend": "convex dev",
-    "dev:erase": "bash scripts/eraseDevData.sh",
+    "dev:delete": "bash scripts/deleteConvexTables.sh",
     "build": "tsc -b && vite build",
     "lint": "biome lint",
     "lint:fix": "biome lint --write",

--- a/scripts/deleteConvexTables.sh
+++ b/scripts/deleteConvexTables.sh
@@ -1,1 +1,2 @@
+# https://stack.convex.dev/yolo-fast-mvp#delete-dev-data-liberally-and-maintain-a-seed-script-to-re-initialize
 for tableName in `npx convex data`; do npx convex import --table $tableName --replace -y --format jsonLines /dev/null; done

--- a/scripts/eraseDevData.sh
+++ b/scripts/eraseDevData.sh
@@ -1,0 +1,1 @@
+for tableName in `npx convex data`; do npx convex import --table $tableName --replace -y --format jsonLines /dev/null; done


### PR DESCRIPTION
## What changed?
Add a new `pnpm dev:delete` script which will erase all Convex tables locally.

## Why?
When migrations occur, local dev data can get out of sync with production. Rather than attempt to set up migrations, it can be helpful to just delete and re-seed the dev database. See [YOLO: Get to an MVP fast](https://stack.convex.dev/yolo-fast-mvp#delete-dev-data-liberally-and-maintain-a-seed-script-to-re-initialize) and [Discord](https://discord.com/channels/1019350475847499849/1349141814703034508/1349145489970565162)

## How was this change made?
Added a new script to erase all Convex tables; added a new command that can be run from the CLI.

## How was this tested?
Ran it locally and it deleted everything!

## Anything else?
We should follow up with improvements to our `seed.ts` script that insert more data into the dev database. I updated #410 to move it onto the v1.0 board. It's not strictly necessary, definitely toward the bottom of the stack, but worth working on!