### PR TITLE
feat: Add county selection with `typed-usa-states`

### DIFF
--- a/.changeset/late-beans-scream.md
+++ b/.changeset/late-beans-scream.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Add support for selecting a county of residence

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -31,64 +31,18 @@ import {
   Sun,
   Zap,
 } from "lucide-react";
+import { usaStates } from "typed-usa-states";
 
-export const JURISDICTIONS = {
-  AK: "Alaska",
-  AL: "Alabama",
-  AR: "Arkansas",
-  AZ: "Arizona",
-  CA: "California",
-  CO: "Colorado",
-  CT: "Connecticut",
-  DC: "District of Columbia",
-  DE: "Delaware",
-  FL: "Florida",
-  GA: "Georgia",
-  HI: "Hawaii",
-  IA: "Iowa",
-  ID: "Idaho",
-  IL: "Illinois",
-  IN: "Indiana",
-  KS: "Kansas",
-  KY: "Kentucky",
-  LA: "Louisiana",
-  MA: "Massachusetts",
-  MD: "Maryland",
-  ME: "Maine",
-  MI: "Michigan",
-  MN: "Minnesota",
-  MO: "Missouri",
-  MS: "Mississippi",
-  MT: "Montana",
-  NC: "North Carolina",
-  ND: "North Dakota",
-  NE: "Nebraska",
-  NH: "New Hampshire",
-  NJ: "New Jersey",
-  NM: "New Mexico",
-  NV: "Nevada",
-  NY: "New York",
-  OH: "Ohio",
-  OK: "Oklahoma",
-  OR: "Oregon",
-  PA: "Pennsylvania",
-  PR: "Puerto Rico",
-  RI: "Rhode Island",
-  SC: "South Carolina",
-  SD: "South Dakota",
-  TN: "Tennessee",
-  TX: "Texas",
-  UT: "Utah",
-  VA: "Virginia",
-  VT: "Vermont",
-  WA: "Washington",
-  WI: "Wisconsin",
-  WV: "West Virginia",
-  WY: "Wyoming",
-} as const;
+export const JURISDICTIONS = usaStates.reduce(
+  (acc, state) => {
+    acc[state.abbreviation] = state.name;
+    return acc;
+  },
+  {} as Record<string, string>,
+);
 export type Jurisdiction = keyof typeof JURISDICTIONS;
 
