### PR TITLE
fix: Unknown `isReadOnly` prop and other React console errors

### DIFF
--- a/.changeset/green-ends-invent.md
+++ b/.changeset/green-ends-invent.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix React console errors about invalid props

--- a/src/components/common/DateField/DateField.tsx
+++ b/src/components/common/DateField/DateField.tsx
@@ -39,10 +39,10 @@ export function DateField<T extends DateValue>({
         "flex flex-col gap-1",
       )}
     >
-      {(renderProps) => (
+      {({ isDisabled, isInvalid }) => (
         <>
           {label && <Label size={size}>{label}</Label>}
-          <FieldGroup {...renderProps} size={size}>
+          <FieldGroup isDisabled={isDisabled} isInvalid={isInvalid} size={size}>
             <DateInput size={size} />
           </FieldGroup>
           {description && <FieldDescription>{description}</FieldDescription>}

--- a/src/components/common/DatePicker/DatePicker.tsx
+++ b/src/components/common/DatePicker/DatePicker.tsx
@@ -38,10 +38,14 @@ export function DatePicker<T extends DateValue>({
         "group flex flex-col gap-1",
       )}
     >
-      {(renderProps) => (
+      {({ isDisabled, isInvalid }) => (
         <>
           {label && <Label>{label}</Label>}
-          <FieldGroup {...renderProps} className="min-w-[208px] w-auto">
+          <FieldGroup
+            isDisabled={isDisabled}
+            isInvalid={isInvalid}
+            className="min-w-[208px] w-auto"
+          >
             <DateInput className="flex-1 min-w-[150px] px-3 py-2" />
             <Button
               variant="icon"

--- a/src/components/common/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/common/DateRangePicker/DateRangePicker.tsx
@@ -38,10 +38,14 @@ export function DateRangePicker<T extends DateValue>({
         "group flex flex-col gap-1",
       )}
     >
-      {(renderProps) => (
+      {({ isDisabled, isInvalid }) => (
         <>
           {label && <Label>{label}</Label>}
-          <FieldGroup {...renderProps} className="min-w-[208px] w-auto">
+          <FieldGroup
+            isDisabled={isDisabled}
+            isInvalid={isInvalid}
+            className="min-w-[208px] w-auto"
+          >
             <DateInput slot="start" className="px-3 py-2" />
             <span
               aria-hidden="true"

--- a/src/components/common/NumberField/NumberField.tsx
+++ b/src/components/common/NumberField/NumberField.tsx
@@ -38,10 +38,10 @@ export function NumberField({
         "group flex flex-col gap-1.5",
       )}
     >
-      {(renderProps) => (
+      {({ isDisabled, isInvalid }) => (
         <>
           {label && <Label>{label}</Label>}
-          <FieldGroup {...renderProps}>
+          <FieldGroup isDisabled={isDisabled} isInvalid={isInvalid}>
             {(renderProps) => (
               <>
                 {prefix && (

--- a/src/components/common/SearchField/SearchField.tsx
+++ b/src/components/common/SearchField/SearchField.tsx
@@ -36,10 +36,10 @@ export function SearchField({
         "group flex flex-col gap-1 min-w-[40px]",
       )}
     >
-      {(renderProps) => (
+      {({ isDisabled, isInvalid }) => (
         <>
           {label && <Label>{label}</Label>}
-          <FieldGroup {...renderProps}>
+          <FieldGroup isDisabled={isDisabled} isInvalid={isInvalid}>
             <Search
               aria-hidden
               className="w-4 h-4 ml-3 text-gray-dim forced-colors:text-[ButtonText] group-disabled:opacity-50 forced-colors:group-disabled:text-[GrayText]"

--- a/src/components/common/TextArea/TextArea.tsx
+++ b/src/components/common/TextArea/TextArea.tsx
@@ -30,10 +30,14 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           "flex flex-col gap-1.5",
         )}
       >
-        {(renderProps) => (
+        {({ isDisabled, isInvalid }) => (
           <>
             {label && <Label size={size}>{label}</Label>}
-            <FieldGroup {...renderProps} size={size}>
+            <FieldGroup
+              isDisabled={isDisabled}
+              isInvalid={isInvalid}
+              size={size}
+            >
               <InputTextArea ref={ref} size={size} />
             </FieldGroup>
             {description && <FieldDescription>{description}</FieldDescription>}

--- a/src/components/common/TextField/TextField.tsx
+++ b/src/components/common/TextField/TextField.tsx
@@ -56,10 +56,14 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         )}
         type={type === "password" && isPasswordVisible ? "text" : type}
       >
-        {(renderProps) => (
+        {({ isDisabled, isInvalid }) => (
           <>
             {label && <Label size={size}>{label}</Label>}
-            <FieldGroup {...renderProps} size={size}>
+            <FieldGroup
+              isDisabled={isDisabled}
+              isInvalid={isInvalid}
+              size={size}
+            >
               {prefix}
               <Input
                 className={twMerge(

--- a/src/components/common/TimeField/TimeField.tsx
+++ b/src/components/common/TimeField/TimeField.tsx
@@ -34,10 +34,10 @@ export function TimeField<T extends TimeValue>({
         "flex flex-col gap-1",
       )}
     >
-      {(renderProps) => (
+      {({ isDisabled, isInvalid }) => (
         <>
           {label && <Label>{label}</Label>}
-          <FieldGroup {...renderProps}>
+          <FieldGroup isDisabled={isDisabled} isInvalid={isInvalid}>
             <DateInput />
           </FieldGroup>
           {description && <FieldDescription>{description}</FieldDescription>}


### PR DESCRIPTION
## What changed?
Fixes #430.

## How was this change made?
Destructure all `renderProps` that get passed into `FieldGroup` to only pass down supported props.

## How was this tested?
Opened all common components in Storybook to verify no console errors display. Ran `pnpm test` and verified no errors or warnings emit.