### PR TITLE
feat: Make app responsive

### DIFF
--- a/.changeset/rude-cats-build.md
+++ b/.changeset/rude-cats-build.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Make app mobile-responsive

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -52,8 +52,13 @@ const quests = defineTable({
   urls: v.optional(v.array(v.string())),
   /** Time in ms since epoch when the quest was deleted. */
   deletedAt: v.optional(v.number()),
-  /** Steps in the quest */
+  /**
+   * Steps in the quest
+   * @deprecated Use `content` instead.
+   */
   steps: v.optional(v.array(v.id("questSteps"))),
+  /** Rich text comprising the contents of the quest, stored as Tiptap JSON. */
+  content: v.optional(v.string()),
   /** Questions related to the quest. */
   faqs: v.optional(v.array(v.id("questFaqs"))),
   /** Time in ms since epoch when the quest was last updated. */

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -52,13 +52,8 @@ const quests = defineTable({
   urls: v.optional(v.array(v.string())),
   /** Time in ms since epoch when the quest was deleted. */
   deletedAt: v.optional(v.number()),
-  /**
-   * Steps in the quest
-   * @deprecated Use `content` instead.
-   */
+  /** Steps in the quest. */
   steps: v.optional(v.array(v.id("questSteps"))),
-  /** Rich text comprising the contents of the quest, stored as Tiptap JSON. */
-  content: v.optional(v.string()),
   /** Questions related to the quest. */
   faqs: v.optional(v.array(v.id("questFaqs"))),
   /** Time in ms since epoch when the quest was last updated. */

--- a/index.html
+++ b/index.html
@@ -1,16 +1,21 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="/favicon.ico" sizes="32x32" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="manifest" crossorigin="use-credentials" href="/manifest.webmanifest" />
-    <title>Namesake</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="theme-color" content="#fcfcfd" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#18191b" media="(prefers-color-scheme: dark)" />
+  <link rel="icon" href="/favicon.ico" sizes="32x32" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+  <link rel="manifest" crossorigin="use-credentials" href="/manifest.webmanifest" />
+  <title>Namesake</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -3,5 +3,6 @@
   "icons": [
     { "src": "/favicon-192.png", "type": "image/png", "sizes": "192x192" },
     { "src": "/favicon-512.png", "type": "image/png", "sizes": "512x512" }
-  ]
+  ],
+  "display": "standalone"
 }

--- a/src/components/admin/AdminNav/AdminNav.test.tsx
+++ b/src/components/admin/AdminNav/AdminNav.test.tsx
@@ -1,0 +1,27 @@
+import { useMatchRoute } from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AdminNav } from "./AdminNav";
+
+describe("AdminNav", () => {
+  const mockMatchRoute = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (useMatchRoute as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockMatchRoute,
+    );
+  });
+
+  it("renders the navigation container and items", () => {
+    render(<AdminNav />);
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
+
+    const navItems = screen.getAllByRole("link");
+    expect(navItems).toHaveLength(2);
+
+    expect(screen.getByText("Quests")).toBeInTheDocument();
+    expect(screen.getByText("Early Access")).toBeInTheDocument();
+  });
+});

--- a/src/components/admin/AdminNav/AdminNav.tsx
+++ b/src/components/admin/AdminNav/AdminNav.tsx
@@ -1,0 +1,17 @@
+import { Nav, NavGroup, NavItem } from "@/components/common";
+import { FlaskConical, Milestone } from "lucide-react";
+
+export const AdminNav = () => {
+  return (
+    <Nav>
+      <NavGroup>
+        <NavItem icon={Milestone} href={{ to: "/admin/quests" }}>
+          Quests
+        </NavItem>
+        <NavItem icon={FlaskConical} href={{ to: "/admin/early-access" }}>
+          Early Access
+        </NavItem>
+      </NavGroup>
+    </Nav>
+  );
+};

--- a/src/components/admin/index.ts
+++ b/src/components/admin/index.ts
@@ -1,0 +1,1 @@
+export * from "./AdminNav/AdminNav";

--- a/src/components/app/AppContent/AppContent.tsx
+++ b/src/components/app/AppContent/AppContent.tsx
@@ -4,7 +4,7 @@ type AppContentProps = {
 
 export const AppContent = ({ children }: AppContentProps) => {
   return (
-    <main className="flex-1 w-full max-w-[960px] mx-auto app-padding">
+    <main className="flex-1 w-full max-w-[960px] mx-auto app-padding pb-4">
       {children}
     </main>
   );

--- a/src/components/app/AppMobileNav/AppMobileNav.test.tsx
+++ b/src/components/app/AppMobileNav/AppMobileNav.test.tsx
@@ -1,0 +1,99 @@
+import { useMatchRoute } from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import { useQuery } from "convex/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppMobileNav } from "./AppMobileNav";
+
+describe("AppMobileNav", () => {
+  const mockMatchRoute = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (useMatchRoute as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockMatchRoute,
+    );
+    (useQuery as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      role: "user",
+    });
+  });
+
+  it("renders home and settings links for regular users", () => {
+    render(<AppMobileNav />);
+
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.queryByText("Admin")).not.toBeInTheDocument();
+  });
+
+  it("includes admin link for admin users", () => {
+    (useQuery as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      role: "admin",
+    });
+
+    render(<AppMobileNav />);
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+  });
+
+  describe("handles active state", () => {
+    it("marks home as active for root path", () => {
+      mockMatchRoute.mockImplementation((options) => {
+        return options.to === "/" && options.fuzzy;
+      });
+
+      render(<AppMobileNav />);
+
+      const homeLink = screen.getByText("Home").closest("a");
+      expect(homeLink).toHaveClass("text-gray-normal font-bold");
+    });
+
+    it("marks home as active for quest paths", () => {
+      mockMatchRoute.mockImplementation((options) => {
+        return options.to === "/quests/$questSlug" && options.fuzzy;
+      });
+
+      render(<AppMobileNav />);
+
+      const homeLink = screen.getByText("Home").closest("a");
+      expect(homeLink).toHaveClass("text-gray-normal font-bold");
+    });
+
+    it("marks settings as active for settings path", () => {
+      mockMatchRoute.mockImplementation((options) => {
+        return options.to === "/settings" && options.fuzzy;
+      });
+
+      render(<AppMobileNav />);
+
+      const settingsLink = screen.getByText("Settings").closest("a");
+      expect(settingsLink).toHaveClass("text-gray-normal font-bold");
+    });
+
+    it("marks admin as active for admin path", () => {
+      (useQuery as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        role: "admin",
+      });
+
+      mockMatchRoute.mockImplementation((options) => {
+        return options.to === "/admin" && options.fuzzy;
+      });
+
+      render(<AppMobileNav />);
+
+      const adminLink = screen.getByText("Admin").closest("a");
+      expect(adminLink).toHaveClass("text-gray-normal font-bold");
+    });
+  });
+
+  it("renders icons for all navigation items", () => {
+    (useQuery as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      role: "admin",
+    });
+
+    render(<AppMobileNav />);
+
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+  });
+});