-export const BIRTHPLACES = {
+export const BIRTHPLACES: Record<Jurisdiction | "other", string> = {
   ...JURISDICTIONS,
   other: "I was born outside the US",
 };
@@ -395,6 +349,10 @@ export const USER_FORM_DATA_FIELDS: Record<string, FieldDefinition> = {
     label: "Residence city",
     type: "string",
   },
+  residenceCounty: {
+    label: "Residence county",
+    type: "string",
+  },
   residenceState: {
     label: "Residence state",
     type: "string",
@@ -413,6 +371,10 @@ export const USER_FORM_DATA_FIELDS: Record<string, FieldDefinition> = {
   },
   mailingCity: {
     label: "Mailing city",
+    type: "string",
+  },
+  mailingCounty: {
+    label: "Mailing county",
     type: "string",
   },
   mailingState: {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "tailwindcss": "^4.0.14",
     "text-readability": "^1.1.1",
     "tw-animate-css": "^1.2.7",
+    "typed-usa-states": "^2.1.0",
     "use-debounce": "^10.0.4",
     "zod": "^3.24.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       tw-animate-css:
         specifier: ^1.2.7
         version: 1.2.7
+      typed-usa-states:
+        specifier: ^2.1.0
+        version: 2.1.0
       use-debounce:
         specifier: ^10.0.4
         version: 10.0.4(react@19.1.0)
@@ -5287,6 +5290,9 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typed-usa-states@2.1.0:
+    resolution: {integrity: sha512-9HyajobhSjkrF/vg0f70AVBZUY7t9RqFowyyFtim2HmKQ+LtYh14AmIe+3dTfOH5zYrgSLgOlSR+luH9F0g6dw==}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -11108,6 +11114,8 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typed-usa-states@2.1.0: {}
 
   typescript@5.8.3: {}
 

--- a/src/components/forms/AddressField/AddressField.stories.tsx
+++ b/src/components/forms/AddressField/AddressField.stories.tsx
@@ -20,3 +20,11 @@ Example.args = {
     </div>
   ),
 };
+
+export const IncludeCounty = (args: AddressFieldProps) => (
+  <AddressField {...args} includeCounty />
+);
+
+IncludeCounty.args = {
+  type: "residence",
+};

--- a/src/components/forms/AddressField/AddressField.test.tsx
+++ b/src/components/forms/AddressField/AddressField.test.tsx
@@ -109,4 +109,90 @@ describe("AddressField", () => {
     expect(stateSelect).toHaveAttribute("name", "mailingState");
     expect(zipInput).toHaveAttribute("name", "mailingZipCode");
   });
+
+  it("does not show county selection by default", () => {
+    renderWithFormProvider(<AddressField type="residence" />);
+
+    expect(screen.queryByLabelText("County")).not.toBeInTheDocument();
+  });
+
+  it("shows county selection when includeCounty is true and state is selected", async () => {
+    renderWithFormProvider(<AddressField type="residence" includeCounty />);
+
+    // Initially county should not be visible
+    expect(screen.queryByLabelText("County")).not.toBeInTheDocument();
+
+    // Select California
+    const stateSelect = screen.getByLabelText("State");
+    await userEvent.click(stateSelect);
+    const californiaOption = screen.getByRole("option", {
+      name: JURISDICTIONS.CA,
+    });
+    await userEvent.click(californiaOption);
+
+    // County dropdown should now be visible
+    const countySelect = screen.getByLabelText("County");
+    expect(countySelect).toBeInTheDocument();
+
+    // Should be able to select a county
+    await userEvent.click(countySelect);
+    const losAngelesOption = screen.getByRole("option", {
+      name: "Los Angeles County",
+    });
+    await userEvent.click(losAngelesOption);
+    expect(countySelect).toHaveTextContent("Los Angeles County");
+  });
+
+  it("clears county selection when state changes", async () => {
+    renderWithFormProvider(<AddressField type="residence" includeCounty />);
+
+    // Select New York
+    const stateSelect = screen.getByLabelText("State");
+    await userEvent.click(stateSelect);
+    const newYorkOption = screen.getByRole("option", {
+      name: JURISDICTIONS.NY,
+    });
+    await userEvent.click(newYorkOption);
+
+    // Select New York county
+    const countySelect = screen.getByLabelText("County");
+    await userEvent.click(countySelect);
+    const queensCountyOption = screen.getByRole("option", {
+      name: "Queens County",
+    });
+    await userEvent.click(queensCountyOption);
+
+    // Change state to Massachusetts
+    await userEvent.click(stateSelect);
+    const massachusettsOption = screen.getByRole("option", {
+      name: JURISDICTIONS.MA,
+    });
+    await userEvent.click(massachusettsOption);
+
+    // County should update to Massachusetts counties
+    await userEvent.click(countySelect);
+    expect(
+      screen.queryByRole("option", { name: "Queens County" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Suffolk County" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the correct name for county field based on address type", async () => {
+    renderWithFormProvider(<AddressField type="residence" includeCounty />);
+
+    // Select New York to show county field
+    const stateSelect = screen.getByLabelText("State");
+    await userEvent.click(stateSelect);
+    const newYorkOption = screen.getByRole("option", {
+      name: JURISDICTIONS.NY,
+    });
+    await userEvent.click(newYorkOption);
+
+    const selectElements = screen.getAllByRole("combobox", {
+      hidden: true,
+    });
+    expect(selectElements[1]).toHaveAttribute("name", "residenceCounty");
+  });
 });

--- a/src/forms/ma/cjp27-petition-to-change-name-of-adult.test.ts
+++ b/src/forms/ma/cjp27-petition-to-change-name-of-adult.test.ts
@@ -15,6 +15,7 @@ describe("CJP27 Petition to Change Name of Adult", () => {
     residenceStreetAddress: "123 Main St",
     residenceCity: "Cambridge",
     residenceState: "MA",
+    residenceCounty: "Suffolk",
     residenceZipCode: "02139",
     isMailingAddressDifferentFromResidence: true,
     mailingStreetAddress: "456 Post St",
@@ -33,6 +34,9 @@ describe("CJP27 Petition to Change Name of Adult", () => {
       pdf: petitionToChangeNameOfAdult,
       userData: testData,
     });
+
+    // Division (County)
+    expect(form.getTextField("county").getText()).toBe("Suffolk");
 
     // Verify fields
     expect(form.getTextField("newFirstName").getText()).toBe("Eva");

--- a/src/forms/ma/cjp27-petition-to-change-name-of-adult.ts
+++ b/src/forms/ma/cjp27-petition-to-change-name-of-adult.ts
@@ -19,6 +19,7 @@ export default definePdf({
     residenceStreetAddress?: string;
     residenceCity?: string;
     residenceState?: string;
+    residenceCounty?: string;
     residenceZipCode?: string;
     email?: string;
     phoneNumber?: string;
@@ -48,7 +49,7 @@ export default definePdf({
     petitionerLastName: data.oldLastName,
 
     // Division (County)
-    county: "Suffolk", // TODO: https://github.com/namesakefyi/namesake/issues/453
+    county: data.residenceCounty,
 
     // Current legal name
     oldFirstName: data.oldFirstName,

--- a/src/routes/_authenticated/forms/ma-court-order.tsx
+++ b/src/routes/_authenticated/forms/ma-court-order.tsx
@@ -130,7 +130,7 @@ function RouteComponent() {
         />
         {!form.watch("isCurrentlyUnhoused") === true && (
           <>
-            <AddressField type="residence" />
+            <AddressField type="residence" includeCounty />
             <CheckboxField
               name="isMailingAddressDifferentFromResidence"
               label="I use a different mailing address"


### PR DESCRIPTION
## What changed?
Adds a county select dropdown which can be conditionally rendered with `AddressField` inside forms. Resolves #453 

https://github.com/user-attachments/assets/37f5163a-6f0e-44e8-83e3-a92f0e9eae99

## Why?
Some of the name change forms in MA require a county. Future states/forms may require county information, too.

## How was this change made?
- Installed [typed-usa-states](https://www.npmjs.com/package/typed-usa-states) package for access to all states and countes
- Replaced existing `JURISDICTIONS` definnition with values from `typed-usa-states`
- Added form data values for `residenceCounty` and `mailingCounty`
- Updated the `AddressField` component with the new county select dropdown, conditionally rendered
- Updated the form definition and form UI for `ma-court-order` to include the new county field

## How was this tested?
Created new `AddressField` tests for county selection.

## Anything else?
Note that moving to this library includes new territories for states which weren't previously in the dropdown: American Samoa, Guam, Northern Mariana Islands, Puerto Rico and the Virgin Islands. None of these have county-level info, so the field is not displayed.