### PR TITLE
chore: Split Dependabot groups into smaller chunks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,5 +14,19 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      convex:
+        patterns: ["@convex-dev/**", "convex*", "convex"]
+        update-types: ["patch", "minor"]
+      storybook:
+        patterns: ["@storybook/**", "storybook"]
+        update-types: ["patch", "minor"]
+      tiptap:
+        patterns: ["@tiptap/**", "tiptap"]
+        update-types: ["patch", "minor"]
+      vite:
+        patterns: ["vite*", "@vitejs/**", "@vitest/**", "vite"]
+        update-types: ["patch", "minor"]
+      # All other patch or minor updates
       patch-minor:
+        patterns: ["*"]
         update-types: ["patch", "minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,18 +15,17 @@ updates:
       interval: "weekly"
     groups:
       convex:
-        patterns: ["@convex-dev/**", "convex*", "convex"]
+        patterns: ["@convex-dev/**", "convex", "convex*"]
         update-types: ["patch", "minor"]
       storybook:
-        patterns: ["@storybook/**", "storybook"]
+        patterns: ["@storybook/**", "storybook", "storybook*"]
         update-types: ["patch", "minor"]
       tiptap:
-        patterns: ["@tiptap/**", "tiptap"]
+        patterns: ["@tiptap/**", "tiptap", "tiptap*"]
         update-types: ["patch", "minor"]
-      vite:
-        patterns: ["vite*", "@vitejs/**", "@vitest/**", "vite"]
+      vite-vitest:
+        patterns: ["@vitejs/**", "@vitest/**", "vite", "vite*"]
         update-types: ["patch", "minor"]
       # All other patch or minor updates
       patch-minor:
-        patterns: ["*"]
         update-types: ["patch", "minor"]


### PR DESCRIPTION
## What changed?
This PR splits the `patch-minor` Dependabot group into sections for:
1. convex
2. storybook
3. tiptap
4. vite and vitest

## Why?
#460 included updates to 44 packages, which is a lot to review at once. Dependabot grouping is nice, but maybe we can split things down into smaller sections without overwhelming the number of PRs that get generated each week.

## How was this change made?
Updated the groups and `patterns` logic in the Dependabot config.

## How was this tested?
N/A