### PR TITLE
fix: Add "save changes" button to `QuestContent` editor

### DIFF
--- a/.changeset/stupid-ants-punch.md
+++ b/.changeset/stupid-ants-punch.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Add save changes button to editor

--- a/convex/quests.ts
+++ b/convex/quests.ts
@@ -187,6 +187,15 @@ export const setTimeRequired = userMutation({
   },
 });
 
+export const setContent = userMutation({
+  args: { questId: v.id("quests"), content: v.string() },
+  handler: async (ctx, args) => {
+    return await Quests.update(ctx, args.questId, ctx.userId, {
+      content: args.content,
+    });
+  },
+});
+
 export const addFaq = userMutation({
   args: { questId: v.id("quests"), question: v.string(), answer: v.string() },
   handler: async (ctx, args) => {

--- a/src/components/quests/QuestContent/QuestContent.tsx
+++ b/src/components/quests/QuestContent/QuestContent.tsx
@@ -1,6 +1,9 @@
-import { Editor, type EditorProps } from "@/components/common";
+import { Button, Editor, type EditorProps, Form } from "@/components/common";
+import { api } from "@convex/_generated/api";
 import type { Doc } from "@convex/_generated/dataModel";
+import { useMutation } from "convex/react";
 import { useState } from "react";
+import { toast } from "sonner";
 
 interface QuestContentProps extends EditorProps {
   quest: Doc<"quests">;
@@ -13,15 +16,49 @@ export function QuestContent({
   ...props
 }: QuestContentProps) {
   const [content, setContent] = useState(quest.content);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const save = useMutation(api.quests.setContent);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!content) return;
+
+    try {
+      setIsSubmitting(true);
+      await save({ questId: quest._id, content });
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Something went wrong.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
-    <Editor
-      {...props}
-      initialContent={content}
-      editable={editable}
-      onUpdate={(props) => {
-        setContent(props.editor.getHTML());
-      }}
-    />
+    <div className="flex flex-col gap-3">
+      <Editor
+        {...props}
+        initialContent={content}
+        editable={editable}
+        onUpdate={(props) => {
+          setContent(props.editor.getHTML());
+        }}
+      />
+      {editable && (
+        <Form className="flex justify-end" onSubmit={handleSubmit}>
+          <Button
+            type="submit"
+            variant="primary"
+            className="ml-auto"
+            isDisabled={content === quest.content}
+            isSubmitting={isSubmitting}
+          >
+            Save Changes
+          </Button>
+        </Form>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## What changed?
Add an explicit button for saving contents of a quest, until we can implement #502.