### PR TITLE
fix: Fix theme switcher submenu

### DIFF
--- a/.changeset/poor-zoos-dance.md
+++ b/.changeset/poor-zoos-dance.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix theme switcher submenu

--- a/src/components/app/AppSidebar/AppSidebar.tsx
+++ b/src/components/app/AppSidebar/AppSidebar.tsx
@@ -7,7 +7,6 @@ import {
   MenuItem,
   MenuSeparator,
   MenuTrigger,
-  Popover,
   SubmenuTrigger,
 } from "@/components/common";
 import { useTheme } from "@/utils/useTheme";
@@ -69,20 +68,18 @@ export const AppSidebar = ({ children }: AppSidebarProps) => {
                     {THEMES[theme as Theme].label}
                   </span>
                 </MenuItem>
-                <Popover title="Select a theme">
-                  <Menu
-                    disallowEmptySelection
-                    selectionMode="single"
-                    selectedKeys={themeSelection}
-                    onSelectionChange={setTheme}
-                  >
-                    {Object.entries(THEMES).map(([theme, details]) => (
-                      <MenuItem key={theme} id={theme} icon={details.icon}>
-                        {details.label}
-                      </MenuItem>
-                    ))}
-                  </Menu>
-                </Popover>
+                <Menu
+                  disallowEmptySelection
+                  selectionMode="single"
+                  selectedKeys={themeSelection}
+                  onSelectionChange={setTheme}
+                >
+                  {Object.entries(THEMES).map(([theme, details]) => (
+                    <MenuItem key={theme} id={theme} icon={details.icon}>
+                      {details.label}
+                    </MenuItem>
+                  ))}
+                </Menu>
               </SubmenuTrigger>
               <MenuSeparator />
               <MenuItem icon={LogOut} onAction={handleSignOut}>

--- a/src/components/app/AppSidebar/AppSidebar.tsx
+++ b/src/components/app/AppSidebar/AppSidebar.tsx
@@ -47,11 +47,9 @@ export const AppSidebar = ({ children }: AppSidebarProps) => {
           <MenuTrigger>
             <Button
               aria-label="User settings"
-              variant="ghost"
+              variant="icon"
               icon={CircleUser}
-            >
-              <span className="truncate max-w-[16ch]">{user?.name}</span>
-            </Button>
+            />
             <Menu placement="top start">
               {isAdmin && (
                 <MenuItem icon={GlobeLock} href={{ to: "/admin" }}>

--- a/src/components/common/Menu/Menu.stories.tsx
+++ b/src/components/common/Menu/Menu.stories.tsx
@@ -5,7 +5,6 @@ import {
   MenuSection,
   MenuSeparator,
   MenuTrigger,
-  Popover,
   SubmenuTrigger,
 } from "@/components/common";
 import type { Meta } from "@storybook/react";
@@ -64,32 +63,26 @@ export const Submenu = (args: any) => (
       <MenuItem id="new">New…</MenuItem>
       <SubmenuTrigger>
         <MenuItem id="open">Open</MenuItem>
-        <Popover title="Open in">
-          <Menu>
-            <MenuItem id="open-new">Open in New Window</MenuItem>
-            <MenuItem id="open-current">Open in Current Window</MenuItem>
-          </Menu>
-        </Popover>
+        <Menu>
+          <MenuItem id="open-new">Open in New Window</MenuItem>
+          <MenuItem id="open-current">Open in Current Window</MenuItem>
+        </Menu>
       </SubmenuTrigger>
       <MenuSeparator />
       <MenuItem id="print">Print…</MenuItem>
       <SubmenuTrigger>
         <MenuItem id="share">Share</MenuItem>
-        <Popover title="Share">
-          <Menu>
-            <MenuItem id="sms">SMS</MenuItem>
-            <MenuItem id="twitter">Twitter</MenuItem>
-            <SubmenuTrigger>
-              <MenuItem id="email">Email</MenuItem>
-              <Popover title="Email">
-                <Menu>
-                  <MenuItem id="work">Work</MenuItem>
-                  <MenuItem id="personal">Personal</MenuItem>
-                </Menu>
-              </Popover>
-            </SubmenuTrigger>
-          </Menu>
-        </Popover>
+        <Menu>
+          <MenuItem id="sms">SMS</MenuItem>
+          <MenuItem id="twitter">Twitter</MenuItem>
+          <SubmenuTrigger>
+            <MenuItem id="email">Email</MenuItem>
+            <Menu>
+              <MenuItem id="work">Work</MenuItem>
+              <MenuItem id="personal">Personal</MenuItem>
+            </Menu>
+          </SubmenuTrigger>
+        </Menu>
       </SubmenuTrigger>
     </Menu>
   </MenuTrigger>


### PR DESCRIPTION
## What changed?
Fix the theme switcher submenu. Fixes #429.

https://github.com/user-attachments/assets/de0b94fd-2a55-4a0a-9d6f-e2a8f5915c5f

## Why?
The [March 5 release of React Aria](https://react-spectrum.adobe.com/releases/2025-03-05.html) changed how `Popover` works inside `Menu` and negated the need to manually supply a `Popover` when using `SubmenuTrigger`.

## How was this change made?
This PR removes the nested `Popover` components within `Menu`, fixing the bug.

## How was this tested?
Tested manually in the app and in Storybook.

## Anything else?
Removes the inline user display name from `AppSidebar` in favor of an icon-only menu toggle. This improves the appearance when no name is displayed.

| Before | After |
|--------|--------|
| ![CleanShot 2025-03-14 at 16 30 54@2x](https://github.com/user-attachments/assets/e52f4c3f-60bb-436d-9091-a3c9f3e4a651) | ![CleanShot 2025-03-14 at 16 30 14@2x](https://github.com/user-attachments/assets/73ff7aac-f933-422b-8c2a-9f846d7380eb) | 