### PR TITLE
style: Remove focus ring if `FieldGroup` `:has([data-focus-visible])`

### DIFF
--- a/.changeset/spotty-taxes-serve.md
+++ b/.changeset/spotty-taxes-serve.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix duplicate focus rings

--- a/src/components/common/Field/Field.module.css
+++ b/src/components/common/Field/Field.module.css
@@ -1,0 +1,3 @@
+.field-group:has(button[data-focus-visible]) {
+  outline: none;
+}

--- a/src/components/common/Field/Field.module.css
+++ b/src/components/common/Field/Field.module.css
@@ -1,3 +1,0 @@
-.field-group:has(button[data-focus-visible]) {
-  outline: none;
-}

--- a/src/components/common/Field/Field.tsx
+++ b/src/components/common/Field/Field.tsx
@@ -17,6 +17,7 @@ import {
 } from "react-aria-components";
 import { twMerge } from "tailwind-merge";
 import { tv } from "tailwind-variants";
+import styles from "./Field.module.css";
 
 export type FieldSize = "small" | "medium" | "large";
 
@@ -123,8 +124,10 @@ export function FieldGroup({ size, ...props }: GroupProps) {
   return (
     <Group
       {...props}
-      className={composeRenderProps(props.className, (className, renderProps) =>
-        fieldGroupStyles({ ...renderProps, size, className }),
+      className={composeRenderProps(
+        `${props.className} ${styles["field-group"]}`,
+        (className, renderProps) =>
+          fieldGroupStyles({ ...renderProps, size, className }),
       )}
     />
   );

--- a/src/components/common/Field/Field.tsx
+++ b/src/components/common/Field/Field.tsx
@@ -17,7 +17,6 @@ import {
 } from "react-aria-components";
 import { twMerge } from "tailwind-merge";
 import { tv } from "tailwind-variants";
-import styles from "./Field.module.css";
 
 export type FieldSize = "small" | "medium" | "large";
 
@@ -102,7 +101,7 @@ export const innerBorderStyles = tv({
 
 const fieldGroupStyles = tv({
   extend: focusRing,
-  base: "border-none text-sm ring-inset ring-1 group flex items-center bg-element forced-colors:bg-[Field] rounded-lg overflow-hidden",
+  base: "border-none text-sm ring-inset ring-1 group flex items-center bg-element forced-colors:bg-[Field] rounded-lg",
   variants: {
     ...fieldBorderStyles.variants,
     size: {
@@ -124,10 +123,8 @@ export function FieldGroup({ size, ...props }: GroupProps) {
   return (
     <Group
       {...props}
-      className={composeRenderProps(
-        `${props.className} ${styles["field-group"]}`,
-        (className, renderProps) =>
-          fieldGroupStyles({ ...renderProps, size, className }),
+      className={composeRenderProps(props.className, (className, renderProps) =>
+        fieldGroupStyles({ ...renderProps, size, className }),
       )}
     />
   );

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -3,7 +3,7 @@ import { twMerge } from "tailwind-merge";
 import { tv } from "tailwind-variants";
 
 export const focusRing = tv({
-  base: "outline outline-offset-2",
+  base: "outline outline-offset-2 has-[[data-focus-visible]]:outline-0",
   variants: {
     isFocusVisible: {
       false: "outline-transparent",

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -28,7 +28,7 @@
   h2 {
     @apply text-2xl font-medium;
     @apply pb-2;
-    @apply border-b border-gray-5
+    @apply border-b border-gray-5;
   }
 
   h3 {
@@ -197,4 +197,8 @@ body,
 
 .animate-focus-ring-in {
   animation: animate-focus-ring-in 300ms ease forwards;
+
+  &:has(button[data-focus-visible]) {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## What changed?
Fixes #145. Removes focus ring from `FieldGroup` if it `:has([data-focus-visible])`, not sure if this is the preferred solve!

## How was this tested?
Tabbing around `/signin`.