### PR TITLE
fix: Autofill field styles

### DIFF
--- a/.changeset/silver-seals-bow.md
+++ b/.changeset/silver-seals-bow.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix autofill form field styles

--- a/src/components/common/Field/Field.tsx
+++ b/src/components/common/Field/Field.tsx
@@ -136,7 +136,7 @@ interface InputProps extends Omit<AriaInputProps, "size"> {
 }
 
 export const inputStyles = tv({
-  base: "flex-1 min-w-0 outline outline-none bg-transparent disable-autofill text-gray-normal disabled:text-gray-dim",
+  base: "flex-1 min-w-0 outline outline-none bg-transparent disable-native-autofill text-gray-normal disabled:text-gray-dim",
   variants: {
     size: {
       small: "px-2 h-8 text-sm",
@@ -162,7 +162,7 @@ export function Input({ ref, size, ...props }: InputProps) {
 }
 
 export const inputTextAreaStyles = tv({
-  base: "flex-1 min-w-0 leading-snug outline-none bg-transparent text-gray-normal disabled:text-gray-dim",
+  base: "flex-1 min-w-0 leading-snug outline-none bg-transparent disable-native-autofill text-gray-normal disabled:text-gray-dim",
   variants: {
     size: {
       small: "px-2 py-1",

--- a/src/components/common/Field/Field.tsx
+++ b/src/components/common/Field/Field.tsx
@@ -72,8 +72,9 @@ export function FieldError(props: FieldErrorProps) {
 export const fieldBorderStyles = tv({
   variants: {
     isFocusWithin: {
-      false: "ring-gray-6 has-autofill:ring-purple-6",
-      true: "ring-gray-7 has-autofill:ring-purple-6",
+      false:
+        "ring-gray-6 has-autofill:ring-amber-6 dark:has-autofill:ring-purple-6",
+      true: "ring-gray-7 has-autofill:ring-amber-6 dark:has-autofill:ring-purple-6",
     },
     isInvalid: {
       true: "ring-red-9",
@@ -87,8 +88,9 @@ export const fieldBorderStyles = tv({
 export const innerBorderStyles = tv({
   variants: {
     isFocusWithin: {
-      false: "border-gray-6 has-autofill:border-purple-6",
-      true: "border-gray-7 has-autofill:border-purple-6",
+      false:
+        "border-gray-6 has-autofill:border-amber-6 dark:has-autofill:border-purple-6",
+      true: "border-gray-7 has-autofill:border-amber-6 dark:has-autofill:border-purple-6",
     },
     isInvalid: {
       true: "border-red-9",
@@ -101,7 +103,7 @@ export const innerBorderStyles = tv({
 
 const fieldGroupStyles = tv({
   extend: focusRing,
-  base: "border-none text-sm has-autofill:bg-purple-a3 ring-inset ring-1 group flex items-center bg-element forced-colors:bg-[Field] rounded-lg",
+  base: "border-none text-sm has-autofill:bg-amber-a3 dark:has-autofill:bg-purple-a3 ring-inset ring-1 group flex items-center bg-element forced-colors:bg-[Field] rounded-lg",
   variants: {
     ...fieldBorderStyles.variants,
     size: {

--- a/src/components/common/Field/Field.tsx
+++ b/src/components/common/Field/Field.tsx
@@ -72,8 +72,8 @@ export function FieldError(props: FieldErrorProps) {
 export const fieldBorderStyles = tv({
   variants: {
     isFocusWithin: {
-      false: "ring-gray-6",
-      true: "ring-gray-7",
+      false: "ring-gray-6 has-autofill:ring-amber-6",
+      true: "ring-gray-7 has-autofill:ring-amber-6",
     },
     isInvalid: {
       true: "ring-red-9",
@@ -87,8 +87,8 @@ export const fieldBorderStyles = tv({
 export const innerBorderStyles = tv({
   variants: {
     isFocusWithin: {
-      false: "border-gray-6",
-      true: "border-gray-7",
+      false: "border-gray-6 has-autofill:border-amber-6",
+      true: "border-gray-7 has-autofill:border-amber-6",
     },
     isInvalid: {
       true: "border-red-9",
@@ -101,7 +101,7 @@ export const innerBorderStyles = tv({
 
 const fieldGroupStyles = tv({
   extend: focusRing,
-  base: "border-none text-sm ring-inset ring-1 group flex items-center bg-element forced-colors:bg-[Field] rounded-lg",
+  base: "border-none text-sm has-autofill:bg-amber-a3 ring-inset ring-1 group flex items-center bg-element forced-colors:bg-[Field] rounded-lg",
   variants: {
     ...fieldBorderStyles.variants,
     size: {
@@ -136,7 +136,7 @@ interface InputProps extends Omit<AriaInputProps, "size"> {
 }
 
 export const inputStyles = tv({
-  base: "flex-1 min-w-0 outline outline-none bg-transparent text-gray-normal disabled:text-gray-dim",
+  base: "flex-1 min-w-0 outline outline-none bg-transparent disable-autofill text-gray-normal disabled:text-gray-dim",
   variants: {
     size: {
       small: "px-2 h-8 text-sm",

--- a/src/components/common/Field/Field.tsx
+++ b/src/components/common/Field/Field.tsx
@@ -72,8 +72,8 @@ export function FieldError(props: FieldErrorProps) {
 export const fieldBorderStyles = tv({
   variants: {
     isFocusWithin: {
-      false: "ring-gray-6 has-autofill:ring-amber-6",
-      true: "ring-gray-7 has-autofill:ring-amber-6",
+      false: "ring-gray-6 has-autofill:ring-purple-6",
+      true: "ring-gray-7 has-autofill:ring-purple-6",
     },
     isInvalid: {
       true: "ring-red-9",
@@ -87,8 +87,8 @@ export const fieldBorderStyles = tv({
 export const innerBorderStyles = tv({
   variants: {
     isFocusWithin: {
-      false: "border-gray-6 has-autofill:border-amber-6",
-      true: "border-gray-7 has-autofill:border-amber-6",
+      false: "border-gray-6 has-autofill:border-purple-6",
+      true: "border-gray-7 has-autofill:border-purple-6",
     },
     isInvalid: {
       true: "border-red-9",
@@ -101,7 +101,7 @@ export const innerBorderStyles = tv({
 
 const fieldGroupStyles = tv({
   extend: focusRing,
-  base: "border-none text-sm has-autofill:bg-amber-a3 ring-inset ring-1 group flex items-center bg-element forced-colors:bg-[Field] rounded-lg",
+  base: "border-none text-sm has-autofill:bg-purple-a3 ring-inset ring-1 group flex items-center bg-element forced-colors:bg-[Field] rounded-lg",
   variants: {
     ...fieldBorderStyles.variants,
     size: {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -207,3 +207,21 @@ body,
     animation: none;
   }
 }
+
+@keyframes disable-autofill {
+  100% {
+    background-color: transparent;
+    color: inherit;
+    font-size: inherit;
+  }
+}
+
+.disable-autofill:-webkit-autofill,
+.disable-autofill:autofill {
+  /* The background color itself can't be overridden, so we use a hack to disable it.
+  https://css-tricks.com/snippets/css/change-autocomplete-styles-webkit-browsers/ */
+
+  /* Set transition delay to the max possible integer in CSS (68.24 years)
+  https://stackoverflow.com/questions/37861312/what-is-the-maximum-value-of-a-css-transitions-duration */
+  transition: background-color 0s linear 2147483647s;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -219,5 +219,6 @@ body,
   transition-delay: 0s;
   transition-duration: 2147483647s;
   transition-timing-function: linear;
+  background-color: transparent !important;
   -webkit-text-fill-color: inherit;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -215,5 +215,9 @@ body,
 
   /* Set transition delay to the max possible integer in CSS (68.24 years)
   https://stackoverflow.com/questions/37861312/what-is-the-maximum-value-of-a-css-transitions-duration */
-  transition: background-color 0s linear 2147483647s;
+  transition-property: background-color, color;
+  transition-delay: 0s;
+  transition-duration: 2147483647s;
+  transition-timing-function: linear;
+  -webkit-text-fill-color: inherit;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -216,8 +216,8 @@ body,
   /* Set transition delay to the max possible integer in CSS (68.24 years)
   https://stackoverflow.com/questions/37861312/what-is-the-maximum-value-of-a-css-transitions-duration */
   transition-property: background-color, color;
-  transition-delay: 0s;
-  transition-duration: 2147483647s;
+  transition-duration: 0s;
+  transition-delay: 2147483647s;
   transition-timing-function: linear;
   background-color: transparent !important;
   -webkit-text-fill-color: inherit;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -208,16 +208,8 @@ body,
   }
 }
 
-@keyframes disable-autofill {
-  100% {
-    background-color: transparent;
-    color: inherit;
-    font-size: inherit;
-  }
-}
-
-.disable-autofill:-webkit-autofill,
-.disable-autofill:autofill {
+.disable-native-autofill:-webkit-autofill,
+.disable-native-autofill:autofill {
   /* The background color itself can't be overridden, so we use a hack to disable it.
   https://css-tricks.com/snippets/css/change-autocomplete-styles-webkit-browsers/ */
 


### PR DESCRIPTION
## What changed?
Add custom styles for auto-filled fields. Fixes #486 

| Before | After |
|--------|--------|
| ![CleanShot 2025-04-24 at 17 49 56@2x](https://github.com/user-attachments/assets/79806e88-ad28-40e2-a17c-18b318f838be) | ![CleanShot 2025-04-24 at 17 42 35@2x](https://github.com/user-attachments/assets/ee571e3e-266a-4198-a55a-b4873541a428) |
| ![CleanShot 2025-04-24 at 17 49 13@2x](https://github.com/user-attachments/assets/3ac08336-e599-43d4-a138-62b3b161bcfe) | ![CleanShot 2025-04-24 at 17 48 42@2x](https://github.com/user-attachments/assets/e189d553-0136-4afb-9066-42d29e76497a) |

Works on Safari iOS, too:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/6891b158-66c3-461d-ae2a-675067822fd7) | ![IMG_6141](https://github.com/user-attachments/assets/dddbe642-0339-4d61-921c-25aabf3d01e4) | 

## Why?
Prettier.

## How was this change made?
Browsers don't make it easy to override these styles so it required [some hacks](https://gist.github.com/evadecker/b947c476f62bd9dbf6b17f1a4aa1a034). Still, it works!

## How was this tested?
Tested fields locally on macOS / Chrome and iOS / Safari.

## Anything else?
Love building for the web. It is consistent and predictable