### PR TITLE
fix: Editor `onUpdate` events

### DIFF
--- a/.changeset/odd-ghosts-repeat.md
+++ b/.changeset/odd-ghosts-repeat.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix quest editor interactions

--- a/src/components/quests/QuestContent/QuestContent.tsx
+++ b/src/components/quests/QuestContent/QuestContent.tsx
@@ -1,5 +1,6 @@
 import { Editor, type EditorProps } from "@/components/common";
 import type { Doc } from "@convex/_generated/dataModel";
+import { useState } from "react";
 
 interface QuestContentProps extends EditorProps {
   quest: Doc<"quests">;
@@ -11,7 +12,16 @@ export function QuestContent({
   editable = false,
   ...props
 }: QuestContentProps) {
+  const [content, setContent] = useState(quest.content);
+
   return (
-    <Editor {...props} initialContent={quest.content} editable={editable} />
+    <Editor
+      {...props}
+      initialContent={content}
+      editable={editable}
+      onUpdate={(props) => {
+        setContent(props.editor.getHTML());
+      }}
+    />
   );
 }


### PR DESCRIPTION
## What changed?
#480 introduced `QuestContent` but did not pass values to `onUpdate`. Fix.