### PR TITLE
fix: Do not nest unnecessary `Dialog` within `Popover`

### DIFF
--- a/.changeset/curvy-pumas-fold.md
+++ b/.changeset/curvy-pumas-fold.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix popover handling

--- a/src/components/common/ComboBox/ComboBox.stories.tsx
+++ b/src/components/common/ComboBox/ComboBox.stories.tsx
@@ -12,6 +12,7 @@ const meta: Meta<typeof ComboBox> = {
 
   args: {
     label: "Ice cream flavor",
+    placeholder: "Select a flavor",
   },
 };
 

--- a/src/components/common/ComboBox/ComboBox.tsx
+++ b/src/components/common/ComboBox/ComboBox.tsx
@@ -58,7 +58,7 @@ export function ComboBox<T extends object>({
           </FieldGroup>
           {description && <FieldDescription>{description}</FieldDescription>}
           <FieldError>{errorMessage}</FieldError>
-          <Popover title="Select an option" className="w-(--trigger-width)">
+          <Popover className="w-(--trigger-width)">
             <ListBox
               items={items}
               className="outline-0 p-1 max-h-[inherit] overflow-auto [clip-path:inset(0_0_0_0_round_.75rem)]"

--- a/src/components/common/ComboBox/ComboBox.tsx
+++ b/src/components/common/ComboBox/ComboBox.tsx
@@ -63,7 +63,7 @@ export function ComboBox<T extends object>({
           <Popover className="w-(--trigger-width)">
             <ListBox
               items={items}
-              className="outline-0 p-1 max-h-[inherit] overflow-auto [clip-path:inset(0_0_0_0_round_.75rem)]"
+              className="outline-none p-1 max-h-[inherit] overflow-auto [clip-path:inset(0_0_0_0_round_.75rem)]"
             >
               {children}
             </ListBox>

--- a/src/components/common/ComboBox/ComboBox.tsx
+++ b/src/components/common/ComboBox/ComboBox.tsx
@@ -27,6 +27,7 @@ export interface ComboBoxProps<T extends object>
   description?: string | null;
   errorMessage?: string | ((validation: ValidationResult) => string);
   children: React.ReactNode | ((item: T) => React.ReactNode);
+  placeholder?: string;
 }
 
 export function ComboBox<T extends object>({
@@ -35,6 +36,7 @@ export function ComboBox<T extends object>({
   errorMessage,
   children,
   items,
+  placeholder,
   ...props
 }: ComboBoxProps<T>) {
   return (
@@ -49,7 +51,7 @@ export function ComboBox<T extends object>({
         <>
           <Label>{label}</Label>
           <FieldGroup {...renderProps}>
-            <Input />
+            <Input placeholder={placeholder} />
             <Button
               variant="icon"
               className="w-7 h-7 p-0 mr-1 outline-offset-0"

--- a/src/components/common/DateField/DateField.tsx
+++ b/src/components/common/DateField/DateField.tsx
@@ -54,7 +54,7 @@ export function DateField<T extends DateValue>({
 }
 
 const segmentStyles = tv({
-  base: "inline px-0.5 type-literal:px-1 rounded-sm outline-0 forced-color-adjust-none caret-transparent text-gray-normal forced-colors:text-[ButtonText]",
+  base: "inline px-0.5 type-literal:px-1 rounded-sm outline-none forced-color-adjust-none caret-transparent text-gray-normal forced-colors:text-[ButtonText]",
   variants: {
     isPlaceholder: {
       true: "text-gray-9",

--- a/src/components/common/DatePicker/DatePicker.tsx
+++ b/src/components/common/DatePicker/DatePicker.tsx
@@ -56,7 +56,7 @@ export function DatePicker<T extends DateValue>({
           </FieldGroup>
           {description && <FieldDescription>{description}</FieldDescription>}
           <FieldError>{errorMessage}</FieldError>
-          <Popover title="Select a date" className="p-3">
+          <Popover className="p-3">
             <Calendar />
           </Popover>
         </>

--- a/src/components/common/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/common/DateRangePicker/DateRangePicker.tsx
@@ -63,7 +63,7 @@ export function DateRangePicker<T extends DateValue>({
           </FieldGroup>
           {description && <FieldDescription>{description}</FieldDescription>}
           <FieldError>{errorMessage}</FieldError>
-          <Popover title="Select a date range" className="p-3">
+          <Popover className="p-3">
             <RangeCalendar />
           </Popover>
         </>

--- a/src/components/common/Dialog/Dialog.tsx
+++ b/src/components/common/Dialog/Dialog.tsx
@@ -13,7 +13,7 @@ export function Dialog(props: DialogProps) {
     <AriaDialog
       {...props}
       className={twMerge(
-        "outline outline-0 p-0 max-h-[inherit] relative",
+        "outline outline-none p-0 max-h-[inherit] relative",
         props.className,
       )}
     />

--- a/src/components/common/Field/Field.tsx
+++ b/src/components/common/Field/Field.tsx
@@ -136,7 +136,7 @@ interface InputProps extends Omit<AriaInputProps, "size"> {
 }
 
 export const inputStyles = tv({
-  base: "flex-1 min-w-0 outline outline-0 bg-transparent text-gray-normal disabled:text-gray-dim",
+  base: "flex-1 min-w-0 outline outline-none bg-transparent text-gray-normal disabled:text-gray-dim",
   variants: {
     size: {
       small: "px-2 h-8 text-sm",
@@ -162,7 +162,7 @@ export function Input({ ref, size, ...props }: InputProps) {
 }
 
 export const inputTextAreaStyles = tv({
-  base: "flex-1 min-w-0 leading-snug outline-0 bg-transparent text-gray-normal disabled:text-gray-dim",
+  base: "flex-1 min-w-0 leading-snug outline-none bg-transparent text-gray-normal disabled:text-gray-dim",
   variants: {
     size: {
       small: "px-2 py-1",

--- a/src/components/common/ListBox/ListBox.tsx
+++ b/src/components/common/ListBox/ListBox.tsx
@@ -24,7 +24,7 @@ export function ListBox<T extends object>({
       {...props}
       className={composeTailwindRenderProps(
         props.className,
-        "outline-0 p-1 border border-gray-dim rounded-lg overflow-y-auto",
+        "outline-none p-1 border border-gray-dim rounded-lg overflow-y-auto",
       )}
     >
       {children}
@@ -64,7 +64,7 @@ export function ListBoxItem(props: ListBoxItemProps) {
 }
 
 export const dropdownItemStyles = tv({
-  base: "group flex items-center gap-3 cursor-pointer select-none py-2 px-2.5 pr-3 rounded-lg outline-0 text-sm forced-color-adjust-none",
+  base: "group flex items-center gap-3 cursor-pointer select-none py-2 px-2.5 pr-3 rounded-lg outline-none text-sm forced-color-adjust-none",
   variants: {
     isDisabled: {
       false: "text-gray-normal",

--- a/src/components/common/Menu/Menu.test.tsx
+++ b/src/components/common/Menu/Menu.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
 describe("Menu", () => {
-  it("renders Menu with accessible title", async () => {
+  it("renders Menu", async () => {
     render(
       <DialogTrigger>
         <Button>Open Menu</Button>
@@ -22,10 +22,8 @@ describe("Menu", () => {
     const menu = await screen.findByRole("menu");
     expect(menu).toBeInTheDocument();
 
-    // Renders the accessible title
-    const title = await screen.findByRole("dialog", {
-      name: "Select an option",
-    });
-    expect(title).toBeInTheDocument();
+    // Renders the menu popover
+    const popover = await screen.findByRole("dialog");
+    expect(popover).toBeInTheDocument();
   });
 });

--- a/src/components/common/Menu/Menu.tsx
+++ b/src/components/common/Menu/Menu.tsx
@@ -40,7 +40,7 @@ export function Menu<T extends object>(props: MenuProps<T>) {
     <Popover placement={props.placement} className="min-w-[150px]">
       <AriaMenu
         {...props}
-        className="p-1 outline-0 max-h-[inherit] overflow-auto [clip-path:inset(0_0_0_0_round_.75rem)]"
+        className="p-1 outline-none max-h-[inherit] overflow-auto [clip-path:inset(0_0_0_0_round_.75rem)]"
       />
     </Popover>
   );

--- a/src/components/common/Menu/Menu.tsx
+++ b/src/components/common/Menu/Menu.tsx
@@ -37,14 +37,10 @@ export function MenuTrigger(props: MenuTriggerProps) {
 
 export function Menu<T extends object>(props: MenuProps<T>) {
   return (
-    <Popover
-      title="Select an option"
-      placement={props.placement}
-      className="min-w-[150px]"
-    >
+    <Popover placement={props.placement} className="min-w-[150px]">
       <AriaMenu
         {...props}
-        className="p-1 outline outline-0 max-h-[inherit] overflow-auto [clip-path:inset(0_0_0_0_round_.75rem)]"
+        className="p-1 outline-0 max-h-[inherit] overflow-auto [clip-path:inset(0_0_0_0_round_.75rem)]"
       />
     </Popover>
   );

--- a/src/components/common/Popover/Popover.stories.tsx
+++ b/src/components/common/Popover/Popover.stories.tsx
@@ -4,9 +4,6 @@ import { CircleHelp } from "lucide-react";
 
 const meta: Meta<typeof Popover> = {
   component: Popover,
-  args: {
-    title: "Help",
-  },
 };
 
 export default meta;

--- a/src/components/common/Popover/Popover.test.tsx
+++ b/src/components/common/Popover/Popover.test.tsx
@@ -8,7 +8,7 @@ describe("Popover", () => {
     render(
       <DialogTrigger>
         <Button>Open</Button>
-        <Popover title="Help" className="max-w-[250px]">
+        <Popover className="max-w-[250px]">
           <p className="text-sm">
             For help accessing your account, please contact support.
           </p>
@@ -23,7 +23,5 @@ describe("Popover", () => {
 
     const popover = await screen.findByRole("dialog");
     expect(popover).toBeInTheDocument();
-
-    expect(popover).toHaveAttribute("aria-label", "Help");
   });
 });

--- a/src/components/common/Popover/Popover.tsx
+++ b/src/components/common/Popover/Popover.tsx
@@ -1,4 +1,3 @@
-import { Dialog } from "@/components/common";
 import type React from "react";
 import {
   Popover as AriaPopover,
@@ -11,8 +10,6 @@ import { tv } from "tailwind-variants";
 
 export interface PopoverProps extends Omit<AriaPopoverProps, "children"> {
   children: React.ReactNode;
-  /** Provide a screen reader title for the popover. */
-  title: string;
 }
 
 const styles = tv({
@@ -27,12 +24,7 @@ const styles = tv({
   },
 });
 
-export function Popover({
-  children,
-  className,
-  title,
-  ...props
-}: PopoverProps) {
+export function Popover({ children, className, ...props }: PopoverProps) {
   const popoverContext = useSlottedContext(PopoverContext)!;
   const isSubmenu = popoverContext?.trigger === "SubmenuTrigger";
   const offset = isSubmenu ? 2 : 8;
@@ -45,7 +37,7 @@ export function Popover({
         styles({ ...renderProps, className }),
       )}
     >
-      <Dialog aria-label={title}>{children}</Dialog>
+      {children}
     </AriaPopover>
   );
 }

--- a/src/components/common/RangeCalendar/RangeCalendar.tsx
+++ b/src/components/common/RangeCalendar/RangeCalendar.tsx
@@ -47,7 +47,7 @@ export function RangeCalendar<T extends DateValue>({
           {(date) => (
             <CalendarCell
               date={date}
-              className="group w-9 h-9 text-sm outline-0 cursor-default outside-month:text-gray-10 selected:bg-purple-3 selected:text-purple-12 forced-colors:selected:bg-[Highlight] invalid:selected:bg-red-3 forced-colors:invalid:selected:bg-[Mark] [td:first-child_&]:rounded-s-full selection-start:rounded-s-full [td:last-child_&]:rounded-e-full selection-end:rounded-e-full"
+              className="group w-9 h-9 text-sm outline-none cursor-default outside-month:text-gray-10 selected:bg-purple-3 selected:text-purple-12 forced-colors:selected:bg-[Highlight] invalid:selected:bg-red-3 forced-colors:invalid:selected:bg-[Mark] [td:first-child_&]:rounded-s-full selection-start:rounded-s-full [td:last-child_&]:rounded-e-full selection-end:rounded-e-full"
             >
               {({
                 formattedDate,

--- a/src/components/common/RichText/RichText.tsx
+++ b/src/components/common/RichText/RichText.tsx
@@ -93,9 +93,8 @@ export function RichText({
     base: "w-full",
     variants: {
       editable: {
-        true: "px-3.5 py-3 [&_.tiptap]:outline-hidden",
-        false:
-          "ring-0 rounded-none bg-transparent focus-within:outline-hidden!",
+        true: "px-3.5 py-3 [&_.tiptap]:outline-none",
+        false: "ring-0 rounded-none bg-transparent focus-within:outline-none!",
       },
     },
   });

--- a/src/components/common/Select/Select.tsx
+++ b/src/components/common/Select/Select.tsx
@@ -64,7 +64,7 @@ export function Select<T extends object>({
       <Popover className="min-w-(--trigger-width)">
         <ListBox
           items={items}
-          className="outline-hidden p-1 max-h-[inherit] overflow-auto [clip-path:inset(0_0_0_0_round_.75rem)]"
+          className="outline-none p-1 max-h-[inherit] overflow-auto [clip-path:inset(0_0_0_0_round_.75rem)]"
         >
           {children}
         </ListBox>

--- a/src/components/common/Select/Select.tsx
+++ b/src/components/common/Select/Select.tsx
@@ -61,7 +61,7 @@ export function Select<T extends object>({
       </Button>
       {description && <FieldDescription>{description}</FieldDescription>}
       <FieldError>{errorMessage}</FieldError>
-      <Popover title="Select an option" className="min-w-(--trigger-width)">
+      <Popover className="min-w-(--trigger-width)">
         <ListBox
           items={items}
           className="outline-hidden p-1 max-h-[inherit] overflow-auto [clip-path:inset(0_0_0_0_round_.75rem)]"

--- a/src/components/quests/StatGroup/StatGroup.tsx
+++ b/src/components/quests/StatGroup/StatGroup.tsx
@@ -23,9 +23,7 @@ export const StatPopover = ({ tooltip, children }: StatPopoverProps) => (
       />
       <Tooltip>{tooltip}</Tooltip>
     </TooltipTrigger>
-    <Popover title={tooltip} className="p-4">
-      {children}
-    </Popover>
+    <Popover className="p-4">{children}</Popover>
   </DialogTrigger>
 );
 

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -3,7 +3,7 @@ import { twMerge } from "tailwind-merge";
 import { tv } from "tailwind-variants";
 
 export const focusRing = tv({
-  base: "outline outline-offset-2 has-[[data-focus-visible]]:outline-0",
+  base: "outline outline-offset-2 has-[[data-focus-visible]]:outline-none",
   variants: {
     isFocusVisible: {
       false: "outline-transparent",


### PR DESCRIPTION
## What changed?
- Fix `Popover` markup to allow for correct focus management when using `ComboBox`
- Remove the previously-required `title` prop from `Popover`
- Add support for placeholders in `ComboBox`.

![CleanShot 2025-04-11 at 12 49 03@2x](https://github.com/user-attachments/assets/0f644426-f134-4146-bdcf-540e86863f96)

## Why?
I encountered an issue with `ComboBox` where typing in the input would trigger the menu and then lose focus, making it impossible to type more than one character.

https://github.com/user-attachments/assets/62ee9eea-8d93-4194-bf36-03de7c8a216c

After some digging, I discovered this was because our `Popover` component had a `Dialog` nested within it. This was inserted some time ago after encountering a bug with React-Aria and warnings about missing aria-labels. It seems the bug is fixed, and manual aria-labels are no longer required (`Popover` will automatically link its trigger element via `aria-labelledby`).

With the changes to `Popover`, `ComboBox` works as expected:

https://github.com/user-attachments/assets/19233b38-4fce-47f8-9847-f9dbc886540d

## How was this change made?
- Removed inner `Dialog`
- Removed `title` prop
- Updated all components so type checking and tests pass

## How was this tested?
Re-ran `pnpm test`

## Anything else?
We aren't using `ComboBox` anywhere in the app right now, but there's a spot I want to add it soon.