--- a/src/components/app/AppMobileNav/AppMobileNav.test.tsx
+++ b/src/components/app/AppMobileNav/AppMobileNav.test.tsx
@@ -44,7 +44,7 @@ describe("AppMobileNav", () => {
       render(<AppMobileNav />);
 
       const homeLink = screen.getByText("Home").closest("a");
-      expect(homeLink).toHaveClass("text-gray-normal font-bold");
+      expect(homeLink).toHaveClass("text-gray-normal");
     });
 
     it("marks home as active for quest paths", () => {
@@ -55,7 +55,7 @@ describe("AppMobileNav", () => {
       render(<AppMobileNav />);
 
       const homeLink = screen.getByText("Home").closest("a");
-      expect(homeLink).toHaveClass("text-gray-normal font-bold");
+      expect(homeLink).toHaveClass("text-gray-normal");
     });
 
     it("marks settings as active for settings path", () => {
@@ -66,7 +66,7 @@ describe("AppMobileNav", () => {
       render(<AppMobileNav />);
 
       const settingsLink = screen.getByText("Settings").closest("a");
-      expect(settingsLink).toHaveClass("text-gray-normal font-bold");
+      expect(settingsLink).toHaveClass("text-gray-normal");
     });
 
     it("marks admin as active for admin path", () => {
@@ -81,7 +81,7 @@ describe("AppMobileNav", () => {
       render(<AppMobileNav />);
 
       const adminLink = screen.getByText("Admin").closest("a");
-      expect(adminLink).toHaveClass("text-gray-normal font-bold");
+      expect(adminLink).toHaveClass("text-gray-normal");
     });
   });
 

--- a/src/components/app/AppMobileNav/AppMobileNav.tsx
+++ b/src/components/app/AppMobileNav/AppMobileNav.tsx
@@ -25,7 +25,14 @@ const AppMobileNavItem = ({
   ...props
 }: AppMobileNavItemProps) => {
   const matchRoute = useMatchRoute();
-  const isActive = Boolean(matchRoute({ ...props.href, fuzzy: true }));
+
+  const isActive =
+    label === "Home"
+      ? Boolean(
+          matchRoute({ to: "/", fuzzy: true }) ||
+            matchRoute({ to: "/quests/$questSlug", fuzzy: true }),
+        )
+      : Boolean(matchRoute({ ...props.href, fuzzy: true }));
 
   return (
     <Link {...props} className={navItemStyles({ isActive })}>

--- a/src/components/app/AppMobileNav/AppMobileNav.tsx
+++ b/src/components/app/AppMobileNav/AppMobileNav.tsx
@@ -1,6 +1,8 @@
 import { Link, type LinkProps } from "@/components/common";
+import { api } from "@convex/_generated/api";
 import { type ToOptions, useMatchRoute } from "@tanstack/react-router";
-import { Home, Settings } from "lucide-react";
+import { useQuery } from "convex/react";
+import { GlobeLock, Home, Settings } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { tv } from "tailwind-variants";
 
@@ -43,14 +45,24 @@ const AppMobileNavItem = ({
 };
 
 export const AppMobileNav = () => {
+  const user = useQuery(api.users.getCurrent);
+  const isAdmin = user?.role === "admin";
+
   return (
-    <div className="w-full shrink-0 bg-element border-t border-gray-a4 grid grid-cols-2 gap-1 p-2 items-center sticky bottom-0 mt-auto shadow-2xl">
+    <div className="w-full shrink-0 bg-element border-t border-gray-a4 flex *:flex-1 *:shrink-0 gap-1 p-2 items-center sticky bottom-0 mt-auto shadow-2xl">
       <AppMobileNavItem icon={Home} label="Home" href={{ to: "/" }} />
       <AppMobileNavItem
         icon={Settings}
         label="Settings"
         href={{ to: "/settings" }}
       />
+      {isAdmin && (
+        <AppMobileNavItem
+          icon={GlobeLock}
+          label="Admin"
+          href={{ to: "/admin" }}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/app/AppMobileNav/AppMobileNav.tsx
+++ b/src/components/app/AppMobileNav/AppMobileNav.tsx
@@ -1,0 +1,49 @@
+import { Link, type LinkProps } from "@/components/common";
+import { type ToOptions, useMatchRoute } from "@tanstack/react-router";
+import { Home, Settings } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { tv } from "tailwind-variants";
+
+interface AppMobileNavItemProps extends Omit<LinkProps, "href"> {
+  icon: LucideIcon;
+  label: string;
+  href: ToOptions;
+}
+
+const navItemStyles = tv({
+  base: "flex flex-col items-center h-12 gap-0.5 justify-center no-underline text-xs text-gray-dim hover:text-gray-normal leading-none rounded-md py-1 px-2 transition-colors",
+  variants: {
+    isActive: {
+      true: "text-gray-normal font-bold",
+    },
+  },
+});
+
+const AppMobileNavItem = ({
+  icon: Icon,
+  label,
+  ...props
+}: AppMobileNavItemProps) => {
+  const matchRoute = useMatchRoute();
+  const isActive = Boolean(matchRoute({ ...props.href, fuzzy: true }));
+
+  return (
+    <Link {...props} className={navItemStyles({ isActive })}>
+      <Icon className="opacity-80" />
+      {label}
+    </Link>
+  );
+};
+
+export const AppMobileNav = () => {
+  return (
+    <div className="w-full shrink-0 bg-element border-t border-gray-a4 grid grid-cols-2 gap-1 p-2 items-center sticky bottom-0 mt-auto shadow-2xl">
+      <AppMobileNavItem icon={Home} label="Home" href={{ to: "/" }} />
+      <AppMobileNavItem
+        icon={Settings}
+        label="Settings"
+        href={{ to: "/settings" }}
+      />
+    </div>
+  );
+};

--- a/src/components/app/AppMobileNav/AppMobileNav.tsx
+++ b/src/components/app/AppMobileNav/AppMobileNav.tsx
@@ -13,11 +13,20 @@ interface AppMobileNavItemProps extends Omit<LinkProps, "href"> {
 }
 
 const navItemStyles = tv({
-  base: "flex flex-col items-center h-12 gap-0.5 justify-center no-underline text-xs text-gray-dim hover:text-gray-normal leading-none rounded-md py-1 px-2 transition-colors",
+  base: "font-medium flex flex-col items-center h-12 gap-0.5 justify-center no-underline text-xs text-gray-dim hover:text-gray-normal leading-none rounded-md py-1 px-2 transition-colors",
   variants: {
     isActive: {
-      false: "text-gray-dim font-medium",
-      true: "text-gray-normal font-bold",
+      false: "text-gray-dim",
+      true: "text-gray-normal",
+    },
+  },
+});
+
+const iconStyles = tv({
+  variants: {
+    isActive: {
+      false: "text-gray-8 stroke-[1.5px]",
+      true: "text-gray-11 stroke-2",
     },
   },
 });
@@ -39,7 +48,7 @@ const AppMobileNavItem = ({
 
   return (
     <Link {...props} className={navItemStyles({ isActive })}>
-      <Icon className="opacity-80" />
+      <Icon className={iconStyles({ isActive })} />
       {label}
     </Link>
   );

--- a/src/components/app/AppMobileNav/AppMobileNav.tsx
+++ b/src/components/app/AppMobileNav/AppMobileNav.tsx
@@ -16,6 +16,7 @@ const navItemStyles = tv({
   base: "flex flex-col items-center h-12 gap-0.5 justify-center no-underline text-xs text-gray-dim hover:text-gray-normal leading-none rounded-md py-1 px-2 transition-colors",
   variants: {
     isActive: {
+      false: "text-gray-dim font-medium",
       true: "text-gray-normal font-bold",
     },
   },
@@ -49,7 +50,7 @@ export const AppMobileNav = () => {
   const isAdmin = user?.role === "admin";
 
   return (
-    <div className="w-full shrink-0 bg-element border-t border-gray-a4 flex *:flex-1 *:shrink-0 gap-1 p-2 items-center sticky bottom-0 mt-auto shadow-2xl">
+    <div className="w-full shrink-0 bg-element border-t border-gray-a4 flex *:flex-1 *:shrink-0 gap-1 h-mobile-nav p-1 items-center fixed bottom-0 shadow-2xl">
       <AppMobileNavItem icon={Home} label="Home" href={{ to: "/" }} />
       <AppMobileNavItem
         icon={Settings}

--- a/src/components/app/AppMobileNav/AppMobileNav.tsx
+++ b/src/components/app/AppMobileNav/AppMobileNav.tsx
@@ -25,7 +25,7 @@ const navItemStyles = tv({
 const iconStyles = tv({
   variants: {
     isActive: {
-      false: "text-gray-8 stroke-[1.5px]",
+      false: "text-gray-9 stroke-[1.5px]",
       true: "text-gray-11 stroke-2",
     },
   },

--- a/src/components/app/AppSidebar/AppSidebar.test.tsx
+++ b/src/components/app/AppSidebar/AppSidebar.test.tsx
@@ -1,7 +1,6 @@
 import { useTheme } from "@/utils/useTheme";
 import { useAuthActions } from "@convex-dev/auth/react";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { useQuery } from "convex/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppSidebar } from "./AppSidebar";
@@ -27,101 +26,50 @@ describe("AppSidebar", () => {
     });
   });
 
-  it("renders logo and early access badge", () => {
-    render(
-      <AppSidebar>
-        <div>Content</div>
-      </AppSidebar>,
-    );
-
-    expect(screen.getByRole("img", { name: "Namesake" })).toBeInTheDocument();
-    expect(screen.getByText("Early Access")).toBeInTheDocument();
-  });
-
   it("renders children content", () => {
     render(
       <AppSidebar>
-        <div>Test Content</div>
+        <div>Main Content</div>
       </AppSidebar>,
     );
 
-    expect(screen.getByText("Test Content")).toBeInTheDocument();
+    expect(screen.getByText("Main Content")).toBeInTheDocument();
   });
 
-  it("shows admin option in menu for admin users", async () => {
-    const user = userEvent.setup();
-    (useQuery as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      role: "admin",
-    });
-
+  it("renders header when provided", () => {
     render(
-      <AppSidebar>
-        <div>Content</div>
+      <AppSidebar header={<div>Header Content</div>}>
+        <div>Main Content</div>
       </AppSidebar>,
     );
 
-    await user.click(screen.getByRole("button", { name: "User settings" }));
-    expect(screen.getByText("Admin")).toBeInTheDocument();
+    expect(screen.getByText("Header Content")).toBeInTheDocument();
+    expect(screen.getByText("Main Content")).toBeInTheDocument();
   });
 
-  it("does not show admin option for regular users", async () => {
-    const user = userEvent.setup();
+  it("renders footer when provided", () => {
     render(
-      <AppSidebar>
-        <div>Content</div>
+      <AppSidebar footer={<div>Footer Content</div>}>
+        <div>Main Content</div>
       </AppSidebar>,
     );
 
-    await user.click(screen.getByRole("button", { name: "User settings" }));
-    expect(screen.queryByText("Admin")).not.toBeInTheDocument();
+    expect(screen.getByText("Main Content")).toBeInTheDocument();
+    expect(screen.getByText("Footer Content")).toBeInTheDocument();
   });
 
-  it("handles theme changes", async () => {
-    const user = userEvent.setup();
+  it("renders all sections when provided", () => {
     render(
-      <AppSidebar>
-        <div>Content</div>
+      <AppSidebar
+        header={<div>Header Content</div>}
+        footer={<div>Footer Content</div>}
+      >
+        <div>Main Content</div>
       </AppSidebar>,
     );
 
-    await user.click(screen.getByRole("button", { name: "User settings" }));
-    await user.click(screen.getByText("Theme"));
-    await user.click(screen.getByText("Dark"));
-
-    const [[firstArg]] = mockSetTheme.mock.calls;
-    expect(firstArg).toBeInstanceOf(Set);
-    expect([...firstArg]).toEqual(["dark"]);
-  });
-
-  it("shows current theme in menu", async () => {
-    const user = userEvent.setup();
-    (useTheme as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      theme: "dark",
-      themeSelection: new Set(["dark"]),
-      setTheme: mockSetTheme,
-    });
-
-    render(
-      <AppSidebar>
-        <div>Content</div>
-      </AppSidebar>,
-    );
-
-    await user.click(screen.getByRole("button", { name: "User settings" }));
-    expect(screen.getByText("Dark")).toBeInTheDocument();
-  });
-
-  it("handles sign out", async () => {
-    const user = userEvent.setup();
-    render(
-      <AppSidebar>
-        <div>Content</div>
-      </AppSidebar>,
-    );
-
-    await user.click(screen.getByRole("button", { name: "User settings" }));
-    await user.click(screen.getByText("Sign out"));
-
-    expect(mockSignOut).toHaveBeenCalled();
+    expect(screen.getByText("Header Content")).toBeInTheDocument();
+    expect(screen.getByText("Main Content")).toBeInTheDocument();
+    expect(screen.getByText("Footer Content")).toBeInTheDocument();
   });
 });

--- a/src/components/app/AppSidebar/AppSidebar.tsx
+++ b/src/components/app/AppSidebar/AppSidebar.tsx
@@ -14,7 +14,7 @@ export const AppSidebar = ({ header, children, footer }: AppSidebarProps) => {
       )}
       <div className="app-padding flex-1">{children}</div>
       {footer && (
-        <div className="app-padding h-header -ml-3 shrink-0 flex items-center sticky bottom-0 bg-sidebar">
+        <div className="h-header shrink-0 flex items-center sticky bottom-0 bg-sidebar">
           {footer}
         </div>
       )}

--- a/src/components/app/AppSidebar/AppSidebar.tsx
+++ b/src/components/app/AppSidebar/AppSidebar.tsx
@@ -6,7 +6,7 @@ type AppSidebarProps = {
 
 export const AppSidebar = ({ header, children, footer }: AppSidebarProps) => {
   return (
-    <div className="w-72 lg:w-80 xl:w-[22rem] flex flex-col shrink-0 sticky top-0 max-h-full align-self-stretch overflow-y-auto bg-sidebar border-r border-gray-a4">
+    <div className="w-72 lg:w-80 xl:w-[22rem] flex flex-col shrink-0 sticky top-0 h-screen max-h-full align-self-stretch overflow-y-auto bg-sidebar border-r border-gray-a4">
       {header && (
         <div className="app-padding h-header flex items-center shrink-0 sticky top-0 bg-sidebar z-20">
           {header}

--- a/src/components/app/AppSidebar/AppSidebar.tsx
+++ b/src/components/app/AppSidebar/AppSidebar.tsx
@@ -1,92 +1,23 @@
-import { Logo } from "@/components/app";
-import {
-  Badge,
-  Button,
-  Link,
-  Menu,
-  MenuItem,
-  MenuSeparator,
-  MenuTrigger,
-  SubmenuTrigger,
-} from "@/components/common";
-import { useTheme } from "@/utils/useTheme";
-import { useAuthActions } from "@convex-dev/auth/react";
-import { api } from "@convex/_generated/api";
-import { THEMES, type Theme } from "@convex/constants";
-import { Authenticated, useQuery } from "convex/react";
-import { CircleUser, Cog, GlobeLock, LogOut } from "lucide-react";
-
 type AppSidebarProps = {
+  header?: React.ReactNode;
   children: React.ReactNode;
+  footer?: React.ReactNode;
 };
 
-export const AppSidebar = ({ children }: AppSidebarProps) => {
-  const { signOut } = useAuthActions();
-  const { theme, themeSelection, setTheme } = useTheme();
-
-  const user = useQuery(api.users.getCurrent);
-  const isAdmin = user?.role === "admin";
-
-  const handleSignOut = async () => {
-    await signOut();
-  };
-
+export const AppSidebar = ({ header, children, footer }: AppSidebarProps) => {
   return (
-    <div className="w-72 lg:w-80 xl:w-[22rem] flex flex-col shrink-0 sticky top-0 h-screen overflow-y-auto bg-sidebar border-r border-gray-a4">
-      <div className="app-padding h-header flex gap-2 items-center shrink-0 sticky top-0 bg-sidebar z-20">
-        <Link href={{ to: "/" }} className="p-1 -m-1">
-          <Logo className="h-5 lg:h-[1.35rem]" />
-        </Link>
-        <Badge className="-mb-1" variant="waiting">
-          Early Access
-        </Badge>
-      </div>
+    <div className="w-72 lg:w-80 xl:w-[22rem] flex flex-col shrink-0 sticky top-0 max-h-full align-self-stretch overflow-y-auto bg-sidebar border-r border-gray-a4">
+      {header && (
+        <div className="app-padding h-header shrink-0 sticky top-0 bg-sidebar z-20">
+          {header}
+        </div>
+      )}
       <div className="app-padding flex-1">{children}</div>
-      <div className="app-padding h-header -ml-3 shrink-0 flex items-center sticky bottom-0 bg-sidebar">
-        <Authenticated>
-          <MenuTrigger>
-            <Button
-              aria-label="User settings"
-              variant="icon"
-              icon={CircleUser}
-            />
-            <Menu placement="top start">
-              {isAdmin && (
-                <MenuItem icon={GlobeLock} href={{ to: "/admin" }}>
-                  Admin
-                </MenuItem>
-              )}
-              <MenuItem href={{ to: "/settings/account" }} icon={Cog}>
-                Settings and Help
-              </MenuItem>
-              <SubmenuTrigger>
-                <MenuItem icon={THEMES[theme as Theme].icon} textValue="Theme">
-                  <span>Theme</span>
-                  <span slot="shortcut" className="ml-auto text-gray-dim">
-                    {THEMES[theme as Theme].label}
-                  </span>
-                </MenuItem>
-                <Menu
-                  disallowEmptySelection
-                  selectionMode="single"
-                  selectedKeys={themeSelection}
-                  onSelectionChange={setTheme}
-                >
-                  {Object.entries(THEMES).map(([theme, details]) => (
-                    <MenuItem key={theme} id={theme} icon={details.icon}>
-                      {details.label}
-                    </MenuItem>
-                  ))}
-                </Menu>
-              </SubmenuTrigger>
-              <MenuSeparator />
-              <MenuItem icon={LogOut} onAction={handleSignOut}>
-                Sign out
-              </MenuItem>
-            </Menu>
-          </MenuTrigger>
-        </Authenticated>
-      </div>
+      {footer && (
+        <div className="app-padding h-header -ml-3 shrink-0 flex items-center sticky bottom-0 bg-sidebar">
+          {footer}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/app/AppSidebar/AppSidebar.tsx
+++ b/src/components/app/AppSidebar/AppSidebar.tsx
@@ -8,7 +8,7 @@ export const AppSidebar = ({ header, children, footer }: AppSidebarProps) => {
   return (
     <div className="w-72 lg:w-80 xl:w-[22rem] flex flex-col shrink-0 sticky top-0 max-h-full align-self-stretch overflow-y-auto bg-sidebar border-r border-gray-a4">
       {header && (
-        <div className="app-padding h-header shrink-0 sticky top-0 bg-sidebar z-20">
+        <div className="app-padding h-header flex items-center shrink-0 sticky top-0 bg-sidebar z-20">
           {header}
         </div>
       )}

--- a/src/components/app/AppSidebarFooter/AppSidebarFooter.test.tsx
+++ b/src/components/app/AppSidebarFooter/AppSidebarFooter.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { useQuery } from "convex/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppSidebarFooter } from "./AppSidebarFooter";
+
+describe("AppSidebarFooter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useQuery as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      role: "user",
+    });
+  });
+
+  it("renders settings link for regular users", () => {
+    render(<AppSidebarFooter />);
+
+    const settingsLink = screen.getByRole("link", { name: "Settings" });
+    expect(settingsLink).toBeInTheDocument();
+
+    // Admin link should not be present
+    expect(
+      screen.queryByRole("link", { name: "Admin" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("includes admin link for admin users", () => {
+    (useQuery as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      role: "admin",
+    });
+
+    render(<AppSidebarFooter />);
+
+    expect(screen.getByRole("link", { name: "Settings" })).toBeInTheDocument();
+
+    const adminLink = screen.getByRole("link", { name: "Admin" });
+    expect(adminLink).toBeInTheDocument();
+  });
+});

--- a/src/components/app/AppSidebarFooter/AppSidebarFooter.tsx
+++ b/src/components/app/AppSidebarFooter/AppSidebarFooter.tsx
@@ -1,0 +1,68 @@
+import {
+  Button,
+  Menu,
+  MenuItem,
+  MenuSeparator,
+  MenuTrigger,
+  SubmenuTrigger,
+} from "@/components/common";
+import { useTheme } from "@/utils/useTheme";
+import { useAuthActions } from "@convex-dev/auth/react";
+import { api } from "@convex/_generated/api";
+import { THEMES, type Theme } from "@convex/constants";
+import { Authenticated, useQuery } from "convex/react";
+import { CircleUser, Cog, GlobeLock, LogOut } from "lucide-react";
+
+export const AppSidebarFooter = () => {
+  const { signOut } = useAuthActions();
+  const { theme, themeSelection, setTheme } = useTheme();
+
+  const user = useQuery(api.users.getCurrent);
+  const isAdmin = user?.role === "admin";
+
+  const handleSignOut = async () => {
+    await signOut();
+  };
+
+  return (
+    <Authenticated>
+      <MenuTrigger>
+        <Button aria-label="User settings" variant="icon" icon={CircleUser} />
+        <Menu placement="top start">
+          {isAdmin && (
+            <MenuItem icon={GlobeLock} href={{ to: "/admin" }}>
+              Admin
+            </MenuItem>
+          )}
+          <MenuItem href={{ to: "/settings" }} icon={Cog}>
+            Settings and Help
+          </MenuItem>
+          <SubmenuTrigger>
+            <MenuItem icon={THEMES[theme as Theme].icon} textValue="Theme">
+              <span>Theme</span>
+              <span slot="shortcut" className="ml-auto text-gray-dim">
+                {THEMES[theme as Theme].label}
+              </span>
+            </MenuItem>
+            <Menu
+              disallowEmptySelection
+              selectionMode="single"
+              selectedKeys={themeSelection}
+              onSelectionChange={setTheme}
+            >
+              {Object.entries(THEMES).map(([theme, details]) => (
+                <MenuItem key={theme} id={theme} icon={details.icon}>
+                  {details.label}
+                </MenuItem>
+              ))}
+            </Menu>
+          </SubmenuTrigger>
+          <MenuSeparator />
+          <MenuItem icon={LogOut} onAction={handleSignOut}>
+            Sign out
+          </MenuItem>
+        </Menu>
+      </MenuTrigger>
+    </Authenticated>
+  );
+};

--- a/src/components/app/AppSidebarFooter/AppSidebarFooter.tsx
+++ b/src/components/app/AppSidebarFooter/AppSidebarFooter.tsx
@@ -9,7 +9,7 @@ export const AppSidebarFooter = () => {
 
   return (
     <Authenticated>
-      <div className="flex items-center gap-2 justify-between w-full px-4">
+      <div className="flex items-center gap-1 justify-end w-full px-4">
         <TooltipTrigger>
           <Link
             button={{ variant: "icon" }}

--- a/src/components/app/AppSidebarFooter/AppSidebarFooter.tsx
+++ b/src/components/app/AppSidebarFooter/AppSidebarFooter.tsx
@@ -1,68 +1,38 @@
-import {
-  Button,
-  Menu,
-  MenuItem,
-  MenuSeparator,
-  MenuTrigger,
-  SubmenuTrigger,
-} from "@/components/common";
-import { useTheme } from "@/utils/useTheme";
-import { useAuthActions } from "@convex-dev/auth/react";
+import { Link, Tooltip, TooltipTrigger } from "@/components/common";
 import { api } from "@convex/_generated/api";
-import { THEMES, type Theme } from "@convex/constants";
 import { Authenticated, useQuery } from "convex/react";
-import { CircleUser, Cog, GlobeLock, LogOut } from "lucide-react";
+import { Cog, GlobeLock } from "lucide-react";
 
 export const AppSidebarFooter = () => {
-  const { signOut } = useAuthActions();
-  const { theme, themeSelection, setTheme } = useTheme();
-
   const user = useQuery(api.users.getCurrent);
   const isAdmin = user?.role === "admin";
 
-  const handleSignOut = async () => {
-    await signOut();
-  };
-
   return (
     <Authenticated>
-      <MenuTrigger>
-        <Button aria-label="User settings" variant="icon" icon={CircleUser} />
-        <Menu placement="top start">
-          {isAdmin && (
-            <MenuItem icon={GlobeLock} href={{ to: "/admin" }}>
-              Admin
-            </MenuItem>
-          )}
-          <MenuItem href={{ to: "/settings" }} icon={Cog}>
-            Settings and Help
-          </MenuItem>
-          <SubmenuTrigger>
-            <MenuItem icon={THEMES[theme as Theme].icon} textValue="Theme">
-              <span>Theme</span>
-              <span slot="shortcut" className="ml-auto text-gray-dim">
-                {THEMES[theme as Theme].label}
-              </span>
-            </MenuItem>
-            <Menu
-              disallowEmptySelection
-              selectionMode="single"
-              selectedKeys={themeSelection}
-              onSelectionChange={setTheme}
+      <div className="flex items-center gap-2 justify-between w-full px-4">
+        <TooltipTrigger>
+          <Link
+            button={{ variant: "icon" }}
+            href={{ to: "/settings" }}
+            aria-label="Settings"
+          >
+            <Cog className="size-5" />
+          </Link>
+          <Tooltip>Settings</Tooltip>
+        </TooltipTrigger>
+        {isAdmin && (
+          <TooltipTrigger>
+            <Link
+              button={{ variant: "icon" }}
+              href={{ to: "/admin" }}
+              aria-label="Admin"
             >
-              {Object.entries(THEMES).map(([theme, details]) => (
-                <MenuItem key={theme} id={theme} icon={details.icon}>
-                  {details.label}
-                </MenuItem>
-              ))}
-            </Menu>
-          </SubmenuTrigger>
-          <MenuSeparator />
-          <MenuItem icon={LogOut} onAction={handleSignOut}>
-            Sign out
-          </MenuItem>
-        </Menu>
-      </MenuTrigger>
+              <GlobeLock className="size-5" />
+            </Link>
+            <Tooltip>Admin</Tooltip>
+          </TooltipTrigger>
+        )}
+      </div>
     </Authenticated>
   );
 };

--- a/src/components/app/AppSidebarHeader/AppSidebarHeader.tsx
+++ b/src/components/app/AppSidebarHeader/AppSidebarHeader.tsx
@@ -1,0 +1,15 @@
+import { Badge, Link } from "@/components/common";
+import { Logo } from "../Logo/Logo";
+
+export const AppSidebarHeader = () => {
+  return (
+    <div className="flex gap-2 items-center">
+      <Link href={{ to: "/" }} className="p-1 -m-1">
+        <Logo className="h-5 lg:h-[1.35rem]" />
+      </Link>
+      <Badge className="-mb-1" variant="waiting">
+        Early Access
+      </Badge>
+    </div>
+  );
+};

--- a/src/components/app/PageHeader/PageHeader.test.tsx
+++ b/src/components/app/PageHeader/PageHeader.test.tsx
@@ -1,0 +1,82 @@
+import { useIsMobile } from "@/utils/useIsMobile";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PageHeader } from "./PageHeader";
+
+// Mock the useIsMobile hook
+vi.mock("@/utils/useIsMobile");
+
+describe("PageHeader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useIsMobile as unknown as ReturnType<typeof vi.fn>).mockReturnValue(false);
+  });
+
+  it("renders the title correctly", () => {
+    render(<PageHeader title="Test Page" />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Test Page",
+    );
+  });
+
+  it("renders children in the right section", () => {
+    render(
+      <PageHeader title="Test Page">
+        <button type="button">Action Button</button>
+      </PageHeader>,
+    );
+    expect(screen.getByText("Action Button")).toBeInTheDocument();
+  });
+
+  it("renders badge when provided", () => {
+    render(
+      <PageHeader
+        title="Test Page"
+        badge={<span data-testid="test-badge">Badge</span>}
+      />,
+    );
+    expect(screen.getByTestId("test-badge")).toBeInTheDocument();
+    expect(screen.getByText("Badge")).toBeInTheDocument();
+  });
+
+  it("applies custom className when provided", () => {
+    render(<PageHeader title="Test Page" className="custom-class" />);
+    expect(screen.getByRole("banner")).toHaveClass("custom-class");
+  });
+
+  describe("mobile back link", () => {
+    it("does not render back link on desktop", () => {
+      (useIsMobile as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+        false,
+      );
+
+      render(
+        <PageHeader title="Test Page" mobileBackLink={{ to: "/settings" }} />,
+      );
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+
+    it("renders back link on mobile when mobileBackLink is provided", () => {
+      (useIsMobile as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+        true,
+      );
+
+      render(
+        <PageHeader title="Test Page" mobileBackLink={{ to: "/settings" }} />,
+      );
+      const backLink = screen.getByRole("link");
+      expect(backLink).toBeInTheDocument();
+      const icon = backLink.querySelector("svg");
+      expect(icon).toHaveClass("lucide-arrow-left");
+    });
+
+    it("does not render back link on mobile when mobileBackLink is not provided", () => {
+      (useIsMobile as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+        true,
+      );
+
+      render(<PageHeader title="Test Page" />);
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/app/PageHeader/PageHeader.tsx
+++ b/src/components/app/PageHeader/PageHeader.tsx
@@ -1,22 +1,33 @@
 import { Link, type LinkProps } from "@/components/common";
+import { useIsMobile } from "@/utils/useIsMobile";
 import { ArrowLeft } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
 export interface PageHeaderProps {
+  /** The title of the page. */
   title: string;
-  backLink?: LinkProps["href"];
+  /** An arrow button which only displays on mobile devices. */
+  mobileBackLink?: LinkProps["href"];
+  /** A badge which displays inline to the right of the title. */
   badge?: React.ReactNode;
+  /**
+   * Additional content to display to the right of the title.
+   * Often used for buttons.
+   */
   children?: React.ReactNode;
+  /** Additional classes to apply to the header. */
   className?: string;
 }
 
 export const PageHeader = ({
   title,
-  backLink,
+  mobileBackLink,
   badge,
   children,
   className,
 }: PageHeaderProps) => {
+  const isMobile = useIsMobile();
+
   return (
     <header
       className={twMerge(
@@ -26,9 +37,9 @@ export const PageHeader = ({
     >
       <div className="flex flex-col gap-1">
         <div className="flex gap-2 items-center">
-          {backLink && (
+          {isMobile && mobileBackLink && (
             <Link
-              href={backLink}
+              href={mobileBackLink}
               button={{ variant: "icon" }}
               className="-ml-2"
             >

--- a/src/components/app/PageHeader/PageHeader.tsx
+++ b/src/components/app/PageHeader/PageHeader.tsx
@@ -1,9 +1,10 @@
-import type { LucideIcon } from "lucide-react";
+import { Link, type LinkProps } from "@/components/common";
+import { ArrowLeft } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
 export interface PageHeaderProps {
   title: string;
-  icon?: LucideIcon;
+  backLink?: LinkProps["href"];
   badge?: React.ReactNode;
   children?: React.ReactNode;
   className?: string;
@@ -11,7 +12,7 @@ export interface PageHeaderProps {
 
 export const PageHeader = ({
   title,
-  icon: Icon,
+  backLink,
   badge,
   children,
   className,
@@ -25,8 +26,16 @@ export const PageHeader = ({
     >
       <div className="flex flex-col gap-1">
         <div className="flex gap-2 items-center">
-          {Icon && <Icon className="text-gray-dim" />}
-          <h1 className="text-lg lg:text-2xl font-medium whitespace-nowrap">
+          {backLink && (
+            <Link
+              href={backLink}
+              button={{ variant: "icon" }}
+              className="-ml-2"
+            >
+              <ArrowLeft className="size-5" />
+            </Link>
+          )}
+          <h1 className="text-xl lg:text-2xl font-medium whitespace-nowrap">
             {title}
           </h1>
           {badge}

--- a/src/components/app/index.ts
+++ b/src/components/app/index.ts
@@ -1,6 +1,7 @@
 export * from "./AppContent/AppContent";
 export * from "./AppMobileNav/AppMobileNav";
 export * from "./AppSidebar/AppSidebar";
+export * from "./AppSidebarFooter/AppSidebarFooter";
 export * from "./AppSidebarHeader/AppSidebarHeader";
 export * from "./Logo/Logo";
 export * from "./PageHeader/PageHeader";

--- a/src/components/app/index.ts
+++ b/src/components/app/index.ts
@@ -1,5 +1,7 @@
 export * from "./AppContent/AppContent";
+export * from "./AppMobileNav/AppMobileNav";
 export * from "./AppSidebar/AppSidebar";
+export * from "./AppSidebarHeader/AppSidebarHeader";
 export * from "./Logo/Logo";
 export * from "./PageHeader/PageHeader";
 export * from "./PasswordStrength/PasswordStrength";

--- a/src/components/common/Nav/Nav.tsx
+++ b/src/components/common/Nav/Nav.tsx
@@ -1,8 +1,7 @@
-import { Badge, Link, type LinkProps } from "@/components/common";
+import { Link, type LinkProps } from "@/components/common";
 import { focusRing } from "@/components/utils";
 import { useMatchRoute } from "@tanstack/react-router";
 import { ExternalLink, type LucideIcon } from "lucide-react";
-import { Header } from "react-aria-components";
 import { tv } from "tailwind-variants";
 
 interface NavItemProps extends LinkProps {
@@ -62,7 +61,7 @@ export const NavItem = ({
   const matchRoute = useMatchRoute();
   let current: boolean | undefined;
 
-  if (typeof props.href === "string") {
+  if (typeof props.href === "string" || !props.href) {
     // Link is external, so we can't match it
     current = false;
   } else {
@@ -92,29 +91,12 @@ export const NavItem = ({
 };
 
 interface NavGroupProps {
-  label: string;
   children: React.ReactNode;
-  count?: number;
-  icon?: LucideIcon;
 }
 
-export const NavGroup = ({
-  label,
-  children,
-  count,
-  icon: Icon,
-}: NavGroupProps) => {
+export const NavGroup = ({ children }: NavGroupProps) => {
   return (
-    <div className="flex flex-col gap-0.5 not-first:mt-4">
-      <Header className="text-sm h-8 font-medium text-gray-dim border-b border-gray-4 flex justify-start items-center gap-1.5">
-        {Icon && <Icon size={20} className="size-4" />}
-        {label}
-        {count && (
-          <Badge size="xs" className="rounded-full">
-            {count}
-          </Badge>
-        )}
-      </Header>
+    <div className="flex flex-col gap-0.5 pt-2 mt-2 border-t border-gray-dim first:mt-0 first:border-0 first:pt-0">
       {children}
     </div>
   );

--- a/src/components/common/Nav/Nav.tsx
+++ b/src/components/common/Nav/Nav.tsx
@@ -1,26 +1,35 @@
 import { Link, type LinkProps } from "@/components/common";
 import { focusRing } from "@/components/utils";
+import { useIsMobile } from "@/utils/useIsMobile";
 import { useMatchRoute } from "@tanstack/react-router";
-import { ExternalLink, type LucideIcon } from "lucide-react";
+import { ChevronRight, ExternalLink, type LucideIcon } from "lucide-react";
 import { tv } from "tailwind-variants";
 
-interface NavItemProps extends LinkProps {
+type NavItemBaseProps = {
   icon?: LucideIcon;
   className?: string;
   children?: React.ReactNode;
   size?: "medium" | "large";
-}
+};
+
+type NavLinkProps = LinkProps;
+
+type NavButtonProps = {
+  onClick: () => void;
+};
+
+type NavItemProps = NavItemBaseProps & (NavLinkProps | NavButtonProps);
 
 const navItemStyles = tv({
   extend: focusRing,
-  base: "rounded-md no-underline px-2 -mx-2 flex border border-transparent items-center text-base md:text-sm lg:text-base hover:bg-gray-3 hover:text-gray-12 aria-current:font-semibold aria-current:text-gray-normal",
+  base: "rounded-md gap-2 no-underline px-2 -mx-2 flex border border-transparent items-center text-base md:text-sm lg:text-base hover:bg-gray-3 hover:text-gray-12 aria-current:font-semibold aria-current:text-gray-normal cursor-pointer",
   variants: {
     isActive: {
       true: "bg-gray-3 hover:bg-gray-3 text-gray-normal",
     },
     size: {
-      medium: "h-9 md:h-8 lg:h-9 gap-1.5",
-      large: "h-12 gap-2",
+      medium: "h-9 md:h-8 lg:h-9",
+      large: "h-12",
     },
   },
   defaultVariants: {
@@ -29,14 +38,14 @@ const navItemStyles = tv({
 });
 
 const iconStyles = tv({
-  base: "text-gray-dim shrink-0",
+  base: "text-gray-dim shrink-0 stroke-[1.5px]",
   variants: {
     isActive: {
       true: "text-gray-normal",
     },
     size: {
       medium: "size-5",
-      large: "bg-gray-a3 rounded-sm size-8 p-1 stroke-[1.5px]",
+      large: "bg-gray-a3 rounded-sm size-8 p-1",
     },
   },
   compoundVariants: [
@@ -58,14 +67,22 @@ export const NavItem = ({
   size,
   ...props
 }: NavItemProps) => {
+  const isMobile = useIsMobile();
   const matchRoute = useMatchRoute();
   let current: boolean | undefined;
+  let displayExternalLink = false;
+  let displayChevron = false;
 
-  if (typeof props.href === "string" || !props.href) {
-    // Link is external, so we can't match it
-    current = false;
-  } else {
-    current = Boolean(matchRoute({ ...props.href, fuzzy: true }));
+  if ("href" in props) {
+    if (typeof props.href === "string" || !props.href) {
+      // Link is external, so we can't match it
+      current = false;
+    } else {
+      current = Boolean(matchRoute({ ...props.href, fuzzy: true }));
+    }
+
+    displayExternalLink = props.target === "_blank";
+    displayChevron = isMobile && !displayExternalLink;
   }
 
   return (
@@ -81,10 +98,15 @@ export const NavItem = ({
       }
       aria-current={current ? "true" : null}
     >
-      {Icon && <Icon className={iconStyles({ isActive: !!current, size })} />}
-      {children}
-      {props.target === "_blank" && (
-        <ExternalLink aria-hidden className="size-4 ml-auto text-gray-8" />
+      <div className="flex flex-1 items-center gap-2">
+        {Icon && <Icon className={iconStyles({ isActive: !!current, size })} />}
+        {children}
+      </div>
+      {displayExternalLink && (
+        <ExternalLink aria-hidden className="size-4 text-gray-8" />
+      )}
+      {displayChevron && (
+        <ChevronRight aria-hidden className="size-5 text-gray-8" />
       )}
     </Link>
   );

--- a/src/components/common/Nav/Nav.tsx
+++ b/src/components/common/Nav/Nav.tsx
@@ -19,7 +19,7 @@ const navItemStyles = tv({
       true: "bg-gray-3 hover:bg-gray-3 text-gray-normal",
     },
     size: {
-      medium: "h-10 md:h-8 lg:h-9 gap-1.5",
+      medium: "h-9 md:h-8 lg:h-9 gap-1.5",
       large: "h-12 gap-2",
     },
   },
@@ -107,5 +107,5 @@ interface NavProps {
 }
 
 export const Nav = ({ children }: NavProps) => {
-  return <nav className="flex flex-col gap-0.5">{children}</nav>;
+  return <nav className="flex flex-col gap-0.5 pb-4">{children}</nav>;
 };

--- a/src/components/common/Nav/Nav.tsx
+++ b/src/components/common/Nav/Nav.tsx
@@ -14,7 +14,7 @@ interface NavItemProps extends LinkProps {
 
 const navItemStyles = tv({
   extend: focusRing,
-  base: "rounded-md no-underline px-2 -mx-2 flex border border-transparent items-center text-base md:text-sm lg:text-base hover:bg-gray-3 hover:text-gray-normal aria-current:font-semibold aria-current:text-gray-normal",
+  base: "rounded-md no-underline px-2 -mx-2 flex border border-transparent items-center text-base md:text-sm lg:text-base hover:bg-gray-3 hover:text-gray-12 aria-current:font-semibold aria-current:text-gray-normal",
   variants: {
     isActive: {
       true: "bg-gray-3 hover:bg-gray-3 text-gray-normal",

--- a/src/components/common/Nav/Nav.tsx
+++ b/src/components/common/Nav/Nav.tsx
@@ -106,7 +106,7 @@ export const NavItem = ({
         <ExternalLink aria-hidden className="size-4 text-gray-8" />
       )}
       {displayChevron && (
-        <ChevronRight aria-hidden className="size-5 text-gray-8" />
+        <ChevronRight aria-hidden className="size-5 -mr-0.5 text-gray-8" />
       )}
     </Link>
   );

--- a/src/components/common/Nav/Nav.tsx
+++ b/src/components/common/Nav/Nav.tsx
@@ -14,13 +14,13 @@ interface NavItemProps extends LinkProps {
 
 const navItemStyles = tv({
   extend: focusRing,
-  base: "rounded-md no-underline px-2 -mx-2 flex border border-transparent items-center text-sm lg:text-base hover:bg-gray-3 aria-current:font-semibold aria-current:text-gray-normal",
+  base: "rounded-md no-underline px-2 -mx-2 flex border border-transparent items-center text-base md:text-sm lg:text-base hover:bg-gray-3 hover:text-gray-normal aria-current:font-semibold aria-current:text-gray-normal",
   variants: {
     isActive: {
       true: "bg-gray-3 hover:bg-gray-3 text-gray-normal",
     },
     size: {
-      medium: "h-8 lg:h-9 gap-1.5",
+      medium: "h-10 md:h-8 lg:h-9 gap-1.5",
       large: "h-12 gap-2",
     },
   },

--- a/src/components/common/RadioGroup/RadioGroup.tsx
+++ b/src/components/common/RadioGroup/RadioGroup.tsx
@@ -64,7 +64,7 @@ const radioItemStyles = tv({
 
 const radioStyles = tv({
   extend: focusRing,
-  base: "rounded-full border bg-app transition-all ease-out duration-150 cursor-pointer",
+  base: "rounded-full border bg-app transition-all ease-out duration-150 cursor-pointer shrink-0",
   variants: {
     isSelected: {
       false: "border-gray-dim",

--- a/src/components/common/ToggleButton/ToggleButton.tsx
+++ b/src/components/common/ToggleButton/ToggleButton.tsx
@@ -16,7 +16,7 @@ export interface ToggleButtonProps extends AriaToggleButtonProps {
 
 const styles = tv({
   extend: focusRing,
-  base: "px-3.5 [&:has(svg:only-child)]:px-2 text-sm text-center font-medium transition rounded-lg border border-transparent relative isolate",
+  base: "px-3.5 [&:has(svg:only-child)]:px-2 text-sm text-center font-medium transition rounded-lg border border-transparent relative isolate shrink-0",
   variants: {
     isSelected: {
       false: "bg-transparent text-gray-dim hover:text-gray-normal",

--- a/src/components/common/Tooltip/Tooltip.tsx
+++ b/src/components/common/Tooltip/Tooltip.tsx
@@ -39,7 +39,7 @@ export function Tooltip({ children, ...props }: TooltipProps) {
           width={8}
           height={8}
           viewBox="0 0 8 8"
-          className="fill-gray-12 forced-colors:fill-[Canvas] group-placement-[bottom]:rotate-180 group-placement-[left]:-rotate-90 group-placement-[right]:rotate-90"
+          className="fill-gray-12 forced-colors:fill-[Canvas] group-placement-bottom:rotate-180 group-placement-left:-rotate-90 group-placement-right:rotate-90"
         >
           <path d="M0 0 L4 4 L8 0" />
         </svg>

--- a/src/components/forms/FormContainer/FormContainer.tsx
+++ b/src/components/forms/FormContainer/FormContainer.tsx
@@ -40,43 +40,45 @@ export function FormContainer({
   const { history } = useRouter();
 
   return (
-    <main>
-      <FormProvider {...form}>
-        <Container className="w-[720px] py-16">
-          <Form onSubmit={onSubmit} autoComplete="on">
-            <header className="flex flex-col gap-6 mb-8">
-              <Heading className="text-5xl font-medium text-pretty">
-                {title}
-              </Heading>
-              {description && (
-                <p className="text-sm text-gray-dim">
-                  {smartquotes(description)}
-                </p>
-              )}
-              <Banner variant="success" icon={ShieldCheck} size="large">
-                Namesake takes your privacy seriously. All responses are
-                end-to-end encrypted. That means no one—not even Namesake—can
-                see your answers.
-              </Banner>
-            </header>
-            {children}
-          </Form>
-        </Container>
-        <TooltipTrigger>
-          <Button
-            className="fixed top-4 left-4 z-10"
-            onPress={() => {
-              history.go(-1);
-            }}
-            aria-label="Save and exit"
-            icon={ArrowLeft}
-            variant="icon"
-            size="large"
-          />
-          <Tooltip placement="right">Save and exit</Tooltip>
-        </TooltipTrigger>
-        <FormNavigation />
-      </FormProvider>
-    </main>
+    <FormProvider {...form}>
+      <Container className="w-full max-w-[720px] py-16 px-6">
+        <Form
+          onSubmit={onSubmit}
+          autoComplete="on"
+          className="gap-0 divide-y divide-gray-a3"
+        >
+          <header className="flex flex-col gap-6 mb-8">
+            <Heading className="text-5xl font-medium text-pretty">
+              {title}
+            </Heading>
+            {description && (
+              <p className="text-sm text-gray-dim">
+                {smartquotes(description)}
+              </p>
+            )}
+            <Banner variant="success" icon={ShieldCheck} size="large">
+              Namesake takes your privacy seriously. All responses are
+              end-to-end encrypted. That means no one—not even Namesake—can see
+              your answers.
+            </Banner>
+          </header>
+          {children}
+        </Form>
+      </Container>
+      <TooltipTrigger>
+        <Button
+          className="fixed top-4 left-4 z-10"
+          onPress={() => {
+            history.go(-1);
+          }}
+          aria-label="Save and exit"
+          icon={ArrowLeft}
+          variant="icon"
+          size="large"
+        />
+        <Tooltip placement="right">Save and exit</Tooltip>
+      </TooltipTrigger>
+      <FormNavigation />
+    </FormProvider>
   );
 }

--- a/src/components/forms/FormSection/FormSection.tsx
+++ b/src/components/forms/FormSection/FormSection.tsx
@@ -66,10 +66,7 @@ export function FormSection({
       id={getQuestionId(title)}
       data-form-section
       data-testid="form-section"
-      className={twMerge(
-        "flex flex-col gap-8 p-8 pb-9 justify-center outline-1 outline-gray-a3 shadow-sm dark:shadow-md rounded-2xl bg-app",
-        className,
-      )}
+      className={twMerge("flex flex-col gap-8 py-12 justify-center", className)}
       disabled={!isVisible}
     >
       <FormHeader title={title} description={description} />
@@ -96,7 +93,7 @@ export function FormSubsection({
   return (
     <fieldset
       className={twMerge(
-        "flex flex-col gap-8 -mx-8 px-8 pt-8 border-t border-gray-a3 justify-center",
+        "flex flex-col gap-8 pl-6 py-2 border-l-3 border-gray-a3 justify-center",
         className,
       )}
       disabled={!isVisible}

--- a/src/components/quests/JurisdictionInterstitial/JurisdictionInterstitial.test.tsx
+++ b/src/components/quests/JurisdictionInterstitial/JurisdictionInterstitial.test.tsx
@@ -65,7 +65,7 @@ describe("JurisdictionInterstitial", () => {
 
     expect(mockSetResidence).toHaveBeenCalledWith({ residence: "CA" });
     expect(mockNavigate).toHaveBeenCalledWith({
-      to: "/$questSlug",
+      to: "/quests/$questSlug",
       params: { questSlug: "test-quest" },
     });
   });

--- a/src/components/quests/JurisdictionInterstitial/JurisdictionInterstitial.tsx
+++ b/src/components/quests/JurisdictionInterstitial/JurisdictionInterstitial.tsx
@@ -64,7 +64,7 @@ export const JurisdictionInterstitial = ({
       if (findQuest?._id) {
         await addQuest({ questId: findQuest._id });
         navigate({
-          to: "/$questSlug",
+          to: "/quests/$questSlug",
           params: { questSlug: findQuest.slug },
         });
       } else {

--- a/src/components/quests/QuestsNav/QuestsNav.test.tsx
+++ b/src/components/quests/QuestsNav/QuestsNav.test.tsx
@@ -1,0 +1,144 @@
+import { CATEGORIES } from "@convex/constants";
+import { useMatchRoute } from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import { useQuery } from "convex/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QuestsNav } from "./QuestsNav";
+
+interface MockQueriesConfig {
+  user?: { birthplace: string } | undefined;
+  totalQuests?: number | undefined;
+  completedQuests?: number | undefined;
+  questsByCategory?: Record<string, any[]> | undefined;
+}
+
+const mockQueries = ({
+  user = { birthplace: "US" },
+  totalQuests = 0,
+  completedQuests = 0,
+  questsByCategory = {},
+}: MockQueriesConfig = {}) => {
+  const queryMock = useQuery as ReturnType<typeof vi.fn>;
+
+  queryMock
+    .mockReturnValueOnce(user)
+    .mockReturnValueOnce(totalQuests)
+    .mockReturnValueOnce(completedQuests)
+    .mockReturnValueOnce(questsByCategory);
+};
+
+describe("QuestsNav", () => {
+  const mockMatchRoute = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useMatchRoute as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockMatchRoute,
+    );
+  });
+
+  it("renders progress bar when there are quests", () => {
+    mockQueries({
+      totalQuests: 5,
+      completedQuests: 2,
+    });
+
+    render(<QuestsNav />);
+
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("/")).toBeInTheDocument();
+    expect(screen.getByText("5 complete")).toBeInTheDocument();
+  });
+
+  it("does not render progress bar when there are no quests", () => {
+    mockQueries();
+    render(<QuestsNav />);
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+
+  it("renders core category items when no quests exist", () => {
+    mockQueries();
+    render(<QuestsNav />);
+
+    // Check for core category labels
+    expect(screen.getByText(CATEGORIES.courtOrder.label)).toBeInTheDocument();
+    expect(
+      screen.getByText(CATEGORIES.socialSecurity.label),
+    ).toBeInTheDocument();
+    expect(screen.getByText(CATEGORIES.stateId.label)).toBeInTheDocument();
+    expect(screen.getByText(CATEGORIES.passport.label)).toBeInTheDocument();
+    expect(
+      screen.getByText(CATEGORIES.birthCertificate.label),
+    ).toBeInTheDocument();
+  });
+
+  it("hides birth certificate option for users born outside US", () => {
+    mockQueries({
+      user: { birthplace: "other" },
+    });
+
+    render(<QuestsNav />);
+    expect(
+      screen.queryByText(CATEGORIES.birthCertificate.label),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders quest items with status badges and jurisdiction", () => {
+    mockQueries({
+      totalQuests: 1,
+      questsByCategory: {
+        courtOrder: [
+          {
+            _id: "quest1",
+            slug: "ma-court-order",
+            title: "MA Court Order",
+            status: "inProgress",
+            jurisdiction: "Massachusetts",
+            category: "courtOrder",
+          },
+        ],
+      },
+    });
+
+    render(<QuestsNav />);
+
+    expect(screen.getByText("MA Court Order")).toBeInTheDocument();
+    expect(screen.getByText("Massachusetts")).toBeInTheDocument();
+    expect(screen.getByLabelText("In progress")).toBeInTheDocument();
+  });
+
+  it("renders additional quest groups", () => {
+    mockQueries({
+      totalQuests: 1,
+      questsByCategory: {
+        other: [
+          {
+            _id: "quest2",
+            slug: "other-quest",
+            title: "Other Quest",
+            status: "notStarted",
+            category: "other",
+          },
+        ],
+      },
+    });
+
+    render(<QuestsNav />);
+
+    expect(screen.getByText("Other Quest")).toBeInTheDocument();
+    expect(screen.getByLabelText("Not started")).toBeInTheDocument();
+  });
+
+  it("handles loading state when queries return undefined", () => {
+    mockQueries({
+      user: undefined,
+      totalQuests: undefined,
+      completedQuests: undefined,
+      questsByCategory: undefined,
+    });
+
+    render(<QuestsNav />);
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/quests/QuestsNav/QuestsNav.tsx
+++ b/src/components/quests/QuestsNav/QuestsNav.tsx
@@ -1,0 +1,158 @@
+import {
+  Badge,
+  Nav,
+  NavGroup,
+  NavItem,
+  ProgressBar,
+} from "@/components/common";
+import { StatusBadge } from "@/components/quests";
+import { api } from "@convex/_generated/api";
+import {
+  CATEGORIES,
+  type Category,
+  type CoreCategory,
+  type Status,
+} from "@convex/constants";
+import { useQuery } from "convex/react";
+import type { LucideIcon } from "lucide-react";
+
+export const QuestsNav = () => {
+  const user = useQuery(api.users.getCurrent);
+  const userQuests = useQuery(api.userQuests.count) ?? 0;
+  const completedQuests = useQuery(api.userQuests.countCompleted) ?? 0;
+  const questsByCategory = useQuery(api.userQuests.getByCategory);
+
+  const CORE_CATEGORIES: Record<
+    CoreCategory,
+    { to: string; label: string; icon: LucideIcon }
+  > = {
+    courtOrder: {
+      to: "court-order",
+      label: CATEGORIES.courtOrder.label,
+      icon: CATEGORIES.courtOrder.icon,
+    },
+    socialSecurity: {
+      to: "social-security",
+      label: CATEGORIES.socialSecurity.label,
+      icon: CATEGORIES.socialSecurity.icon,
+    },
+    stateId: {
+      to: "state-id",
+      label: CATEGORIES.stateId.label,
+      icon: CATEGORIES.stateId.icon,
+    },
+    passport: {
+      to: "passport",
+      label: CATEGORIES.passport.label,
+      icon: CATEGORIES.passport.icon,
+    },
+    birthCertificate: {
+      to: "birth-certificate",
+      label: CATEGORIES.birthCertificate.label,
+      icon: CATEGORIES.birthCertificate.icon,
+    },
+  } as const;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {userQuests > 0 && (
+        <div className="flex items-center">
+          <ProgressBar
+            label="Quest progress"
+            value={completedQuests}
+            maxValue={userQuests}
+            valueLabel={
+              <span className="text-gray-normal">
+                <span className="text-gray-normal text-base font-medium mr-0.5 leading-none">
+                  {completedQuests}
+                </span>{" "}
+                <span className="text-gray-8">/</span>{" "}
+                <span className="text-gray-dim">{userQuests} complete</span>
+              </span>
+            }
+            labelHidden
+          />
+        </div>
+      )}
+      <Nav>
+        {(Object.keys(CORE_CATEGORIES) as CoreCategory[]).map((category) => {
+          const userQuest = questsByCategory?.[category]?.[0];
+          const config = CORE_CATEGORIES[category];
+
+          if (category === "birthCertificate" && user?.birthplace === "other") {
+            return null;
+          }
+
+          if (userQuest) {
+            return (
+              <NavItem
+                key={userQuest._id}
+                href={{
+                  to: "/$questSlug",
+                  params: { questSlug: userQuest.slug },
+                }}
+                icon={config.icon}
+                size="large"
+              >
+                {userQuest.title}
+                {userQuest.jurisdiction && (
+                  <Badge size="xs">{userQuest.jurisdiction}</Badge>
+                )}
+                <StatusBadge
+                  status={userQuest.status as Status}
+                  condensed
+                  className="ml-auto mr-1"
+                />
+              </NavItem>
+            );
+          }
+
+          return (
+            <NavItem
+              key={category}
+              href={{ to: "/$questSlug", params: { questSlug: config.to } }}
+              icon={config.icon}
+              size="large"
+              className="border border-dashed border-gray-dim"
+            >
+              {config.label}
+            </NavItem>
+          );
+        })}
+
+        {questsByCategory &&
+          Object.entries(questsByCategory).map(([group, quests]) => {
+            if (quests.length === 0 || group in CORE_CATEGORIES) return null;
+
+            const { label } = CATEGORIES[group as keyof typeof CATEGORIES];
+
+            return (
+              <NavGroup key={label} label={label}>
+                {quests.map((quest) => (
+                  <NavItem
+                    key={quest._id}
+                    href={{
+                      to: "/$questSlug",
+                      params: { questSlug: quest.slug },
+                    }}
+                    size="large"
+                    icon={CATEGORIES[quest.category as Category].icon}
+                  >
+                    {quest.title}
+                    {quest.jurisdiction && (
+                      <Badge size="xs">{quest.jurisdiction}</Badge>
+                    )}
+                    <StatusBadge
+                      status={quest.status as Status}
+                      condensed
+                      className="ml-auto mr-1"
+                    />
+                  </NavItem>
+                ))}
+              </NavGroup>
+            );
+          })}
+      </Nav>
+    </div>
+  );
+};

--- a/src/components/quests/QuestsNav/QuestsNav.tsx
+++ b/src/components/quests/QuestsNav/QuestsNav.tsx
@@ -88,7 +88,7 @@ export const QuestsNav = () => {
               <NavItem
                 key={userQuest._id}
                 href={{
-                  to: "/$questSlug",
+                  to: "/quests/$questSlug",
                   params: { questSlug: userQuest.slug },
                 }}
                 icon={config.icon}
@@ -110,7 +110,10 @@ export const QuestsNav = () => {
           return (
             <NavItem
               key={category}
-              href={{ to: "/$questSlug", params: { questSlug: config.to } }}
+              href={{
+                to: "/quests/$questSlug",
+                params: { questSlug: config.to },
+              }}
               icon={config.icon}
               size="large"
               className="border border-dashed border-gray-dim"
@@ -132,7 +135,7 @@ export const QuestsNav = () => {
                   <NavItem
                     key={quest._id}
                     href={{
-                      to: "/$questSlug",
+                      to: "/quests/$questSlug",
                       params: { questSlug: quest.slug },
                     }}
                     size="large"

--- a/src/components/quests/QuestsNav/QuestsNav.tsx
+++ b/src/components/quests/QuestsNav/QuestsNav.tsx
@@ -130,7 +130,7 @@ export const QuestsNav = () => {
             const { label } = CATEGORIES[group as keyof typeof CATEGORIES];
 
             return (
-              <NavGroup key={label} label={label}>
+              <NavGroup key={label}>
                 {quests.map((quest) => (
                   <NavItem
                     key={quest._id}

--- a/src/components/quests/index.ts
+++ b/src/components/quests/index.ts
@@ -11,6 +11,7 @@ export * from "./QuestSection/QuestSection";
 export * from "./QuestSteps/QuestSteps";
 export * from "./QuestTimeRequired/QuestTimeRequired";
 export * from "./QuestUsageCount/QuestUsageCount";
+export * from "./QuestsNav/QuestsNav";
 export * from "./ReadingScore/ReadingScore";
 export * from "./StatGroup/StatGroup";
 export * from "./StatusSelect/StatusSelect";

--- a/src/components/settings/EditBirthplaceSetting/EditBirthplaceSetting.tsx
+++ b/src/components/settings/EditBirthplaceSetting/EditBirthplaceSetting.tsx
@@ -55,7 +55,7 @@ export const EditBirthplaceSetting = ({ user }: EditBirthplaceSettingProps) => {
   return (
     <SettingsItem
       label="Birthplace"
-      description="Where were you born? This location is used to select the forms for your birth certificate."
+      description="Where were you born? This helps select the form for your birth certificate."
     >
       <Form onSubmit={handleSubmit} className="gap-2 items-end">
         <Select

--- a/src/components/settings/EditEmailSetting/EditEmailSetting.tsx
+++ b/src/components/settings/EditEmailSetting/EditEmailSetting.tsx
@@ -1,4 +1,11 @@
-import { Banner, Button, Form, TextField } from "@/components/common";
+import {
+  Banner,
+  Button,
+  DialogTrigger,
+  Form,
+  Popover,
+  TextField,
+} from "@/components/common";
 import { SettingsItem } from "@/components/settings";
 import { api } from "@convex/_generated/api";
 import type { Doc } from "@convex/_generated/dataModel";
@@ -47,45 +54,51 @@ export const EditEmailSetting = ({ user }: EditEmailSettingProps) => {
 
   return (
     <SettingsItem label="Email">
-      {!isEditing ? (
+      <DialogTrigger>
         <Button onPress={() => setIsEditing(true)}>
           <span className="truncate max-w-[24ch]">
             {user?.email ?? "Set email"}
           </span>
         </Button>
-      ) : (
-        <Form onSubmit={handleSubmit} className="gap-2">
-          <TextField
-            aria-label="Email"
-            name="email"
-            type="email"
-            value={email}
-            onChange={(value) => setEmail(value)}
-            className="w-60 max-w-full"
-            isRequired
-            autoFocus
-          />
-          <div className="flex gap-1 justify-end">
-            <Button
-              variant="secondary"
-              isDisabled={isSubmitting}
-              size="small"
-              onPress={() => setIsEditing(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              variant="primary"
-              size="small"
-              isDisabled={isSubmitting}
-            >
-              Save
-            </Button>
-          </div>
-          {error && <Banner variant="danger">{error}</Banner>}
-        </Form>
-      )}
+        <Popover
+          title="Edit email"
+          className="p-2"
+          placement="bottom end"
+          isOpen={isEditing}
+        >
+          <Form onSubmit={handleSubmit} className="gap-2">
+            <TextField
+              aria-label="Email"
+              name="email"
+              type="email"
+              value={email}
+              onChange={(value) => setEmail(value)}
+              className="w-60 max-w-full"
+              isRequired
+              autoFocus
+            />
+            <div className="flex gap-1 justify-end">
+              <Button
+                variant="secondary"
+                isDisabled={isSubmitting}
+                size="small"
+                onPress={() => setIsEditing(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                size="small"
+                isDisabled={isSubmitting}
+              >
+                Save
+              </Button>
+            </div>
+            {error && <Banner variant="danger">{error}</Banner>}
+          </Form>
+        </Popover>
+      </DialogTrigger>
     </SettingsItem>
   );
 };

--- a/src/components/settings/EditEmailSetting/EditEmailSetting.tsx
+++ b/src/components/settings/EditEmailSetting/EditEmailSetting.tsx
@@ -46,10 +46,7 @@ export const EditEmailSetting = ({ user }: EditEmailSettingProps) => {
   };
 
   return (
-    <SettingsItem
-      label="Email address"
-      description="What email would you like to use for Namesake?"
-    >
+    <SettingsItem label="Email">
       {!isEditing ? (
         <Button onPress={() => setIsEditing(true)}>
           <span className="truncate max-w-[24ch]">

--- a/src/components/settings/EditMinorSetting/EditMinorSetting.test.tsx
+++ b/src/components/settings/EditMinorSetting/EditMinorSetting.test.tsx
@@ -22,9 +22,7 @@ describe("EditMinorSetting", () => {
 
     expect(screen.getByText("Under 18")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Are you under 18 years old or applying on behalf of someone who is?",
-      ),
+      screen.getByText("Are you applying as a minor?"),
     ).toBeInTheDocument();
     expect(screen.getByRole("switch", { name: "Is minor" })).not.toBeChecked();
   });

--- a/src/components/settings/EditMinorSetting/EditMinorSetting.tsx
+++ b/src/components/settings/EditMinorSetting/EditMinorSetting.tsx
@@ -12,10 +12,7 @@ export const EditMinorSetting = ({ user }: EditMinorSettingProps) => {
   const updateIsMinor = useMutation(api.users.setCurrentUserIsMinor);
 
   return (
-    <SettingsItem
-      label="Under 18"
-      description="Are you under 18 years old or applying on behalf of someone who is?"
-    >
+    <SettingsItem label="Under 18" description="Are you applying as a minor?">
       <Switch
         name="isMinor"
         isSelected={user.isMinor ?? false}

--- a/src/components/settings/EditNameSetting/EditNameSetting.tsx
+++ b/src/components/settings/EditNameSetting/EditNameSetting.tsx
@@ -1,4 +1,11 @@
-import { Banner, Button, Form, TextField } from "@/components/common";
+import {
+  Banner,
+  Button,
+  DialogTrigger,
+  Form,
+  Popover,
+  TextField,
+} from "@/components/common";
 import { SettingsItem } from "@/components/settings";
 import { api } from "@convex/_generated/api";
 import type { Doc } from "@convex/_generated/dataModel";
@@ -48,46 +55,52 @@ export const EditNameSetting = ({ user }: EditNameSettingProps) => {
       label="Display name"
       description="How should Namesake refer to you? This can be different from your legal name."
     >
-      {!isEditing ? (
+      <DialogTrigger>
         <Button onPress={() => setIsEditing(true)}>
           <span className="truncate max-w-[24ch]">
             {user?.name ?? "Set name"}
           </span>
         </Button>
-      ) : (
-        <Form onSubmit={handleSubmit} className="gap-2">
-          <TextField
-            aria-label="Name"
-            name="name"
-            value={name}
-            onChange={(value) => {
-              setName(value);
-              setError(undefined);
-            }}
-            className="w-full"
-            isRequired
-            autoFocus
-          />
-          <div className="flex gap-1 justify-end">
-            <Button
-              size="small"
-              isDisabled={isSubmitting}
-              onPress={handleCancel}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              variant="primary"
-              isDisabled={isSubmitting}
-              size="small"
-            >
-              Save
-            </Button>
-          </div>
-          {error && <Banner variant="danger">{error}</Banner>}
-        </Form>
-      )}
+        <Popover
+          title="Edit name"
+          className="p-2"
+          placement="bottom end"
+          isOpen={isEditing}
+        >
+          <Form onSubmit={handleSubmit} className="gap-2">
+            <TextField
+              aria-label="Name"
+              name="name"
+              value={name}
+              onChange={(value) => {
+                setName(value);
+                setError(undefined);
+              }}
+              className="w-full"
+              isRequired
+              autoFocus
+            />
+            <div className="flex gap-1 justify-end">
+              <Button
+                size="small"
+                isDisabled={isSubmitting}
+                onPress={handleCancel}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                isDisabled={isSubmitting}
+                size="small"
+              >
+                Save
+              </Button>
+            </div>
+            {error && <Banner variant="danger">{error}</Banner>}
+          </Form>
+        </Popover>
+      </DialogTrigger>
     </SettingsItem>
   );
 };

--- a/src/components/settings/EditResidenceSetting/EditResidenceSetting.tsx
+++ b/src/components/settings/EditResidenceSetting/EditResidenceSetting.tsx
@@ -57,7 +57,7 @@ export const EditResidenceSetting = ({ user }: EditResidenceSettingProps) => {
   return (
     <SettingsItem
       label="Residence"
-      description="Where do you live? This location is used to select the forms for your court order and state ID."
+      description="Where do you live? This helps select the forms for your court order and state ID."
     >
       <Form onSubmit={handleSubmit} className="gap-2 items-end">
         <Select

--- a/src/components/settings/EditThemeSetting/EditThemeSetting.test.tsx
+++ b/src/components/settings/EditThemeSetting/EditThemeSetting.test.tsx
@@ -25,7 +25,6 @@ describe("EditThemeSetting", () => {
 
   it("renders component correctly with correct initial theme", () => {
     render(<EditThemeSetting />);
-    expect(screen.getByText("Theme")).toBeInTheDocument();
     for (const theme of Object.values(THEMES)) {
       expect(screen.getByText(theme.label)).toBeInTheDocument();
     }

--- a/src/components/settings/EditThemeSetting/EditThemeSetting.test.tsx
+++ b/src/components/settings/EditThemeSetting/EditThemeSetting.test.tsx
@@ -26,7 +26,6 @@ describe("EditThemeSetting", () => {
   it("renders component correctly with correct initial theme", () => {
     render(<EditThemeSetting />);
     expect(screen.getByText("Theme")).toBeInTheDocument();
-    expect(screen.getByText("Adjust your display.")).toBeInTheDocument();
     for (const theme of Object.values(THEMES)) {
       expect(screen.getByText(theme.label)).toBeInTheDocument();
     }

--- a/src/components/settings/EditThemeSetting/EditThemeSetting.tsx
+++ b/src/components/settings/EditThemeSetting/EditThemeSetting.tsx
@@ -1,5 +1,4 @@
 import { ToggleButton, ToggleButtonGroup } from "@/components/common";
-import { SettingsItem } from "@/components/settings";
 import { useTheme } from "@/utils/useTheme";
 import { THEMES } from "@convex/constants";
 
@@ -7,19 +6,17 @@ export const EditThemeSetting = () => {
   const { themeSelection, setTheme } = useTheme();
 
   return (
-    <SettingsItem label="Theme">
-      <ToggleButtonGroup
-        selectionMode="single"
-        disallowEmptySelection
-        selectedKeys={themeSelection}
-        onSelectionChange={setTheme}
-      >
-        {Object.entries(THEMES).map(([theme, details]) => (
-          <ToggleButton key={theme} id={theme}>
-            {details.label}
-          </ToggleButton>
-        ))}
-      </ToggleButtonGroup>
-    </SettingsItem>
+    <ToggleButtonGroup
+      selectionMode="single"
+      disallowEmptySelection
+      selectedKeys={themeSelection}
+      onSelectionChange={setTheme}
+    >
+      {Object.entries(THEMES).map(([theme, details]) => (
+        <ToggleButton key={theme} id={theme}>
+          {details.label}
+        </ToggleButton>
+      ))}
+    </ToggleButtonGroup>
   );
 };

--- a/src/components/settings/EditThemeSetting/EditThemeSetting.tsx
+++ b/src/components/settings/EditThemeSetting/EditThemeSetting.tsx
@@ -7,7 +7,7 @@ export const EditThemeSetting = () => {
   const { themeSelection, setTheme } = useTheme();
 
   return (
-    <SettingsItem label="Theme" description="Adjust your display.">
+    <SettingsItem label="Theme">
       <ToggleButtonGroup
         selectionMode="single"
         disallowEmptySelection

--- a/src/components/settings/SettingsGroup/SettingsGroup.tsx
+++ b/src/components/settings/SettingsGroup/SettingsGroup.tsx
@@ -1,4 +1,3 @@
-import { Card } from "@/components/common";
 import { Heading } from "react-aria-components";
 
 type SettingsGroupProps = {
@@ -7,10 +6,8 @@ type SettingsGroupProps = {
 };
 
 export const SettingsGroup = ({ title, children }: SettingsGroupProps) => (
-  <section className="flex flex-col gap-4 mb-8 last-of-type:mb-0">
-    <Heading className="text-lg font-medium">{title}</Heading>
-    <Card className="flex flex-col p-0 divide-gray-dim divide-y-[0.5px]">
-      {children}
-    </Card>
+  <section className="flex flex-col mb-8 last-of-type:mb-0">
+    <Heading className="text-lg font-medium mb-4">{title}</Heading>
+    {children}
   </section>
 );

--- a/src/components/settings/SettingsItem/SettingsItem.tsx
+++ b/src/components/settings/SettingsItem/SettingsItem.tsx
@@ -11,7 +11,7 @@ export const SettingsItem = ({
   description,
   children,
 }: SettingsItemProps) => (
-  <div className="flex justify-between items-center gap-x-4 gap-y-3 min-h-16 py-3 px-4">
+  <div className="flex justify-between items-center gap-x-4 gap-y-3 min-h-16 py-3 px-4 border border-gray-dim first-of-type:rounded-t-lg last-of-type:rounded-b-lg not-first-of-type:border-t-0 not-last-of-type:border-b-gray-a3">
     <div>
       <Heading className="text-base -mt-px">{label}</Heading>
       {description && (

--- a/src/components/settings/SettingsItem/SettingsItem.tsx
+++ b/src/components/settings/SettingsItem/SettingsItem.tsx
@@ -15,7 +15,7 @@ export const SettingsItem = ({
     <div className="self-start">
       <Heading className="text-base -mt-px">{label}</Heading>
       {description && (
-        <p className="text-xs text-gray-dim text-balance mt-0.5">
+        <p className="text-xs text-gray-dim text-pretty mt-0.5 max-w-[40ch]">
           {description}
         </p>
       )}

--- a/src/components/settings/SettingsItem/SettingsItem.tsx
+++ b/src/components/settings/SettingsItem/SettingsItem.tsx
@@ -11,8 +11,8 @@ export const SettingsItem = ({
   description,
   children,
 }: SettingsItemProps) => (
-  <div className="flex flex-wrap justify-between items-center gap-x-4 gap-y-3 p-4">
-    <div className="self-start">
+  <div className="flex justify-between items-center gap-x-4 gap-y-3 min-h-16 py-3 px-4">
+    <div>
       <Heading className="text-base -mt-px">{label}</Heading>
       {description && (
         <p className="text-xs text-gray-dim text-pretty mt-0.5 max-w-[40ch]">

--- a/src/components/settings/SettingsItem/SettingsItem.tsx
+++ b/src/components/settings/SettingsItem/SettingsItem.tsx
@@ -11,7 +11,7 @@ export const SettingsItem = ({
   description,
   children,
 }: SettingsItemProps) => (
-  <div className="flex justify-between items-center gap-8 p-4">
+  <div className="flex flex-wrap justify-between items-center gap-x-4 gap-y-3 p-4">
     <div className="self-start">
       <Heading className="text-base -mt-px">{label}</Heading>
       {description && (

--- a/src/components/settings/SettingsItem/SettingsItem.tsx
+++ b/src/components/settings/SettingsItem/SettingsItem.tsx
@@ -11,7 +11,7 @@ export const SettingsItem = ({
   description,
   children,
 }: SettingsItemProps) => (
-  <div className="flex justify-between items-center gap-x-4 gap-y-3 min-h-16 py-3 px-4 border border-gray-dim first-of-type:rounded-t-lg last-of-type:rounded-b-lg not-first-of-type:border-t-0 not-last-of-type:border-b-gray-a3">
+  <div className="flex justify-between items-center gap-x-4 gap-y-3 min-h-16 py-3 px-4 border border-gray-dim first-of-type:rounded-t-xl last-of-type:rounded-b-xl not-first-of-type:border-t-0 not-last-of-type:border-b-gray-a3">
     <div>
       <Heading className="text-base -mt-px">{label}</Heading>
       {description && (

--- a/src/components/settings/SettingsNav/SettingsNav.test.tsx
+++ b/src/components/settings/SettingsNav/SettingsNav.test.tsx
@@ -1,0 +1,72 @@
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useMatchRoute, useNavigate } from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SettingsNav } from "./SettingsNav";
+
+const mockMatchRoute = vi.fn();
+
+describe("SettingsNav", () => {
+  const mockSignOut = vi.fn();
+  const mockNavigate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useAuthActions as ReturnType<typeof vi.fn>).mockReturnValue({
+      signOut: mockSignOut,
+    });
+    (useNavigate as ReturnType<typeof vi.fn>).mockReturnValue(mockNavigate);
+    (useMatchRoute as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockMatchRoute,
+    );
+  });
+
+  it("renders all navigation items", () => {
+    render(<SettingsNav />);
+
+    expect(screen.getByText("Account")).toBeInTheDocument();
+    expect(screen.getByText("Form Responses")).toBeInTheDocument();
+
+    expect(screen.getByText("About")).toBeInTheDocument();
+    expect(screen.getByText(/Changelog/)).toBeInTheDocument();
+    expect(screen.getByText("Report an Issue")).toBeInTheDocument();
+    expect(screen.getByText("System Status")).toBeInTheDocument();
+    expect(screen.getByText("Discord Community")).toBeInTheDocument();
+
+    expect(screen.getByText("Terms of Service")).toBeInTheDocument();
+    expect(screen.getByText("Privacy Policy")).toBeInTheDocument();
+
+    expect(screen.getByText("Sign out")).toBeInTheDocument();
+  });
+
+  it("handles sign out correctly", async () => {
+    render(<SettingsNav />);
+
+    const signOutButton = screen.getByText("Sign out");
+    await userEvent.click(signOutButton);
+
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/signin" });
+  });
+
+  it("renders external links with correct attributes", () => {
+    render(<SettingsNav />);
+
+    // Test specific external links we know should have these attributes
+    const externalLinkTexts = [
+      "About",
+      "Report an Issue",
+      "System Status",
+      "Discord Community",
+      "Terms of Service",
+      "Privacy Policy",
+    ];
+
+    for (const linkText of externalLinkTexts) {
+      const link = screen.getByText(linkText);
+      expect(link.closest("a")).toHaveAttribute("target", "_blank");
+      expect(link.closest("a")).toHaveAttribute("rel", "noreferrer");
+    }
+  });
+});

--- a/src/components/settings/SettingsNav/SettingsNav.tsx
+++ b/src/components/settings/SettingsNav/SettingsNav.tsx
@@ -5,6 +5,7 @@ import {
   DatabaseZap,
   FileClock,
   FileLock2,
+  LogOut,
   MessageCircleQuestion,
   Snail,
 } from "lucide-react";
@@ -12,7 +13,7 @@ import {
 export const SettingsNav = () => {
   return (
     <Nav>
-      <NavGroup label="Settings">
+      <NavGroup>
         <NavItem icon={CircleUser} href={{ to: "/settings/account" }}>
           Account
         </NavItem>
@@ -20,14 +21,14 @@ export const SettingsNav = () => {
           Form Responses
         </NavItem>
       </NavGroup>
-      <NavGroup label="Help">
+      <NavGroup>
         <NavItem
           icon={Snail}
           href="https://namesake.fyi"
           target="_blank"
           rel="noreferrer"
         >
-          About Namesake
+          About
         </NavItem>
         <NavItem
           icon={FileClock}
@@ -35,7 +36,7 @@ export const SettingsNav = () => {
           target="_blank"
           rel="noreferrer"
         >
-          View Changelog (v{APP_VERSION})
+          Changelog (v{APP_VERSION})
         </NavItem>
         <NavItem
           href="https://github.com/namesakefyi/namesake/issues/new/choose"
@@ -62,7 +63,7 @@ export const SettingsNav = () => {
           Discord Community
         </NavItem>
       </NavGroup>
-      <NavGroup label="Legal">
+      <NavGroup>
         <NavItem
           href="https://namesake.fyi/terms"
           target="_blank"
@@ -76,6 +77,11 @@ export const SettingsNav = () => {
           rel="noreferrer"
         >
           Privacy Policy
+        </NavItem>
+      </NavGroup>
+      <NavGroup>
+        <NavItem href={{ to: "/signout" }} icon={LogOut}>
+          Sign out
         </NavItem>
       </NavGroup>
     </Nav>

--- a/src/components/settings/SettingsNav/SettingsNav.tsx
+++ b/src/components/settings/SettingsNav/SettingsNav.tsx
@@ -1,4 +1,6 @@
 import { Nav, NavGroup, NavItem } from "@/components/common";
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useNavigate } from "@tanstack/react-router";
 import {
   Bug,
   CircleUser,
@@ -11,6 +13,14 @@ import {
 } from "lucide-react";
 
 export const SettingsNav = () => {
+  const { signOut } = useAuthActions();
+  const navigate = useNavigate();
+
+  const handleSignOut = async () => {
+    await signOut();
+    navigate({ to: "/signin" });
+  };
+
   return (
     <Nav>
       <NavGroup>
@@ -80,7 +90,7 @@ export const SettingsNav = () => {
         </NavItem>
       </NavGroup>
       <NavGroup>
-        <NavItem href={{ to: "/signout" }} icon={LogOut}>
+        <NavItem onClick={handleSignOut} icon={LogOut}>
           Sign out
         </NavItem>
       </NavGroup>

--- a/src/components/settings/SettingsNav/SettingsNav.tsx
+++ b/src/components/settings/SettingsNav/SettingsNav.tsx
@@ -1,0 +1,83 @@
+import { Nav, NavGroup, NavItem } from "@/components/common";
+import {
+  Bug,
+  CircleUser,
+  DatabaseZap,
+  FileClock,
+  FileLock2,
+  MessageCircleQuestion,
+  Snail,
+} from "lucide-react";
+
+export const SettingsNav = () => {
+  return (
+    <Nav>
+      <NavGroup label="Settings">
+        <NavItem icon={CircleUser} href={{ to: "/settings/account" }}>
+          Account
+        </NavItem>
+        <NavItem icon={FileLock2} href={{ to: "/settings/responses" }}>
+          Form Responses
+        </NavItem>
+      </NavGroup>
+      <NavGroup label="Help">
+        <NavItem
+          icon={Snail}
+          href="https://namesake.fyi"
+          target="_blank"
+          rel="noreferrer"
+        >
+          About Namesake
+        </NavItem>
+        <NavItem
+          icon={FileClock}
+          href="https://github.com/namesakefyi/namesake/releases"
+          target="_blank"
+          rel="noreferrer"
+        >
+          View Changelog (v{APP_VERSION})
+        </NavItem>
+        <NavItem
+          href="https://github.com/namesakefyi/namesake/issues/new/choose"
+          target="_blank"
+          rel="noreferrer"
+          icon={Bug}
+        >
+          Report an Issue
+        </NavItem>
+        <NavItem
+          icon={DatabaseZap}
+          href="https://status.namesake.fyi"
+          target="_blank"
+          rel="noreferrer"
+        >
+          System Status
+        </NavItem>
+        <NavItem
+          href="https://namesake.fyi/chat"
+          target="_blank"
+          rel="noreferrer"
+          icon={MessageCircleQuestion}
+        >
+          Discord Community
+        </NavItem>
+      </NavGroup>
+      <NavGroup label="Legal">
+        <NavItem
+          href="https://namesake.fyi/terms"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Terms of Service
+        </NavItem>
+        <NavItem
+          href="https://namesake.fyi/privacy"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Privacy Policy
+        </NavItem>
+      </NavGroup>
+    </Nav>
+  );
+};

--- a/src/components/settings/SettingsNavHeader/SettingsNavHeader.tsx
+++ b/src/components/settings/SettingsNavHeader/SettingsNavHeader.tsx
@@ -1,0 +1,3 @@
+export const SettingsNavHeader = () => {
+  return <header>SettingsNavHeader</header>;
+};

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -9,3 +9,4 @@ export * from "./EditThemeSetting/EditThemeSetting";
 export * from "./FormResponsesList/FormResponsesList";
 export * from "./SettingsGroup/SettingsGroup";
 export * from "./SettingsItem/SettingsItem";
+export * from "./SettingsNav/SettingsNav";

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -7,7 +7,7 @@ export const focusRing = tv({
   variants: {
     isFocusVisible: {
       false: "outline-transparent",
-      true: "outline-3 outline-purple-a9 animate-focus-ring-in motion-reduce:animate-none z-9999",
+      true: "outline-3 outline-purple-a9 animate-focus-ring-in motion-reduce:animate-none",
     },
   },
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -40,7 +40,7 @@ const NotFoundComponent = () => (
       }}
       link={{
         children: "Go home",
-        href: { to: "/" },
+        href: "/",
         button: {
           variant: "secondary",
         },

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as rootRoute } from './routes/__root'
 import { Route as UnauthenticatedImport } from './routes/_unauthenticated'
 import { Route as AuthenticatedImport } from './routes/_authenticated'
 import { Route as UnauthenticatedSigninImport } from './routes/_unauthenticated/signin'
+import { Route as AuthenticatedSignoutImport } from './routes/_authenticated/signout'
 import { Route as AuthenticatedHomeImport } from './routes/_authenticated/_home'
 import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticated/settings/route'
 import { Route as AuthenticatedAdminRouteImport } from './routes/_authenticated/admin/route'
@@ -47,6 +48,12 @@ const UnauthenticatedSigninRoute = UnauthenticatedSigninImport.update({
   id: '/signin',
   path: '/signin',
   getParentRoute: () => UnauthenticatedRoute,
+} as any)
+
+const AuthenticatedSignoutRoute = AuthenticatedSignoutImport.update({
+  id: '/signout',
+  path: '/signout',
+  getParentRoute: () => AuthenticatedRoute,
 } as any)
 
 const AuthenticatedHomeRoute = AuthenticatedHomeImport.update({
@@ -195,6 +202,13 @@ declare module '@tanstack/react-router' {
       path: ''
       fullPath: ''
       preLoaderRoute: typeof AuthenticatedHomeImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/signout': {
+      id: '/_authenticated/signout'
+      path: '/signout'
+      fullPath: '/signout'
+      preLoaderRoute: typeof AuthenticatedSignoutImport
       parentRoute: typeof AuthenticatedImport
     }
     '/_unauthenticated/signin': {
@@ -362,6 +376,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAdminRouteRoute: typeof AuthenticatedAdminRouteRouteWithChildren
   AuthenticatedSettingsRouteRoute: typeof AuthenticatedSettingsRouteRouteWithChildren
   AuthenticatedHomeRoute: typeof AuthenticatedHomeRouteWithChildren
+  AuthenticatedSignoutRoute: typeof AuthenticatedSignoutRoute
   AuthenticatedFormsMaCourtOrderRoute: typeof AuthenticatedFormsMaCourtOrderRoute
   AuthenticatedDocumentsIndexRoute: typeof AuthenticatedDocumentsIndexRoute
 }
@@ -370,6 +385,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAdminRouteRoute: AuthenticatedAdminRouteRouteWithChildren,
   AuthenticatedSettingsRouteRoute: AuthenticatedSettingsRouteRouteWithChildren,
   AuthenticatedHomeRoute: AuthenticatedHomeRouteWithChildren,
+  AuthenticatedSignoutRoute: AuthenticatedSignoutRoute,
   AuthenticatedFormsMaCourtOrderRoute: AuthenticatedFormsMaCourtOrderRoute,
   AuthenticatedDocumentsIndexRoute: AuthenticatedDocumentsIndexRoute,
 }
@@ -394,6 +410,7 @@ export interface FileRoutesByFullPath {
   '': typeof AuthenticatedHomeRouteWithChildren
   '/admin': typeof AuthenticatedAdminRouteRouteWithChildren
   '/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
+  '/signout': typeof AuthenticatedSignoutRoute
   '/signin': typeof UnauthenticatedSigninRoute
   '/forms/ma-court-order': typeof AuthenticatedFormsMaCourtOrderRoute
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
@@ -412,6 +429,7 @@ export interface FileRoutesByFullPath {
 
 export interface FileRoutesByTo {
   '': typeof UnauthenticatedRouteWithChildren
+  '/signout': typeof AuthenticatedSignoutRoute
   '/signin': typeof UnauthenticatedSigninRoute
   '/forms/ma-court-order': typeof AuthenticatedFormsMaCourtOrderRoute
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
@@ -435,6 +453,7 @@ export interface FileRoutesById {
   '/_authenticated/admin': typeof AuthenticatedAdminRouteRouteWithChildren
   '/_authenticated/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
   '/_authenticated/_home': typeof AuthenticatedHomeRouteWithChildren
+  '/_authenticated/signout': typeof AuthenticatedSignoutRoute
   '/_unauthenticated/signin': typeof UnauthenticatedSigninRoute
   '/_authenticated/forms/ma-court-order': typeof AuthenticatedFormsMaCourtOrderRoute
   '/_authenticated/settings/account': typeof AuthenticatedSettingsAccountRoute
@@ -457,6 +476,7 @@ export interface FileRouteTypes {
     | ''
     | '/admin'
     | '/settings'
+    | '/signout'
     | '/signin'
     | '/forms/ma-court-order'
     | '/settings/account'
@@ -474,6 +494,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | ''
+    | '/signout'
     | '/signin'
     | '/forms/ma-court-order'
     | '/settings/account'
@@ -495,6 +516,7 @@ export interface FileRouteTypes {
     | '/_authenticated/admin'
     | '/_authenticated/settings'
     | '/_authenticated/_home'
+    | '/_authenticated/signout'
     | '/_unauthenticated/signin'
     | '/_authenticated/forms/ma-court-order'
     | '/_authenticated/settings/account'
@@ -542,6 +564,7 @@ export const routeTree = rootRoute
         "/_authenticated/admin",
         "/_authenticated/settings",
         "/_authenticated/_home",
+        "/_authenticated/signout",
         "/_authenticated/forms/ma-court-order",
         "/_authenticated/documents/"
       ]
@@ -580,6 +603,10 @@ export const routeTree = rootRoute
         "/_authenticated/_home/state-id/",
         "/_authenticated/_home/quests/$questSlug/"
       ]
+    },
+    "/_authenticated/signout": {
+      "filePath": "_authenticated/signout.tsx",
+      "parent": "/_authenticated"
     },
     "/_unauthenticated/signin": {
       "filePath": "_unauthenticated/signin.tsx",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -29,7 +29,7 @@ import { Route as AuthenticatedAdminEarlyAccessIndexImport } from './routes/_aut
 import { Route as AuthenticatedHomeStateIdIndexImport } from './routes/_authenticated/_home/state-id.index'
 import { Route as AuthenticatedHomeCourtOrderIndexImport } from './routes/_authenticated/_home/court-order.index'
 import { Route as AuthenticatedHomeBirthCertificateIndexImport } from './routes/_authenticated/_home/birth-certificate.index'
-import { Route as AuthenticatedHomeQuestSlugIndexImport } from './routes/_authenticated/_home/$questSlug.index'
+import { Route as AuthenticatedHomeQuestsQuestSlugIndexImport } from './routes/_authenticated/_home/quests.$questSlug.index'
 
 // Create/Update Routes
 
@@ -151,10 +151,10 @@ const AuthenticatedHomeBirthCertificateIndexRoute =
     getParentRoute: () => AuthenticatedHomeRoute,
   } as any)
 
-const AuthenticatedHomeQuestSlugIndexRoute =
-  AuthenticatedHomeQuestSlugIndexImport.update({
-    id: '/$questSlug/',
-    path: '/$questSlug/',
+const AuthenticatedHomeQuestsQuestSlugIndexRoute =
+  AuthenticatedHomeQuestsQuestSlugIndexImport.update({
+    id: '/quests/$questSlug/',
+    path: '/quests/$questSlug/',
     getParentRoute: () => AuthenticatedHomeRoute,
   } as any)
 
@@ -253,13 +253,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSettingsIndexImport
       parentRoute: typeof AuthenticatedSettingsRouteImport
     }
-    '/_authenticated/_home/$questSlug/': {
-      id: '/_authenticated/_home/$questSlug/'
-      path: '/$questSlug'
-      fullPath: '/$questSlug'
-      preLoaderRoute: typeof AuthenticatedHomeQuestSlugIndexImport
-      parentRoute: typeof AuthenticatedHomeImport
-    }
     '/_authenticated/_home/birth-certificate/': {
       id: '/_authenticated/_home/birth-certificate/'
       path: '/birth-certificate'
@@ -294,6 +287,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/admin/quests'
       preLoaderRoute: typeof AuthenticatedAdminQuestsIndexImport
       parentRoute: typeof AuthenticatedAdminRouteImport
+    }
+    '/_authenticated/_home/quests/$questSlug/': {
+      id: '/_authenticated/_home/quests/$questSlug/'
+      path: '/quests/$questSlug'
+      fullPath: '/quests/$questSlug'
+      preLoaderRoute: typeof AuthenticatedHomeQuestsQuestSlugIndexImport
+      parentRoute: typeof AuthenticatedHomeImport
     }
   }
 }
@@ -339,19 +339,20 @@ const AuthenticatedSettingsRouteRouteWithChildren =
 
 interface AuthenticatedHomeRouteChildren {
   AuthenticatedHomeIndexRoute: typeof AuthenticatedHomeIndexRoute
-  AuthenticatedHomeQuestSlugIndexRoute: typeof AuthenticatedHomeQuestSlugIndexRoute
   AuthenticatedHomeBirthCertificateIndexRoute: typeof AuthenticatedHomeBirthCertificateIndexRoute
   AuthenticatedHomeCourtOrderIndexRoute: typeof AuthenticatedHomeCourtOrderIndexRoute
   AuthenticatedHomeStateIdIndexRoute: typeof AuthenticatedHomeStateIdIndexRoute
+  AuthenticatedHomeQuestsQuestSlugIndexRoute: typeof AuthenticatedHomeQuestsQuestSlugIndexRoute
 }
 
 const AuthenticatedHomeRouteChildren: AuthenticatedHomeRouteChildren = {
   AuthenticatedHomeIndexRoute: AuthenticatedHomeIndexRoute,
-  AuthenticatedHomeQuestSlugIndexRoute: AuthenticatedHomeQuestSlugIndexRoute,
   AuthenticatedHomeBirthCertificateIndexRoute:
     AuthenticatedHomeBirthCertificateIndexRoute,
   AuthenticatedHomeCourtOrderIndexRoute: AuthenticatedHomeCourtOrderIndexRoute,
   AuthenticatedHomeStateIdIndexRoute: AuthenticatedHomeStateIdIndexRoute,
+  AuthenticatedHomeQuestsQuestSlugIndexRoute:
+    AuthenticatedHomeQuestsQuestSlugIndexRoute,
 }
 
 const AuthenticatedHomeRouteWithChildren =
@@ -401,12 +402,12 @@ export interface FileRoutesByFullPath {
   '/admin/': typeof AuthenticatedAdminIndexRoute
   '/documents': typeof AuthenticatedDocumentsIndexRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
-  '/$questSlug': typeof AuthenticatedHomeQuestSlugIndexRoute
   '/birth-certificate': typeof AuthenticatedHomeBirthCertificateIndexRoute
   '/court-order': typeof AuthenticatedHomeCourtOrderIndexRoute
   '/state-id': typeof AuthenticatedHomeStateIdIndexRoute
   '/admin/early-access': typeof AuthenticatedAdminEarlyAccessIndexRoute
   '/admin/quests': typeof AuthenticatedAdminQuestsIndexRoute
+  '/quests/$questSlug': typeof AuthenticatedHomeQuestsQuestSlugIndexRoute
 }
 
 export interface FileRoutesByTo {
@@ -419,12 +420,12 @@ export interface FileRoutesByTo {
   '/admin': typeof AuthenticatedAdminIndexRoute
   '/documents': typeof AuthenticatedDocumentsIndexRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
-  '/$questSlug': typeof AuthenticatedHomeQuestSlugIndexRoute
   '/birth-certificate': typeof AuthenticatedHomeBirthCertificateIndexRoute
   '/court-order': typeof AuthenticatedHomeCourtOrderIndexRoute
   '/state-id': typeof AuthenticatedHomeStateIdIndexRoute
   '/admin/early-access': typeof AuthenticatedAdminEarlyAccessIndexRoute
   '/admin/quests': typeof AuthenticatedAdminQuestsIndexRoute
+  '/quests/$questSlug': typeof AuthenticatedHomeQuestsQuestSlugIndexRoute
 }
 
 export interface FileRoutesById {
@@ -442,12 +443,12 @@ export interface FileRoutesById {
   '/_authenticated/admin/': typeof AuthenticatedAdminIndexRoute
   '/_authenticated/documents/': typeof AuthenticatedDocumentsIndexRoute
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
-  '/_authenticated/_home/$questSlug/': typeof AuthenticatedHomeQuestSlugIndexRoute
   '/_authenticated/_home/birth-certificate/': typeof AuthenticatedHomeBirthCertificateIndexRoute
   '/_authenticated/_home/court-order/': typeof AuthenticatedHomeCourtOrderIndexRoute
   '/_authenticated/_home/state-id/': typeof AuthenticatedHomeStateIdIndexRoute
   '/_authenticated/admin/early-access/': typeof AuthenticatedAdminEarlyAccessIndexRoute
   '/_authenticated/admin/quests/': typeof AuthenticatedAdminQuestsIndexRoute
+  '/_authenticated/_home/quests/$questSlug/': typeof AuthenticatedHomeQuestsQuestSlugIndexRoute
 }
 
 export interface FileRouteTypes {
@@ -464,12 +465,12 @@ export interface FileRouteTypes {
     | '/admin/'
     | '/documents'
     | '/settings/'
-    | '/$questSlug'
     | '/birth-certificate'
     | '/court-order'
     | '/state-id'
     | '/admin/early-access'
     | '/admin/quests'
+    | '/quests/$questSlug'
   fileRoutesByTo: FileRoutesByTo
   to:
     | ''
@@ -481,12 +482,12 @@ export interface FileRouteTypes {
     | '/admin'
     | '/documents'
     | '/settings'
-    | '/$questSlug'
     | '/birth-certificate'
     | '/court-order'
     | '/state-id'
     | '/admin/early-access'
     | '/admin/quests'
+    | '/quests/$questSlug'
   id:
     | '__root__'
     | '/_authenticated'
@@ -502,12 +503,12 @@ export interface FileRouteTypes {
     | '/_authenticated/admin/'
     | '/_authenticated/documents/'
     | '/_authenticated/settings/'
-    | '/_authenticated/_home/$questSlug/'
     | '/_authenticated/_home/birth-certificate/'
     | '/_authenticated/_home/court-order/'
     | '/_authenticated/_home/state-id/'
     | '/_authenticated/admin/early-access/'
     | '/_authenticated/admin/quests/'
+    | '/_authenticated/_home/quests/$questSlug/'
   fileRoutesById: FileRoutesById
 }
 
@@ -574,10 +575,10 @@ export const routeTree = rootRoute
       "parent": "/_authenticated",
       "children": [
         "/_authenticated/_home/",
-        "/_authenticated/_home/$questSlug/",
         "/_authenticated/_home/birth-certificate/",
         "/_authenticated/_home/court-order/",
-        "/_authenticated/_home/state-id/"
+        "/_authenticated/_home/state-id/",
+        "/_authenticated/_home/quests/$questSlug/"
       ]
     },
     "/_unauthenticated/signin": {
@@ -612,10 +613,6 @@ export const routeTree = rootRoute
       "filePath": "_authenticated/settings/index.tsx",
       "parent": "/_authenticated/settings"
     },
-    "/_authenticated/_home/$questSlug/": {
-      "filePath": "_authenticated/_home/$questSlug.index.tsx",
-      "parent": "/_authenticated/_home"
-    },
     "/_authenticated/_home/birth-certificate/": {
       "filePath": "_authenticated/_home/birth-certificate.index.tsx",
       "parent": "/_authenticated/_home"
@@ -635,6 +632,10 @@ export const routeTree = rootRoute
     "/_authenticated/admin/quests/": {
       "filePath": "_authenticated/admin/quests.index.tsx",
       "parent": "/_authenticated/admin"
+    },
+    "/_authenticated/_home/quests/$questSlug/": {
+      "filePath": "_authenticated/_home/quests.$questSlug.index.tsx",
+      "parent": "/_authenticated/_home"
     }
   }
 }

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -1,3 +1,5 @@
+import { AppMobileNav } from "@/components/app";
+import { useIsMobile } from "@/utils/useIsMobile";
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 import { Authenticated } from "convex/react";
 
@@ -10,9 +12,14 @@ export const Route = createFileRoute("/_authenticated")({
 });
 
 function AuthenticatedRoute() {
+  const isMobile = useIsMobile();
+
   return (
     <Authenticated>
-      <Outlet />
+      <main className="grid grid-rows-[1fr_auto] h-screen min-h-0">
+        <Outlet />
+        {isMobile && <AppMobileNav />}
+      </main>
     </Authenticated>
   );
 }

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -2,6 +2,7 @@ import { AppMobileNav } from "@/components/app";
 import { useIsMobile } from "@/utils/useIsMobile";
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 import { Authenticated } from "convex/react";
+import { tv } from "tailwind-variants";
 
 export const Route = createFileRoute("/_authenticated")({
   beforeLoad: async ({ context }) => {
@@ -14,9 +15,17 @@ export const Route = createFileRoute("/_authenticated")({
 function AuthenticatedRoute() {
   const isMobile = useIsMobile();
 
+  const styles = tv({
+    variants: {
+      isMobile: {
+        true: "min-h-dvh pb-14",
+      },
+    },
+  });
+
   return (
     <Authenticated>
-      <main className="grid grid-rows-[1fr_auto] h-screen min-h-0">
+      <main className={styles({ isMobile })}>
         <Outlet />
         {isMobile && <AppMobileNav />}
       </main>

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -16,9 +16,10 @@ function AuthenticatedRoute() {
   const isMobile = useIsMobile();
 
   const styles = tv({
+    base: "min-h-dvh flex flex-col *:flex-1",
     variants: {
       isMobile: {
-        true: "min-h-dvh pb-14",
+        true: "pb-14",
       },
     },
   });

--- a/src/routes/_authenticated/_home.tsx
+++ b/src/routes/_authenticated/_home.tsx
@@ -1,176 +1,25 @@
-import { AppSidebar } from "@/components/app";
-import {
-  Badge,
-  Nav,
-  NavGroup,
-  NavItem,
-  ProgressBar,
-} from "@/components/common";
-import { StatusBadge } from "@/components/quests";
-import { api } from "@convex/_generated/api";
-import {
-  CATEGORIES,
-  type Category,
-  type CoreCategory,
-  type Status,
-} from "@convex/constants";
+import { AppContent, AppSidebar } from "@/components/app";
+import { QuestsNav } from "@/components/quests";
+import { useIsMobile } from "@/utils/useIsMobile";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
-import { useQuery } from "convex/react";
-import type { LucideIcon } from "lucide-react";
 
 export const Route = createFileRoute("/_authenticated/_home")({
   component: IndexRoute,
 });
 
 function IndexRoute() {
-  const MyQuests = () => {
-    const user = useQuery(api.users.getCurrent);
-    const userQuests = useQuery(api.userQuests.count) ?? 0;
-    const completedQuests = useQuery(api.userQuests.countCompleted) ?? 0;
-    const questsByCategory = useQuery(api.userQuests.getByCategory);
-
-    const CORE_CATEGORIES: Record<
-      CoreCategory,
-      { to: string; label: string; icon: LucideIcon }
-    > = {
-      courtOrder: {
-        to: "court-order",
-        label: CATEGORIES.courtOrder.label,
-        icon: CATEGORIES.courtOrder.icon,
-      },
-      socialSecurity: {
-        to: "social-security",
-        label: CATEGORIES.socialSecurity.label,
-        icon: CATEGORIES.socialSecurity.icon,
-      },
-      stateId: {
-        to: "state-id",
-        label: CATEGORIES.stateId.label,
-        icon: CATEGORIES.stateId.icon,
-      },
-      passport: {
-        to: "passport",
-        label: CATEGORIES.passport.label,
-        icon: CATEGORIES.passport.icon,
-      },
-      birthCertificate: {
-        to: "birth-certificate",
-        label: CATEGORIES.birthCertificate.label,
-        icon: CATEGORIES.birthCertificate.icon,
-      },
-    } as const;
-
-    return (
-      <AppSidebar>
-        {userQuests > 0 && (
-          <div className="flex items-center mb-4">
-            <ProgressBar
-              label="Quest progress"
-              value={completedQuests}
-              maxValue={userQuests}
-              valueLabel={
-                <span className="text-gray-normal">
-                  <span className="text-gray-normal text-base font-medium mr-0.5 leading-none">
-                    {completedQuests}
-                  </span>{" "}
-                  <span className="text-gray-8">/</span>{" "}
-                  <span className="text-gray-dim">{userQuests} complete</span>
-                </span>
-              }
-              labelHidden
-            />
-          </div>
-        )}
-        <Nav>
-          {(Object.keys(CORE_CATEGORIES) as CoreCategory[]).map((category) => {
-            const userQuest = questsByCategory?.[category]?.[0];
-            const config = CORE_CATEGORIES[category];
-
-            if (
-              category === "birthCertificate" &&
-              user?.birthplace === "other"
-            ) {
-              return null;
-            }
-
-            if (userQuest) {
-              return (
-                <NavItem
-                  key={userQuest._id}
-                  href={{
-                    to: "/$questSlug",
-                    params: { questSlug: userQuest.slug },
-                  }}
-                  icon={config.icon}
-                  size="large"
-                >
-                  {userQuest.title}
-                  {userQuest.jurisdiction && (
-                    <Badge size="xs">{userQuest.jurisdiction}</Badge>
-                  )}
-                  <StatusBadge
-                    status={userQuest.status as Status}
-                    condensed
-                    className="ml-auto mr-1"
-                  />
-                </NavItem>
-              );
-            }
-
-            return (
-              <NavItem
-                key={category}
-                href={{ to: "/$questSlug", params: { questSlug: config.to } }}
-                icon={config.icon}
-                size="large"
-                className="border border-dashed border-gray-dim"
-              >
-                {config.label}
-              </NavItem>
-            );
-          })}
-
-          {questsByCategory &&
-            Object.entries(questsByCategory).map(([group, quests]) => {
-              if (quests.length === 0 || group in CORE_CATEGORIES) return null;
-
-              const { label } = CATEGORIES[group as keyof typeof CATEGORIES];
-
-              return (
-                <NavGroup key={label} label={label}>
-                  {quests.map((quest) => (
-                    <NavItem
-                      key={quest._id}
-                      href={{
-                        to: "/$questSlug",
-                        params: { questSlug: quest.slug },
-                      }}
-                      size="large"
-                      icon={CATEGORIES[quest.category as Category].icon}
-                    >
-                      {quest.title}
-                      {quest.jurisdiction && (
-                        <Badge size="xs">{quest.jurisdiction}</Badge>
-                      )}
-                      <StatusBadge
-                        status={quest.status as Status}
-                        condensed
-                        className="ml-auto mr-1"
-                      />
-                    </NavItem>
-                  ))}
-                </NavGroup>
-              );
-            })}
-        </Nav>
-      </AppSidebar>
-    );
-  };
+  const isMobile = useIsMobile();
 
   return (
     <div className="flex">
-      <MyQuests />
-      <Outlet />
+      {!isMobile && (
+        <AppSidebar>
+          <QuestsNav />
+        </AppSidebar>
+      )}
+      <AppContent>
+        <Outlet />
+      </AppContent>
     </div>
   );
 }

--- a/src/routes/_authenticated/_home.tsx
+++ b/src/routes/_authenticated/_home.tsx
@@ -1,4 +1,9 @@
-import { AppContent, AppSidebar } from "@/components/app";
+import {
+  AppContent,
+  AppSidebar,
+  AppSidebarFooter,
+  AppSidebarHeader,
+} from "@/components/app";
 import { QuestsNav } from "@/components/quests";
 import { useIsMobile } from "@/utils/useIsMobile";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
@@ -13,7 +18,7 @@ function IndexRoute() {
   return (
     <div className="flex">
       {!isMobile && (
-        <AppSidebar>
+        <AppSidebar header={<AppSidebarHeader />} footer={<AppSidebarFooter />}>
           <QuestsNav />
         </AppSidebar>
       )}

--- a/src/routes/_authenticated/_home/$questSlug.index.tsx
+++ b/src/routes/_authenticated/_home/$questSlug.index.tsx
@@ -1,4 +1,3 @@
-import { AppContent } from "@/components/app";
 import { Empty } from "@/components/common";
 import {
   QuestCosts,
@@ -60,7 +59,7 @@ function QuestDetailRoute() {
   }
 
   return (
-    <AppContent>
+    <>
       <QuestPageHeader quest={quest} userQuest={userQuest} badge={badge} />
       <div className="flex flex-col gap-6 pb-12">
         <QuestBasics quest={quest} editable={isEditing} />
@@ -73,6 +72,6 @@ function QuestDetailRoute() {
         <QuestReferences quest={quest} editable={isEditing} />
       </div>
       <QuestPageFooter quest={quest} userQuest={userQuest} />
-    </AppContent>
+    </>
   );
 }

--- a/src/routes/_authenticated/_home/birth-certificate.index.tsx
+++ b/src/routes/_authenticated/_home/birth-certificate.index.tsx
@@ -1,4 +1,3 @@
-import { AppContent } from "@/components/app";
 import { JurisdictionInterstitial } from "@/components/quests";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
@@ -19,9 +18,5 @@ export const Route = createFileRoute(
 });
 
 function RouteComponent() {
-  return (
-    <AppContent>
-      <JurisdictionInterstitial type="birthCertificate" />
-    </AppContent>
-  );
+  return <JurisdictionInterstitial type="birthCertificate" />;
 }

--- a/src/routes/_authenticated/_home/birth-certificate.index.tsx
+++ b/src/routes/_authenticated/_home/birth-certificate.index.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute(
   beforeLoad: async ({ context: { birthplace } }) => {
     if (birthplace) {
       throw redirect({
-        to: "/$questSlug",
+        to: "/quests/$questSlug",
         params: {
           questSlug: `birth-certificate-${birthplace.toLowerCase()}`,
         },

--- a/src/routes/_authenticated/_home/court-order.index.tsx
+++ b/src/routes/_authenticated/_home/court-order.index.tsx
@@ -1,4 +1,3 @@
-import { AppContent } from "@/components/app";
 import { JurisdictionInterstitial } from "@/components/quests";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
@@ -17,9 +16,5 @@ export const Route = createFileRoute("/_authenticated/_home/court-order/")({
 });
 
 function RouteComponent() {
-  return (
-    <AppContent>
-      <JurisdictionInterstitial type="courtOrder" />
-    </AppContent>
-  );
+  return <JurisdictionInterstitial type="courtOrder" />;
 }

--- a/src/routes/_authenticated/_home/court-order.index.tsx
+++ b/src/routes/_authenticated/_home/court-order.index.tsx
@@ -5,7 +5,7 @@ export const Route = createFileRoute("/_authenticated/_home/court-order/")({
   beforeLoad: async ({ context: { residence } }) => {
     if (residence) {
       throw redirect({
-        to: "/$questSlug",
+        to: "/quests/$questSlug",
         params: {
           questSlug: `court-order-${residence.toLowerCase()}`,
         },

--- a/src/routes/_authenticated/_home/index.tsx
+++ b/src/routes/_authenticated/_home/index.tsx
@@ -1,14 +1,22 @@
-import { AppContent, PageHeader } from "@/components/app";
-import { createFileRoute } from "@tanstack/react-router";
+import { AppSidebarHeader } from "@/components/app";
+import { QuestsNav } from "@/components/quests";
+import { useIsMobile } from "@/utils/useIsMobile";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_authenticated/_home/")({
   component: IndexRoute,
 });
 
 function IndexRoute() {
+  const navigate = useNavigate();
+  const isMobile = useIsMobile();
+
+  if (!isMobile) navigate({ to: "/court-order" });
+
   return (
-    <AppContent>
-      <PageHeader title="Home" />
-    </AppContent>
+    <div className="flex flex-col py-7 gap-7">
+      <AppSidebarHeader />
+      <QuestsNav />
+    </div>
   );
 }

--- a/src/routes/_authenticated/_home/quests.$questSlug.index.tsx
+++ b/src/routes/_authenticated/_home/quests.$questSlug.index.tsx
@@ -12,7 +12,7 @@ import { QuestBasics } from "@/components/quests/QuestBasics/QuestBasics";
 import { QuestPageFooter } from "@/components/quests/QuestPageFooter/QuestPageFooter";
 import { api } from "@convex/_generated/api";
 import { JURISDICTIONS } from "@convex/constants";
-import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { Milestone } from "lucide-react";
 
 type QuestSearch = {
@@ -37,7 +37,6 @@ export const Route = createFileRoute(
 });
 
 function QuestDetailRoute() {
-  const router = useRouter();
   const { edit: isEditing } = Route.useSearch();
   const { questData } = Route.useLoaderData();
 
@@ -48,7 +47,11 @@ function QuestDetailRoute() {
       <Empty
         title="Quest not found"
         icon={Milestone}
-        button={{ children: "Go back", onPress: () => router.history.go(-1) }}
+        link={{
+          children: "Go home",
+          href: { to: "/" },
+          button: { variant: "secondary" },
+        }}
       />
     );
 

--- a/src/routes/_authenticated/_home/quests.$questSlug.index.tsx
+++ b/src/routes/_authenticated/_home/quests.$questSlug.index.tsx
@@ -12,23 +12,21 @@ import { QuestBasics } from "@/components/quests/QuestBasics/QuestBasics";
 import { QuestPageFooter } from "@/components/quests/QuestPageFooter/QuestPageFooter";
 import { api } from "@convex/_generated/api";
 import { JURISDICTIONS } from "@convex/constants";
-import { createFileRoute, notFound } from "@tanstack/react-router";
-import { rootRouteId } from "@tanstack/react-router";
+import { createFileRoute, useRouter } from "@tanstack/react-router";
 import { Milestone } from "lucide-react";
 
 type QuestSearch = {
   edit?: true | undefined;
 };
 
-export const Route = createFileRoute("/_authenticated/_home/$questSlug/")({
+export const Route = createFileRoute(
+  "/_authenticated/_home/quests/$questSlug/",
+)({
   component: QuestDetailRoute,
   loader: async ({ params: { questSlug }, context: { convex } }) => {
     const questData = await convex.query(api.quests.getWithUserQuest, {
       slug: questSlug,
     });
-    if (questData.quest === null) {
-      throw notFound({ routeId: rootRouteId });
-    }
     return { questData };
   },
   validateSearch: (search: Record<string, unknown>): QuestSearch => {
@@ -39,13 +37,20 @@ export const Route = createFileRoute("/_authenticated/_home/$questSlug/")({
 });
 
 function QuestDetailRoute() {
+  const router = useRouter();
   const { edit: isEditing } = Route.useSearch();
   const { questData } = Route.useLoaderData();
 
   // TODO: Improve loading state to prevent flash of empty
   if (questData === undefined) return;
   if (questData.quest === null)
-    return <Empty title="Quest not found" icon={Milestone} />;
+    return (
+      <Empty
+        title="Quest not found"
+        icon={Milestone}
+        button={{ children: "Go back", onPress: () => router.history.go(-1) }}
+      />
+    );
 
   const quest = questData.quest;
   const userQuest = questData.userQuest;

--- a/src/routes/_authenticated/_home/state-id.index.tsx
+++ b/src/routes/_authenticated/_home/state-id.index.tsx
@@ -5,7 +5,7 @@ export const Route = createFileRoute("/_authenticated/_home/state-id/")({
   beforeLoad: async ({ context: { residence } }) => {
     if (residence) {
       throw redirect({
-        to: "/$questSlug",
+        to: "/quests/$questSlug",
         params: {
           questSlug: `state-id-${residence.toLowerCase()}`,
         },

--- a/src/routes/_authenticated/_home/state-id.index.tsx
+++ b/src/routes/_authenticated/_home/state-id.index.tsx
@@ -1,4 +1,3 @@
-import { AppContent } from "@/components/app";
 import { JurisdictionInterstitial } from "@/components/quests";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
@@ -17,9 +16,5 @@ export const Route = createFileRoute("/_authenticated/_home/state-id/")({
 });
 
 function RouteComponent() {
-  return (
-    <AppContent>
-      <JurisdictionInterstitial type="stateId" />
-    </AppContent>
-  );
+  return <JurisdictionInterstitial type="stateId" />;
 }

--- a/src/routes/_authenticated/admin/early-access.index.tsx
+++ b/src/routes/_authenticated/admin/early-access.index.tsx
@@ -96,7 +96,7 @@ function EarlyAccessRoute() {
 
   return (
     <div>
-      <PageHeader title="Early Access Codes">
+      <PageHeader title="Early Access Codes" mobileBackLink={{ to: "/admin" }}>
         <Button
           onPress={handleGenerateCode}
           icon={Plus}

--- a/src/routes/_authenticated/admin/index.tsx
+++ b/src/routes/_authenticated/admin/index.tsx
@@ -15,7 +15,7 @@ function AdminIndexRoute() {
 
   return (
     <>
-      <PageHeader title="Admin" mobileBackLink={{ to: "/" }} />
+      <PageHeader title="Admin" />
       <AdminNav />
     </>
   );

--- a/src/routes/_authenticated/admin/index.tsx
+++ b/src/routes/_authenticated/admin/index.tsx
@@ -1,9 +1,22 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { AdminNav } from "@/components/admin";
+import { PageHeader } from "@/components/app";
+import { useIsMobile } from "@/utils/useIsMobile";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_authenticated/admin/")({
-  beforeLoad: () => {
-    throw redirect({
-      to: "/admin/quests",
-    });
-  },
+  component: AdminIndexRoute,
 });
+
+function AdminIndexRoute() {
+  const navigate = useNavigate();
+  const isMobile = useIsMobile();
+
+  if (!isMobile) navigate({ to: "/admin/quests" });
+
+  return (
+    <>
+      <PageHeader title="Admin" mobileBackLink={{ to: "/" }} />
+      <AdminNav />
+    </>
+  );
+}

--- a/src/routes/_authenticated/admin/quests.index.tsx
+++ b/src/routes/_authenticated/admin/quests.index.tsx
@@ -73,7 +73,7 @@ const NewQuestModal = ({
       clearForm();
       onSubmit();
       navigate({
-        to: "/$questSlug",
+        to: "/quests/$questSlug",
         params: { questSlug: slug },
       });
     }
@@ -158,7 +158,7 @@ const QuestTableRow = ({
     <TableRow
       key={quest._id}
       className="flex gap-2 items-center"
-      href={{ to: "/$questSlug", params: { questSlug: quest.slug } }}
+      href={{ to: "/quests/$questSlug", params: { questSlug: quest.slug } }}
     >
       <TableCell>
         <div className="flex items-center gap-2">

--- a/src/routes/_authenticated/admin/quests.index.tsx
+++ b/src/routes/_authenticated/admin/quests.index.tsx
@@ -219,7 +219,7 @@ function QuestsRoute() {
 
   return (
     <>
-      <PageHeader title="Quests">
+      <PageHeader title="Quests" mobileBackLink={{ to: "/admin" }}>
         <Button
           onPress={() => setIsNewQuestModalOpen(true)}
           icon={Plus}

--- a/src/routes/_authenticated/admin/route.tsx
+++ b/src/routes/_authenticated/admin/route.tsx
@@ -1,7 +1,7 @@
+import { AdminNav } from "@/components/admin";
 import { AppContent, AppSidebar, AppSidebarHeader } from "@/components/app";
-import { Nav, NavGroup, NavItem } from "@/components/common";
+import { useIsMobile } from "@/utils/useIsMobile";
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
-import { FlaskConical, Milestone } from "lucide-react";
 
 export const Route = createFileRoute("/_authenticated/admin")({
   beforeLoad: ({ context }) => {
@@ -19,20 +19,15 @@ export const Route = createFileRoute("/_authenticated/admin")({
 });
 
 function AdminRoute() {
+  const isMobile = useIsMobile();
+
   return (
     <div className="flex">
-      <AppSidebar header={<AppSidebarHeader />}>
-        <Nav>
-          <NavGroup label="Content">
-            <NavItem icon={Milestone} href={{ to: "/admin/quests" }}>
-              Quests
-            </NavItem>
-            <NavItem icon={FlaskConical} href={{ to: "/admin/early-access" }}>
-              Early Access
-            </NavItem>
-          </NavGroup>
-        </Nav>
-      </AppSidebar>
+      {!isMobile && (
+        <AppSidebar header={<AppSidebarHeader />}>
+          <AdminNav />
+        </AppSidebar>
+      )}
       <AppContent>
         <Outlet />
       </AppContent>

--- a/src/routes/_authenticated/admin/route.tsx
+++ b/src/routes/_authenticated/admin/route.tsx
@@ -1,4 +1,4 @@
-import { AppContent, AppSidebar } from "@/components/app";
+import { AppContent, AppSidebar, AppSidebarHeader } from "@/components/app";
 import { Nav, NavGroup, NavItem } from "@/components/common";
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 import { FlaskConical, Milestone } from "lucide-react";
@@ -21,7 +21,7 @@ export const Route = createFileRoute("/_authenticated/admin")({
 function AdminRoute() {
   return (
     <div className="flex">
-      <AppSidebar>
+      <AppSidebar header={<AppSidebarHeader />}>
         <Nav>
           <NavGroup label="Content">
             <NavItem icon={Milestone} href={{ to: "/admin/quests" }}>

--- a/src/routes/_authenticated/forms/ma-court-order.tsx
+++ b/src/routes/_authenticated/forms/ma-court-order.tsx
@@ -104,7 +104,7 @@ function RouteComponent() {
         </div>
       </FormSection>
       <FormSection title="Where were you born?">
-        <div className="grid grid-cols-[1fr_auto] gap-4">
+        <div className="flex flex-wrap gap-4">
           <ShortTextField name="birthplaceCity" label="City" />
           <SelectField
             name="birthplaceState"
@@ -263,7 +263,7 @@ function RouteComponent() {
           name="shouldApplyForFeeWaiver"
           label="Apply for a fee waiver?"
           labelHidden
-          yesLabel="I am unable to pay the filing fees and can provide proof of income"
+          yesLabel="Help me waive filing fees; I can provide proof of income"
           noLabel="I will pay the filing fee"
         />
       </FormSection>

--- a/src/routes/_authenticated/forms/ma-court-order.tsx
+++ b/src/routes/_authenticated/forms/ma-court-order.tsx
@@ -263,8 +263,8 @@ function RouteComponent() {
           name="shouldApplyForFeeWaiver"
           label="Apply for a fee waiver?"
           labelHidden
-          yesLabel="Yes, I am unable to pay the filing fees"
-          noLabel="No, I can pay the filing fee"
+          yesLabel="I am unable to pay the filing fees and can provide proof of income"
+          noLabel="I will pay the filing fee"
         />
       </FormSection>
       <FormSection

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -9,7 +9,6 @@ import {
   EditThemeSetting,
   SettingsGroup,
 } from "@/components/settings";
-import { useIsMobile } from "@/utils/useIsMobile";
 import { api } from "@convex/_generated/api";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
@@ -20,14 +19,10 @@ export const Route = createFileRoute("/_authenticated/settings/account")({
 
 function SettingsAccountRoute() {
   const user = useQuery(api.users.getCurrent);
-  const isMobile = useIsMobile();
 
   return (
     <>
-      <PageHeader
-        title="Account"
-        backLink={isMobile ? { to: "/settings" } : undefined}
-      />
+      <PageHeader title="Account" mobileBackLink={{ to: "/settings" }} />
       {user === undefined ? (
         "Loading..."
       ) : user === null ? (

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -9,6 +9,7 @@ import {
   EditThemeSetting,
   SettingsGroup,
 } from "@/components/settings";
+import { useIsMobile } from "@/utils/useIsMobile";
 import { api } from "@convex/_generated/api";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
@@ -19,10 +20,14 @@ export const Route = createFileRoute("/_authenticated/settings/account")({
 
 function SettingsAccountRoute() {
   const user = useQuery(api.users.getCurrent);
+  const isMobile = useIsMobile();
 
   return (
     <>
-      <PageHeader title="Account" />
+      <PageHeader
+        title="Account"
+        backLink={isMobile ? { to: "/settings" } : undefined}
+      />
       {user === undefined ? (
         "Loading..."
       ) : user === null ? (

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -15,7 +15,7 @@ function SettingsIndexRoute() {
 
   return (
     <>
-      <PageHeader title="Settings" mobileBackLink={{ to: "/" }} />
+      <PageHeader title="Settings" />
       <SettingsNav />
     </>
   );

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -1,7 +1,25 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { PageHeader } from "@/components/app";
+import { SettingsNav } from "@/components/settings";
+import { useIsMobile } from "@/utils/useIsMobile";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_authenticated/settings/")({
-  beforeLoad: () => {
-    throw redirect({ to: "/settings/account" });
-  },
+  component: SettingsIndexRoute,
 });
+
+function SettingsIndexRoute() {
+  const navigate = useNavigate();
+  const isMobile = useIsMobile();
+
+  if (!isMobile) navigate({ to: "/settings/account" });
+
+  return (
+    <>
+      <PageHeader
+        title="Settings"
+        backLink={isMobile ? { to: "/" } : undefined}
+      />
+      <SettingsNav />
+    </>
+  );
+}

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -15,10 +15,7 @@ function SettingsIndexRoute() {
 
   return (
     <>
-      <PageHeader
-        title="Settings"
-        backLink={isMobile ? { to: "/" } : undefined}
-      />
+      <PageHeader title="Settings" mobileBackLink={{ to: "/" }} />
       <SettingsNav />
     </>
   );

--- a/src/routes/_authenticated/settings/responses.tsx
+++ b/src/routes/_authenticated/settings/responses.tsx
@@ -4,7 +4,6 @@ import {
   FormResponsesList,
   getReadableFieldLabel,
 } from "@/components/settings";
-import { useIsMobile } from "@/utils/useIsMobile";
 import { api } from "@convex/_generated/api";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
@@ -16,7 +15,6 @@ export const Route = createFileRoute("/_authenticated/settings/responses")({
 
 function FormResponsesRoute() {
   const userData = useQuery(api.userFormResponses.list);
-  const isMobile = useIsMobile();
   const rows = userData?.map((data) => ({
     id: data._id,
     field: getReadableFieldLabel(data.field),
@@ -27,7 +25,7 @@ function FormResponsesRoute() {
     <>
       <PageHeader
         title="Form Responses"
-        backLink={isMobile ? { to: "/settings" } : undefined}
+        mobileBackLink={{ to: "/settings" }}
         badge={
           <Badge variant="success" icon={ShieldCheck}>
             Encrypted

--- a/src/routes/_authenticated/settings/responses.tsx
+++ b/src/routes/_authenticated/settings/responses.tsx
@@ -4,6 +4,7 @@ import {
   FormResponsesList,
   getReadableFieldLabel,
 } from "@/components/settings";
+import { useIsMobile } from "@/utils/useIsMobile";
 import { api } from "@convex/_generated/api";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
@@ -15,6 +16,7 @@ export const Route = createFileRoute("/_authenticated/settings/responses")({
 
 function FormResponsesRoute() {
   const userData = useQuery(api.userFormResponses.list);
+  const isMobile = useIsMobile();
   const rows = userData?.map((data) => ({
     id: data._id,
     field: getReadableFieldLabel(data.field),
@@ -25,6 +27,7 @@ function FormResponsesRoute() {
     <>
       <PageHeader
         title="Form Responses"
+        backLink={isMobile ? { to: "/settings" } : undefined}
         badge={
           <Badge variant="success" icon={ShieldCheck}>
             Encrypted

--- a/src/routes/_authenticated/settings/route.tsx
+++ b/src/routes/_authenticated/settings/route.tsx
@@ -1,93 +1,22 @@
-import { AppContent, AppSidebar } from "@/components/app";
-import { Nav, NavGroup, NavItem } from "@/components/common";
+import { AppContent, AppSidebar, AppSidebarHeader } from "@/components/app";
+import { SettingsNav } from "@/components/settings";
+import { useIsMobile } from "@/utils/useIsMobile";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
-import {
-  Bug,
-  CircleUser,
-  DatabaseZap,
-  FileClock,
-  FileLock2,
-  MessageCircleQuestion,
-  Snail,
-} from "lucide-react";
 
 export const Route = createFileRoute("/_authenticated/settings")({
   component: SettingsRoute,
 });
 
 function SettingsRoute() {
+  const isMobile = useIsMobile();
+
   return (
     <div className="flex">
-      <AppSidebar>
-        <Nav>
-          <NavGroup label="Settings">
-            <NavItem icon={CircleUser} href={{ to: "/settings/account" }}>
-              Account
-            </NavItem>
-            <NavItem icon={FileLock2} href={{ to: "/settings/responses" }}>
-              Form Responses
-            </NavItem>
-          </NavGroup>
-          <NavGroup label="Help">
-            <NavItem
-              icon={Snail}
-              href="https://namesake.fyi"
-              target="_blank"
-              rel="noreferrer"
-            >
-              About Namesake
-            </NavItem>
-            <NavItem
-              icon={FileClock}
-              href="https://github.com/namesakefyi/namesake/releases"
-              target="_blank"
-              rel="noreferrer"
-            >
-              View Changelog (v{APP_VERSION})
-            </NavItem>
-            <NavItem
-              href="https://github.com/namesakefyi/namesake/issues/new/choose"
-              target="_blank"
-              rel="noreferrer"
-              icon={Bug}
-            >
-              Report an Issue
-            </NavItem>
-            <NavItem
-              icon={DatabaseZap}
-              href="https://status.namesake.fyi"
-              target="_blank"
-              rel="noreferrer"
-            >
-              System Status
-            </NavItem>
-            <NavItem
-              href="https://namesake.fyi/chat"
-              target="_blank"
-              rel="noreferrer"
-              icon={MessageCircleQuestion}
-            >
-              Discord Community
-            </NavItem>
-          </NavGroup>
-          <NavGroup label="Legal">
-            <NavItem
-              href="https://namesake.fyi/terms"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Terms of Service
-            </NavItem>
-            <NavItem
-              href="https://namesake.fyi/privacy"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Privacy Policy
-            </NavItem>
-          </NavGroup>
-        </Nav>
-      </AppSidebar>
+      {!isMobile && (
+        <AppSidebar header={<AppSidebarHeader />}>
+          <SettingsNav />
+        </AppSidebar>
+      )}
       <AppContent>
         <Outlet />
       </AppContent>

--- a/src/routes/_authenticated/signout.tsx
+++ b/src/routes/_authenticated/signout.tsx
@@ -1,0 +1,14 @@
+import { useAuthActions } from "@convex-dev/auth/react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/signout")({
+  component: RouteComponent,
+});
+
+async function RouteComponent() {
+  const navigate = useNavigate();
+  const { signOut } = useAuthActions();
+
+  await signOut();
+  navigate({ to: "/signin" });
+}

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -349,8 +349,8 @@ const ForgotPassword = ({
 
 function LoginRoute() {
   return (
-    <div className="flex flex-col w-96 max-w-full mx-auto min-h-dvh items-center justify-center gap-8 px-4 py-12">
-      <Link href="https://namesake.fyi" className="mb-4">
+    <div className="flex flex-col w-96 max-w-full mx-auto min-h-dvh items-center justify-center gap-8 p-4">
+      <Link href="https://namesake.fyi">
         <Logo />
       </Link>
       <AnimateChangeInHeight className="w-full">

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -16,7 +16,7 @@
 
 .h-mobile-nav {
   height: calc(56px + env(safe-area-inset-bottom));
-  padding-bottom: env(safe-area-inset-bottom);
+  padding-bottom: max(env(safe-area-inset-bottom), 0.25rem);
 }
 
 .prose {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -7,11 +7,16 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 .app-padding {
-  @apply px-6 lg:px-8;
+  @apply px-4 md:px-6 lg:px-8;
 }
 
 .h-header {
   @apply h-16 lg:h-20;
+}
+
+.h-mobile-nav {
+  height: calc(56px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .prose {

--- a/src/utils/useIsMobile.ts
+++ b/src/utils/useIsMobile.ts
@@ -1,20 +1,10 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
-const MOBILE_WIDTH = 800;
+const MOBILE_BREAKPOINT = 800;
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = useState(
-    window.matchMedia(`(width <= ${MOBILE_WIDTH}px)`).matches,
-  );
-
-  useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.matchMedia(`(width <= ${MOBILE_WIDTH}px)`).matches);
-    };
-
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
+  const query = window.matchMedia(`(width <= ${MOBILE_BREAKPOINT}px)`);
+  const [isMobile, setIsMobile] = useState(query.matches);
+  query.onchange = () => setIsMobile(query.matches);
   return isMobile;
 }

--- a/src/utils/useIsMobile.ts
+++ b/src/utils/useIsMobile.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+const MOBILE_WIDTH = 800;
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(
+    window.matchMedia(`(width <= ${MOBILE_WIDTH}px)`).matches,
+  );
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.matchMedia(`(width <= ${MOBILE_WIDTH}px)`).matches);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return isMobile;
+}

--- a/src/utils/useTheme.ts
+++ b/src/utils/useTheme.ts
@@ -12,12 +12,30 @@ export function useTheme() {
   const theme = (nextTheme ?? "system") as Theme;
   const themeSelection = new Set([theme]);
 
+  const THEME = {
+    light: "#fcfcfd",
+    dark: "#18191b",
+  };
+
   const setTheme = (theme: Selection) => {
     const newTheme = [...theme][0] as Theme;
     // Update the theme in the database
     updateTheme({ theme: newTheme });
     // Update the theme in next-themes
     setNextTheme(newTheme);
+    // Update the theme color meta tags
+    for (const meta of document.querySelectorAll('meta[name="theme-color"]')) {
+      if (newTheme === "light") meta.setAttribute("content", THEME.light);
+      if (newTheme === "dark") meta.setAttribute("content", THEME.dark);
+      if (newTheme === "system") {
+        // If system, reset the theme color meta tags to their default values
+        if (meta.getAttribute("media") === "(prefers-color-scheme: light)") {
+          meta.setAttribute("content", THEME.light);
+        } else {
+          meta.setAttribute("content", THEME.dark);
+        }
+      }
+    }
   };
 
   return { theme, themeSelection, setTheme };

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -34,6 +34,7 @@ vi.mock("@tanstack/react-router", () => ({
     },
   }),
   useSearch: vi.fn(),
+  useMatchRoute: vi.fn(),
 }));
 
 // Mock posthog

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -60,6 +60,17 @@ declare global {
 
 // Update the mock assignment
 window.IntersectionObserver = vi.fn() as any;
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
 
 // Mock fetch for PDF tests
 const originalFetch = global.fetch;


### PR DESCRIPTION
## What changed?
Make app mobile-friendly. Resolves #182

https://github.com/user-attachments/assets/a8a9f001-2b2b-4bf7-baec-a4c70ff99cbf

https://github.com/user-attachments/assets/1e626a04-785c-48a8-b0e2-0db0cc215262

Videos shown on iPhone SE.

Additionally:
- Relocate `/$questSlug` route to `/quests/$questSlug` to prevent polluting the top-level routes and have more control over empty state rendering
- Remove the card containers from form sections to give more space for text on mobile; subsections are now indented on the left to communicate the relation to the parent section
- Remove the user menu dropdown from the main app sidebar and replace with a link to `/settings` and a link to `/admin` (if the user is an admin)
- Add a "Sign out" link to the settings nav (necessary for mobile due to lack of user menu dropdown) and add a new "/signout" route

![CleanShot 2025-04-03 at 15 49 21@2x](https://github.com/user-attachments/assets/5dbee2a0-f0c4-48ff-bc87-8d58d344907c)

## Why?
Phones! People use em!

## How was this change made?
- Created a new `useIsMobile()` hook which can be used to test a constant breakpoint across the app
- Split apart `AppSidebar` component into `AppSidebarHeader`, `AppSidebar, and `AppSidebarFooter` in order to permit reusing sidebar logic when certain elements are not needed
- Added new `AppMobileNav` to display at the bottom of the viewport
- Added a `backLink` prop to `PageHeader` to support displaying a back arrow
- Modified routing logic to conditionally render the sidebar navigation as an index route when there isn't enough space for a sidebar
  - For example, on desktop, `/settings` will automatically route the user to `/settings/account`, showing the settings sidebar alongside the account settings; on mobile, `/settings` will render the settings sidebar nav as a full-page view of its own

## How was this tested?
Updated tests and wrote a few more, mostly manual clicking around the app locally and opening the mobile emulator.

## Anything else?
The quest page header needs some work; I'm going to follow up with a separate PR to improve that since this one has already gotten large. Filed #467