### PR TITLE
fix: Put Social Security before State ID

### DIFF
--- a/.changeset/sixty-ads-shave.md
+++ b/.changeset/sixty-ads-shave.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Reorder Social Security before State ID

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -174,14 +174,14 @@ export const CATEGORIES: Record<Category, GroupDetails> = {
     icon: Gavel,
     isCore: true,
   },
-  stateId: {
-    label: "State ID",
-    icon: IdCard,
-    isCore: true,
-  },
   socialSecurity: {
     label: "Social Security",
     icon: ShieldCheck,
+    isCore: true,
+  },
+  stateId: {
+    label: "State ID",
+    icon: IdCard,
     isCore: true,
   },
   passport: {

--- a/src/routes/_authenticated/_home.tsx
+++ b/src/routes/_authenticated/_home.tsx
@@ -38,15 +38,15 @@ function IndexRoute() {
         label: CATEGORIES.courtOrder.label,
         icon: CATEGORIES.courtOrder.icon,
       },
-      stateId: {
-        to: "state-id",
-        label: CATEGORIES.stateId.label,
-        icon: CATEGORIES.stateId.icon,
-      },
       socialSecurity: {
         to: "social-security",
         label: CATEGORIES.socialSecurity.label,
         icon: CATEGORIES.socialSecurity.icon,
+      },
+      stateId: {
+        to: "state-id",
+        label: CATEGORIES.stateId.label,
+        icon: CATEGORIES.stateId.icon,
       },
       passport: {
         to: "passport",


### PR DESCRIPTION
## What changed?
Reorder the list of core quests to put Social Security before State ID. Fixes #435 

## Why?
It's generally recommended to update Social Security after Court Order before moving onto other items, since State ID, Driver's License, Passport, etc. will reference with the Social Security Administration to confirm a name change.

## How was this change made?
Reordered objects.

## How was this tested?
Manually tested and confirmed ordering in dev.

![CleanShot 2025-03-14 at 16 43 38@2x](https://github.com/user-attachments/assets/4e81b3e4-9585-492c-865a-dbb09beb45ce)