### PR TITLE
fix: Fix sign in and sign out redirects

### DIFF
--- a/.changeset/six-shrimps-occur.md
+++ b/.changeset/six-shrimps-occur.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix signin and signout redirects

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -99,3 +99,7 @@ export const deleteCurrentUser = userMutation({
     await Users.deleteUser(ctx, { userId: ctx.userId });
   },
 });
+
+export const isSignedIn = query(async (ctx) => {
+  return !!(await getAuthUserId(ctx));
+});

--- a/src/components/settings/DeleteAccountSetting/DeleteAccountSetting.test.tsx
+++ b/src/components/settings/DeleteAccountSetting/DeleteAccountSetting.test.tsx
@@ -1,4 +1,4 @@
-import { useAuthActions } from "@convex-dev/auth/react";
+import { useNavigate } from "@tanstack/react-router";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useMutation } from "convex/react";
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DeleteAccountSetting } from "./DeleteAccountSetting";
 
 describe("DeleteAccountSetting", () => {
-  const mockSignOut = vi.fn();
+  const mockNavigate = vi.fn();
   const mockDeleteAccount = vi.fn();
 
   beforeEach(() => {
@@ -15,9 +15,9 @@ describe("DeleteAccountSetting", () => {
     (useMutation as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
       mockDeleteAccount,
     );
-    (useAuthActions as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      signOut: mockSignOut,
-    });
+    (useNavigate as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockNavigate,
+    );
   });
 
   it("renders the DeleteAccountSetting component", () => {
@@ -69,7 +69,7 @@ describe("DeleteAccountSetting", () => {
 
     await waitFor(() => {
       expect(mockDeleteAccount).toHaveBeenCalled();
-      expect(mockSignOut).toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/signout" });
       expect(toast.success).toHaveBeenCalledWith("Account deleted.");
     });
   });

--- a/src/components/settings/DeleteAccountSetting/DeleteAccountSetting.tsx
+++ b/src/components/settings/DeleteAccountSetting/DeleteAccountSetting.tsx
@@ -8,8 +8,8 @@ import {
   TextField,
 } from "@/components/common";
 import { SettingsItem } from "@/components/settings";
-import { useAuthActions } from "@convex-dev/auth/react";
 import { api } from "@convex/_generated/api";
+import { useNavigate } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
 import { Trash } from "lucide-react";
 import { useState } from "react";
@@ -26,7 +26,7 @@ const DeleteAccountModal = ({
   onOpenChange,
   onSubmit,
 }: DeleteAccountModalProps) => {
-  const { signOut } = useAuthActions();
+  const navigate = useNavigate();
   const [value, setValue] = useState("");
   const [error, setError] = useState<string>();
   const [isDeleting, setIsDeleting] = useState(false);
@@ -49,8 +49,8 @@ const DeleteAccountModal = ({
       setIsDeleting(true);
       await deleteAccount();
       clearLocalStorage();
-      signOut();
       onSubmit();
+      navigate({ to: "/signout" });
       toast.success("Account deleted.");
     } catch (err) {
       setError("Failed to delete account. Please try again.");

--- a/src/components/settings/SettingsNav/SettingsNav.test.tsx
+++ b/src/components/settings/SettingsNav/SettingsNav.test.tsx
@@ -1,7 +1,6 @@
 import { useAuthActions } from "@convex-dev/auth/react";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SettingsNav } from "./SettingsNav";
 
@@ -38,16 +37,6 @@ describe("SettingsNav", () => {
     expect(screen.getByText("Privacy Policy")).toBeInTheDocument();
 
     expect(screen.getByText("Sign out")).toBeInTheDocument();
-  });
-
-  it("handles sign out correctly", async () => {
-    render(<SettingsNav />);
-
-    const signOutButton = screen.getByText("Sign out");
-    await userEvent.click(signOutButton);
-
-    expect(mockSignOut).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith({ to: "/signin" });
   });
 
   it("renders external links with correct attributes", () => {

--- a/src/components/settings/SettingsNav/SettingsNav.tsx
+++ b/src/components/settings/SettingsNav/SettingsNav.tsx
@@ -1,6 +1,4 @@
 import { Nav, NavGroup, NavItem } from "@/components/common";
-import { useAuthActions } from "@convex-dev/auth/react";
-import { useNavigate } from "@tanstack/react-router";
 import {
   Bug,
   CircleUser,
@@ -13,14 +11,6 @@ import {
 } from "lucide-react";
 
 export const SettingsNav = ({ className }: { className?: string }) => {
-  const { signOut } = useAuthActions();
-  const navigate = useNavigate();
-
-  const handleSignOut = async () => {
-    await signOut();
-    navigate({ to: "/signin" });
-  };
-
   return (
     <Nav className={className}>
       <NavGroup>
@@ -90,7 +80,7 @@ export const SettingsNav = ({ className }: { className?: string }) => {
         </NavItem>
       </NavGroup>
       <NavGroup>
-        <NavItem onClick={handleSignOut} icon={LogOut}>
+        <NavItem href={{ to: "/signout" }} icon={LogOut}>
           Sign out
         </NavItem>
       </NavGroup>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,18 +5,13 @@ import { ConvexAuthProvider } from "@convex-dev/auth/react";
 import { api } from "@convex/_generated/api";
 import type { Jurisdiction, Role } from "@convex/constants";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
-import {
-  type ConvexAuthState,
-  ConvexReactClient,
-  useConvexAuth,
-  useQuery,
-} from "convex/react";
+import { ConvexReactClient, useQuery } from "convex/react";
 import { ArrowLeft, TriangleAlert } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
 import { ThemeProvider } from "next-themes";
 import { posthog } from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
-import { StrictMode, useEffect } from "react";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { HelmetProvider } from "react-helmet-async";
 import { routeTree } from "./routeTree.gen";
@@ -54,7 +49,6 @@ export const router = createRouter({
   context: {
     convex: undefined!,
     title: undefined!,
-    auth: undefined!,
     role: undefined!,
     residence: undefined!,
     birthplace: undefined!,
@@ -69,29 +63,17 @@ declare module "@tanstack/react-router" {
   }
 }
 
-let resolveAuth: (client: ConvexAuthState) => void;
-const authClient: Promise<ConvexAuthState> = new Promise((resolve) => {
-  resolveAuth = resolve;
-});
-
 const InnerApp = () => {
   const title = "Namesake";
-  const auth = useConvexAuth();
   const user = useQuery(api.users.getCurrent);
   const role = user?.role as Role;
   const residence = user?.residence as Jurisdiction;
   const birthplace = user?.birthplace as Jurisdiction;
 
-  useEffect(() => {
-    if (auth.isLoading) return;
-
-    resolveAuth(auth);
-  }, [auth, auth.isLoading]);
-
   return (
     <RouterProvider
       router={router}
-      context={{ convex, title, auth: authClient, role, residence, birthplace }}
+      context={{ convex, title, role, residence, birthplace }}
     />
   );
 };

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,7 +7,7 @@ import {
   useLocation,
   useRouter,
 } from "@tanstack/react-router";
-import type { ConvexAuthState, ConvexReactClient } from "convex/react";
+import type { ConvexReactClient } from "convex/react";
 import {
   AlertTriangle,
   Check,
@@ -46,7 +46,6 @@ function PostHogPageView() {
 interface RouterContext {
   convex: ConvexReactClient;
   title: string;
-  auth: Promise<ConvexAuthState>;
   role: Role;
   residence: Jurisdiction;
   birthplace: Jurisdiction;

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -1,14 +1,10 @@
 import { AppMobileNav } from "@/components/app";
 import { useIsMobile } from "@/utils/useIsMobile";
-import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
-import { Authenticated } from "convex/react";
+import { Navigate, Outlet, createFileRoute } from "@tanstack/react-router";
+import { Authenticated, Unauthenticated } from "convex/react";
 import { tv } from "tailwind-variants";
 
 export const Route = createFileRoute("/_authenticated")({
-  beforeLoad: async ({ context }) => {
-    const { isAuthenticated, isLoading } = await context.auth;
-    if (!isLoading && !isAuthenticated) throw redirect({ to: "/signin" });
-  },
   component: AuthenticatedRoute,
 });
 
@@ -25,11 +21,16 @@ function AuthenticatedRoute() {
   });
 
   return (
-    <Authenticated>
-      <main className={styles({ isMobile })}>
-        <Outlet />
-        {isMobile && <AppMobileNav />}
-      </main>
-    </Authenticated>
+    <>
+      <Authenticated>
+        <main className={styles({ isMobile })}>
+          <Outlet />
+          {isMobile && <AppMobileNav />}
+        </main>
+      </Authenticated>
+      <Unauthenticated>
+        <Navigate to="/signin" />
+      </Unauthenticated>
+    </>
   );
 }

--- a/src/routes/_authenticated/signout.tsx
+++ b/src/routes/_authenticated/signout.tsx
@@ -1,14 +1,32 @@
+import { waitFor } from "@/utils/waitFor";
 import { useAuthActions } from "@convex-dev/auth/react";
+import { api } from "@convex/_generated/api";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useQuery } from "convex/react";
+import { usePostHog } from "posthog-js/react";
+import { useRef } from "react";
+import { toast } from "sonner";
 
 export const Route = createFileRoute("/_authenticated/signout")({
   component: RouteComponent,
 });
 
 async function RouteComponent() {
-  const navigate = useNavigate();
   const { signOut } = useAuthActions();
+  const navigate = useNavigate();
+  const postHog = usePostHog();
 
-  await signOut();
-  navigate({ to: "/signin" });
+  const isSignedIn = useQuery(api.users.isSignedIn);
+  const isSignedInRef = useRef(isSignedIn);
+  isSignedInRef.current = isSignedIn;
+
+  try {
+    await signOut();
+    // Wait for user sign out to complete before redirecting
+    await waitFor(() => isSignedInRef.current === false);
+    navigate({ to: "/signin" });
+  } catch (error) {
+    toast.error(`Couldn't sign out. ${error}`);
+    postHog.captureException(error);
+  }
 }

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -19,8 +19,13 @@ import { waitFor } from "@/utils/waitFor";
 import { useAuthActions } from "@convex-dev/auth/react";
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
-import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
-import { useMutation, useQuery } from "convex/react";
+import { Navigate, createFileRoute, useNavigate } from "@tanstack/react-router";
+import {
+  Authenticated,
+  Unauthenticated,
+  useMutation,
+  useQuery,
+} from "convex/react";
 import { ConvexError } from "convex/values";
 import { ChevronLeft } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
@@ -29,10 +34,6 @@ import type { Key } from "react-aria";
 import { toast } from "sonner";
 
 export const Route = createFileRoute("/_unauthenticated/signin")({
-  beforeLoad: async ({ context }) => {
-    const { isAuthenticated, isLoading } = await context.auth;
-    if (!isLoading && isAuthenticated) throw redirect({ to: "/" });
-  },
   component: LoginRoute,
 });
 
@@ -368,20 +369,27 @@ const ForgotPassword = ({
 
 function LoginRoute() {
   return (
-    <div className="flex flex-col w-96 max-w-full mx-auto min-h-dvh items-center justify-center gap-8 p-4">
-      <Link href="https://namesake.fyi">
-        <Logo />
-      </Link>
-      <AnimateChangeInHeight className="w-full">
-        <Card>
-          <SignIn />
-        </Card>
-      </AnimateChangeInHeight>
-      <div className="flex gap-4 justify-center text-sm">
-        <Link href="https://github.com/namesakefyi/namesake/releases">{`v${APP_VERSION}`}</Link>
-        <Link href="https://namesake.fyi/chat">Support</Link>
-        <Link href="https://status.namesake.fyi">Status</Link>
-      </div>
-    </div>
+    <>
+      <Unauthenticated>
+        <div className="flex flex-col w-96 max-w-full mx-auto min-h-dvh items-center justify-center gap-8 p-4">
+          <Link href="https://namesake.fyi">
+            <Logo />
+          </Link>
+          <AnimateChangeInHeight className="w-full">
+            <Card>
+              <SignIn />
+            </Card>
+          </AnimateChangeInHeight>
+          <div className="flex gap-4 justify-center text-sm">
+            <Link href="https://github.com/namesakefyi/namesake/releases">{`v${APP_VERSION}`}</Link>
+            <Link href="https://namesake.fyi/chat">Support</Link>
+            <Link href="https://status.namesake.fyi">Status</Link>
+          </div>
+        </div>
+      </Unauthenticated>
+      <Authenticated>
+        <Navigate to="/" />
+      </Authenticated>
+    </>
   );
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -16,7 +16,7 @@
 }
 
 .sticky-top-header {
-  @apply sticky top-16 lg:top-20;
+  @apply sticky top-16 lg:top-18;
 }
 
 .h-mobile-nav {
@@ -269,10 +269,6 @@ body,
     outline-color: var(--color-purple-a9);
     outline-width: 3px;
   }
-}
-
-.sticky-top-header {
-  @apply sticky top-16 lg:top-20;
 }
 
 .animate-focus-ring-in {

--- a/src/utils/waitFor.test.ts
+++ b/src/utils/waitFor.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { waitFor } from "./waitFor";
+
+describe("waitFor", () => {
+  beforeEach(() => {
+    // Setup fake timers before each test
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // Cleanup after each test
+    vi.restoreAllMocks();
+  });
+
+  it("should resolve immediately when condition is already true", async () => {
+    const condition = vi.fn(() => true);
+    const promise = waitFor(condition);
+
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(condition).toHaveBeenCalledTimes(1);
+  });
+
+  it("should wait until condition becomes true", async () => {
+    let counter = 0;
+    const condition = vi.fn(() => {
+      counter++;
+      return counter >= 3;
+    });
+
+    const promise = waitFor(condition);
+
+    // Run timers multiple times to simulate polling
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(condition).toHaveBeenCalledTimes(3);
+  });
+
+  it("should poll every 10ms until condition is met", async () => {
+    let conditionMet = false;
+    const condition = vi.fn(() => conditionMet);
+
+    const promise = waitFor(condition);
+
+    // Advance timer by 25ms (should call condition 3 times)
+    await vi.advanceTimersByTimeAsync(25);
+    expect(condition).toHaveBeenCalledTimes(3);
+
+    // Make condition true and run remaining timers
+    conditionMet = true;
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(condition).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/utils/waitFor.ts
+++ b/src/utils/waitFor.ts
@@ -1,0 +1,9 @@
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function waitFor(fn: () => boolean) {
+  while (!fn()) {
+    await delay(10);
+  }
+}


### PR DESCRIPTION
## What changed?
Fixes #277 !!!

Adds a Promise which awaits a query call to confirm that a user successfully logged in, then redirects.

## Why?
Previously, signIn() and signOut() were redirecting before Convex had fully authenticated a user, resulting in a failed navigation attempt. This seems like one of the rough edges with Convex Auth right now. Thanks to help from the Convex Discord, we can fix it by adding a Promise which waits for an auth confirmation from the backend before redirecting the user.

## How was this change made?
Created a new `waitFor()` utility function which sets and checks the results of a Promise. Used that to await a successful backend call to Convex before redirecting on sign in or sign out.

Changed previous calls to `signOut()` to instead navigate to a new `/signout` route which handles the above logic.

## How was this tested?
Manually confirms:

- [x] Redirects on sign in
- [x] Redirects on password reset + code confirmation
- [x] Redirects on sign out
- [x] Redirects when attempting to visit `/signin` and already authenticated
- [x] Redirects to `/signin` when attempting to access authenticated routes and not signed in

## Anything else?
<!-- Include WIP notes, follow-ups, or other to-dos -->