### PR TITLE
chore: React 19 quality of life tweaks

### DIFF
--- a/src/components/common/Field/Field.tsx
+++ b/src/components/common/Field/Field.tsx
@@ -1,5 +1,5 @@
 import { composeTailwindRenderProps, focusRing } from "@/components/utils";
-import { forwardRef } from "react";
+import type { Ref } from "react";
 import {
   FieldError as AriaFieldError,
   type GroupProps as AriaGroupProps,
@@ -132,6 +132,7 @@ export function FieldGroup({ size, ...props }: GroupProps) {
 
 interface InputProps extends Omit<AriaInputProps, "size"> {
   size?: FieldSize;
+  ref?: Ref<HTMLInputElement>;
 }
 
 export const inputStyles = tv({
@@ -148,10 +149,7 @@ export const inputStyles = tv({
   },
 });
 
-export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { size, ...props },
-  ref,
-) {
+export function Input({ ref, size, ...props }: InputProps) {
   return (
     <AriaInput
       {...props}
@@ -161,10 +159,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
       )}
     />
   );
-});
+}
 
 export const inputTextAreaStyles = tv({
-  base: "flex-1 min-w-0 leading-snug outline outline-0 bg-transparent text-gray-normal disabled:text-gray-dim",
+  base: "flex-1 min-w-0 leading-snug outline-0 bg-transparent text-gray-normal disabled:text-gray-dim",
   variants: {
     size: {
       small: "px-2 py-1",
@@ -179,12 +177,10 @@ export const inputTextAreaStyles = tv({
 
 interface InputTextAreaProps extends Omit<AriaTextAreaProps, "size"> {
   size?: FieldSize;
+  ref?: Ref<HTMLTextAreaElement>;
 }
 
-export const InputTextArea = forwardRef<
-  HTMLTextAreaElement,
-  InputTextAreaProps
->(function InputTextArea({ size, ...props }, ref) {
+export function InputTextArea({ ref, size, ...props }: InputTextAreaProps) {
   return (
     <AriaTextArea
       {...props}
@@ -194,4 +190,4 @@ export const InputTextArea = forwardRef<
       )}
     />
   );
-});
+}

--- a/src/components/common/RadioGroup/RadioGroup.tsx
+++ b/src/components/common/RadioGroup/RadioGroup.tsx
@@ -1,7 +1,6 @@
 import { FieldDescription, FieldError, Label } from "@/components/common";
 import { composeTailwindRenderProps, focusRing } from "@/components/utils";
-import type { ReactNode } from "react";
-import { forwardRef } from "react";
+import type { ReactNode, Ref } from "react";
 import {
   Radio as AriaRadio,
   RadioGroup as AriaRadioGroup,
@@ -17,32 +16,37 @@ export interface RadioGroupProps extends Omit<AriaRadioGroupProps, "children"> {
   description?: string;
   errorMessage?: string | ((validation: ValidationResult) => string);
   size?: "medium" | "large";
+  ref?: Ref<HTMLDivElement>;
 }
 
-export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
-  (
-    { className, label, children, description, errorMessage, size, ...props },
-    ref,
-  ) => {
-    return (
-      <AriaRadioGroup
-        {...props}
-        ref={ref}
-        className={composeTailwindRenderProps(
-          className,
-          "group flex flex-col gap-2",
-        )}
-      >
-        <Label size={size}>{label}</Label>
-        <div className="flex flex-col gap-2 group-orientation-horizontal:gap-4 group-orientation-horizontal:flex-wrap">
-          {children}
-        </div>
-        {description && <FieldDescription>{description}</FieldDescription>}
-        <FieldError>{errorMessage}</FieldError>
-      </AriaRadioGroup>
-    );
-  },
-);
+export function RadioGroup({
+  ref,
+  className,
+  label,
+  children,
+  description,
+  errorMessage,
+  size,
+  ...props
+}: RadioGroupProps) {
+  return (
+    <AriaRadioGroup
+      {...props}
+      ref={ref}
+      className={composeTailwindRenderProps(
+        className,
+        "group flex flex-col gap-2",
+      )}
+    >
+      <Label size={size}>{label}</Label>
+      <div className="flex flex-col gap-2 group-orientation-horizontal:gap-4 group-orientation-horizontal:flex-wrap">
+        {children}
+      </div>
+      {description && <FieldDescription>{description}</FieldDescription>}
+      <FieldError>{errorMessage}</FieldError>
+    </AriaRadioGroup>
+  );
+}
 
 const radioItemStyles = tv({
   extend: focusRing,
@@ -92,29 +96,34 @@ const radioStyles = tv({
 export interface RadioProps extends AriaRadioProps {
   size?: "medium" | "large";
   card?: boolean;
+  ref?: Ref<HTMLLabelElement>;
 }
 
-export const Radio = forwardRef<HTMLLabelElement, RadioProps>(
-  ({ className, size = "medium", card = false, ...props }, ref) => {
-    return (
-      <AriaRadio
-        {...props}
-        ref={ref}
-        className={composeTailwindRenderProps(
-          className,
-          radioItemStyles({ size, card }),
-        )}
-      >
-        {(renderProps) => (
-          <>
-            <div className={radioStyles({ ...renderProps, size })} />
-            {/* Types workaround: https://github.com/adobe/react-spectrum/issues/7434 */}
-            {typeof props.children === "function"
-              ? props.children(renderProps)
-              : props.children}
-          </>
-        )}
-      </AriaRadio>
-    );
-  },
-);
+export function Radio({
+  ref,
+  size = "medium",
+  card = false,
+  className,
+  ...props
+}: RadioProps) {
+  return (
+    <AriaRadio
+      {...props}
+      ref={ref}
+      className={composeTailwindRenderProps(
+        className,
+        radioItemStyles({ size, card }),
+      )}
+    >
+      {(renderProps) => (
+        <>
+          <div className={radioStyles({ ...renderProps, size })} />
+          {/* Types workaround: https://github.com/adobe/react-spectrum/issues/7434 */}
+          {typeof props.children === "function"
+            ? props.children(renderProps)
+            : props.children}
+        </>
+      )}
+    </AriaRadio>
+  );
+}

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import { focusRing } from "@/components/utils";
-import { useContext } from "react";
+import { use } from "react";
 import {
   Tab as AriaTab,
   TabList as AriaTabList,
@@ -47,7 +47,7 @@ const tabListStyles = tv({
 });
 
 export function TabList<T extends object>(props: TabListProps<T>) {
-  const state = useContext(TabListStateContext);
+  const state = use(TabListStateContext);
 
   const tabList = state?.collection;
   const activeTab = state?.selectedKey ?? "";

--- a/src/components/common/TagGroup/TagGroup.tsx
+++ b/src/components/common/TagGroup/TagGroup.tsx
@@ -1,7 +1,7 @@
 import { Button, FieldDescription, Label } from "@/components/common";
 import { focusRing } from "@/components/utils";
 import { X } from "lucide-react";
-import { createContext, useContext } from "react";
+import { createContext, use } from "react";
 import {
   Tag as AriaTag,
   TagGroup as AriaTagGroup,
@@ -104,7 +104,7 @@ const removeButtonStyles = tv({
 });
 
 export function Tag({ children, ...props }: TagProps) {
-  const size = useContext(SizeContext);
+  const size = use(SizeContext);
   const textValue = typeof children === "string" ? children : undefined;
 
   return (

--- a/src/components/common/TagGroup/TagGroup.tsx
+++ b/src/components/common/TagGroup/TagGroup.tsx
@@ -77,7 +77,7 @@ export function TagGroup<T extends object>({
   ...props
 }: TagGroupProps<T>) {
   return (
-    <SizeContext.Provider value={size}>
+    <SizeContext value={size}>
       <AriaTagGroup {...props} className={tagGroupStyles({ className })}>
         <Label size={size}>{label}</Label>
         <TagList
@@ -94,7 +94,7 @@ export function TagGroup<T extends object>({
           </Text>
         )}
       </AriaTagGroup>
-    </SizeContext.Provider>
+    </SizeContext>
   );
 }
 

--- a/src/components/common/TextArea/TextArea.tsx
+++ b/src/components/common/TextArea/TextArea.tsx
@@ -6,7 +6,7 @@ import {
   Label,
 } from "@/components/common";
 import { composeTailwindRenderProps } from "@/components/utils";
-import { forwardRef } from "react";
+import type { Ref } from "react";
 import {
   TextField as AriaTextField,
   type TextFieldProps as AriaTextFieldProps,
@@ -18,33 +18,35 @@ export interface TextAreaProps extends AriaTextFieldProps {
   description?: string;
   errorMessage?: string | ((validation: ValidationResult) => string);
   size?: "medium" | "large";
+  ref?: Ref<HTMLTextAreaElement>;
 }
 
-export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  function TextArea({ label, description, errorMessage, size, ...props }, ref) {
-    return (
-      <AriaTextField
-        {...props}
-        className={composeTailwindRenderProps(
-          props.className,
-          "flex flex-col gap-1.5",
-        )}
-      >
-        {({ isDisabled, isInvalid }) => (
-          <>
-            {label && <Label size={size}>{label}</Label>}
-            <FieldGroup
-              isDisabled={isDisabled}
-              isInvalid={isInvalid}
-              size={size}
-            >
-              <InputTextArea ref={ref} size={size} />
-            </FieldGroup>
-            {description && <FieldDescription>{description}</FieldDescription>}
-            <FieldError>{errorMessage}</FieldError>
-          </>
-        )}
-      </AriaTextField>
-    );
-  },
-);
+export function TextArea({
+  ref,
+  label,
+  description,
+  errorMessage,
+  size,
+  ...props
+}: TextAreaProps) {
+  return (
+    <AriaTextField
+      {...props}
+      className={composeTailwindRenderProps(
+        props.className,
+        "flex flex-col gap-1.5",
+      )}
+    >
+      {({ isDisabled, isInvalid }) => (
+        <>
+          {label && <Label size={size}>{label}</Label>}
+          <FieldGroup isDisabled={isDisabled} isInvalid={isInvalid} size={size}>
+            <InputTextArea ref={ref} size={size} />
+          </FieldGroup>
+          {description && <FieldDescription>{description}</FieldDescription>}
+          <FieldError>{errorMessage}</FieldError>
+        </>
+      )}
+    </AriaTextField>
+  );
+}

--- a/src/components/common/TextField/TextField.tsx
+++ b/src/components/common/TextField/TextField.tsx
@@ -11,7 +11,8 @@ import {
 } from "@/components/common";
 import { composeTailwindRenderProps } from "@/components/utils";
 import { Eye, EyeOff } from "lucide-react";
-import { forwardRef, useState } from "react";
+import type { Ref } from "react";
+import { useState } from "react";
 import {
   TextField as AriaTextField,
   type TextFieldProps as AriaTextFieldProps,
@@ -27,76 +28,69 @@ export interface TextFieldProps extends AriaTextFieldProps {
   errorMessage?: string | ((validation: ValidationResult) => string);
   size?: FieldSize;
   placeholder?: string;
+  ref?: Ref<HTMLInputElement>;
 }
 
-export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
-  function TextField(
-    {
-      label,
-      description,
-      prefix,
-      suffix,
-      errorMessage,
-      type,
-      size = "medium",
-      placeholder,
-      ...props
-    },
-    ref,
-  ) {
-    const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+export function TextField({
+  ref,
+  label,
+  description,
+  prefix,
+  suffix,
+  errorMessage,
+  type,
+  size = "medium",
+  placeholder,
+  ...props
+}: TextFieldProps) {
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
-    return (
-      <AriaTextField
-        {...props}
-        ref={ref}
-        className={composeTailwindRenderProps(
-          props.className,
-          "flex flex-col gap-1.5",
-        )}
-        type={type === "password" && isPasswordVisible ? "text" : type}
-      >
-        {({ isDisabled, isInvalid }) => (
-          <>
-            {label && <Label size={size}>{label}</Label>}
-            <FieldGroup
-              isDisabled={isDisabled}
-              isInvalid={isInvalid}
-              size={size}
-            >
-              {prefix}
-              <Input
-                className={twMerge(
-                  type === "password" && "font-mono",
-                  type === "tel" && "tabular-nums",
-                )}
-                size={size}
-                placeholder={placeholder}
-              />
-              {suffix}
-              {type === "password" && (
-                <TooltipTrigger>
-                  <Button
-                    variant="icon"
-                    aria-label={
-                      isPasswordVisible ? "Hide password" : "Show password"
-                    }
-                    onPress={() => setIsPasswordVisible(!isPasswordVisible)}
-                    size="small"
-                    icon={isPasswordVisible ? Eye : EyeOff}
-                    className="mr-1"
-                  />
-                  <Tooltip>
-                    {isPasswordVisible ? "Hide password" : "Show password"}
-                  </Tooltip>
-                </TooltipTrigger>
+  return (
+    <AriaTextField
+      {...props}
+      ref={ref}
+      className={composeTailwindRenderProps(
+        props.className,
+        "flex flex-col gap-1.5",
+      )}
+      type={type === "password" && isPasswordVisible ? "text" : type}
+    >
+      {({ isDisabled, isInvalid }) => (
+        <>
+          {label && <Label size={size}>{label}</Label>}
+          <FieldGroup isDisabled={isDisabled} isInvalid={isInvalid} size={size}>
+            {prefix}
+            <Input
+              className={twMerge(
+                type === "password" && "font-mono",
+                type === "tel" && "tabular-nums",
               )}
-            </FieldGroup>
-            {description && <FieldDescription>{description}</FieldDescription>}
-            <FieldError>{errorMessage}</FieldError>
-          </>
-        )}
-      </AriaTextField>
-    );
-  },
-);
+              size={size}
+              placeholder={placeholder}
+            />
+            {suffix}
+            {type === "password" && (
+              <TooltipTrigger>
+                <Button
+                  variant="icon"
+                  aria-label={
+                    isPasswordVisible ? "Hide password" : "Show password"
+                  }
+                  onPress={() => setIsPasswordVisible(!isPasswordVisible)}
+                  size="small"
+                  icon={isPasswordVisible ? Eye : EyeOff}
+                  className="mr-1"
+                />
+                <Tooltip>
+                  {isPasswordVisible ? "Hide password" : "Show password"}
+                </Tooltip>
+              </TooltipTrigger>
+            )}
+          </FieldGroup>
+          {description && <FieldDescription>{description}</FieldDescription>}
+          <FieldError>{errorMessage}</FieldError>
+        </>
+      )}
+    </AriaTextField>
+  );
+}


### PR DESCRIPTION
## What changed?
Read and watched info about React 19 changes and brought them into our codebase. Notably:

- `forwardRef` is no longer required 🎉 and we can pass refs directly into a component's `props`
- `useContext` can now be accessed with the more general-purpose `use()` hook
- Context no longer requires adding `.Provider` to the component name

## Why?
Latest, greatest, etc.

## How was this change made?
- Replaced all `forwardRef` instances with a ref, adding types as necessary
- Replaced `useContext` hooks with `use`
- Removed `.Provider` from component names

## How was this tested?
Existing tests pass.