### PR TITLE
style: Fix `SkeletonCircle` rounded pseudo style

### DIFF
--- a/src/components/common/Skeleton/Skeleton.stories.tsx
+++ b/src/components/common/Skeleton/Skeleton.stories.tsx
@@ -20,7 +20,7 @@ Default.args = {
 export const Circle = (args: any) => <SkeletonCircle {...args} />;
 
 Circle.args = {
-  className: "w-10 h-10 rounded-full",
+  className: "w-10 h-10",
 };
 
 export const Text = (args: any) => <SkeletonText {...args} />;

--- a/src/components/common/Skeleton/Skeleton.tsx
+++ b/src/components/common/Skeleton/Skeleton.tsx
@@ -4,7 +4,7 @@ const skeletonStyles = tv({
   base: "w-full h-full relative animate-fade-in before:inset-0 before:absolute before:bg-gray-a4 before:rounded-sm before:animate-pulse",
   variants: {
     type: {
-      circle: "rounded-full",
+      circle: "before:rounded-full",
       text: "h-4",
     },
   },


### PR DESCRIPTION
## What changed?
Skeleton animation is styled via a `:before` pseudo element instead of the root `<div>`, so the `rounded-full` class on the circle variant needs to target the pseudo element. Closes #445.