### PR TITLE
chore: Remove references / urls from `quests` schema

### DIFF
--- a/convex/model/questsModel.ts
+++ b/convex/model/questsModel.ts
@@ -174,63 +174,6 @@ export async function update(
   });
 }
 
-export async function updateUrls(
-  ctx: MutationCtx,
-  {
-    questId,
-    userId,
-    urls,
-  }: {
-    questId: Id<"quests">;
-    userId: Id<"users">;
-    urls?: string[];
-  },
-) {
-  return await update(ctx, questId, userId, { urls });
-}
-
-export async function addUrl(
-  ctx: MutationCtx,
-  {
-    questId,
-    userId,
-    url,
-  }: {
-    questId: Id<"quests">;
-    userId: Id<"users">;
-    url: string;
-  },
-) {
-  const quest = await ctx.db.get(questId);
-  if (!quest) throw new Error("Quest not found");
-
-  const existingUrls = quest.urls || [];
-  return await update(ctx, questId, userId, {
-    urls: [...existingUrls, url],
-  });
-}
-
-export async function deleteUrl(
-  ctx: MutationCtx,
-  {
-    questId,
-    userId,
-    url,
-  }: {
-    questId: Id<"quests">;
-    userId: Id<"users">;
-    url: string;
-  },
-) {
-  const quest = await ctx.db.get(questId);
-  if (!quest) throw new Error("Quest not found");
-
-  const existingUrls = quest.urls || [];
-  return await update(ctx, questId, userId, {
-    urls: existingUrls.filter((u) => u !== url),
-  });
-}
-
 export async function setCosts(
   ctx: MutationCtx,
   {

--- a/convex/quests.ts
+++ b/convex/quests.ts
@@ -150,39 +150,6 @@ export const setCategory = userMutation({
   },
 });
 
-export const setUrls = userMutation({
-  args: { questId: v.id("quests"), urls: v.optional(v.array(v.string())) },
-  handler: async (ctx, args) => {
-    return await Quests.updateUrls(ctx, {
-      questId: args.questId,
-      userId: ctx.userId,
-      urls: args.urls,
-    });
-  },
-});
-
-export const addUrl = userMutation({
-  args: { questId: v.id("quests"), url: v.string() },
-  handler: async (ctx, args) => {
-    return await Quests.addUrl(ctx, {
-      questId: args.questId,
-      userId: ctx.userId,
-      url: args.url,
-    });
-  },
-});
-
-export const deleteUrl = userMutation({
-  args: { questId: v.id("quests"), url: v.string() },
-  handler: async (ctx, args) => {
-    return await Quests.deleteUrl(ctx, {
-      questId: args.questId,
-      userId: ctx.userId,
-      url: args.url,
-    });
-  },
-});
-
 export const setCosts = userMutation({
   args: {
     questId: v.id("quests"),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -48,8 +48,6 @@ const quests = defineTable({
       description: v.optional(v.string()),
     }),
   ),
-  /** Links to official documentation about changing names for this quest. */
-  urls: v.optional(v.array(v.string())),
   /** Time in ms since epoch when the quest was deleted. */
   deletedAt: v.optional(v.number()),
   /** Steps in the quest. */


### PR DESCRIPTION
## What changed?
Followup to #493. Remove `references`/`urls` from `quests` schema.

## Why?
Expanding the editor component to support more content means that our schema can be less rigid. In other words, instead of putting references in a dedicated column, we can just put them in the body of the quest contents.

## How was this change made?
Deleted `urls` column from the `quests` table and all related models.

## How was this tested?
N/A. Existing tests pass.