### PR TITLE
fix: Add error boundaries and PostHog reporting

### DIFF
--- a/.changeset/rich-parrots-sin.md
+++ b/.changeset/rich-parrots-sin.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Improve error boundary handling and prevent the entire app from crashing if one component fails

--- a/src/components/app/AppContent/AppContent.test.tsx
+++ b/src/components/app/AppContent/AppContent.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AppContent } from "./AppContent";
+
+describe("AppContent", () => {
+  it("renders children correctly", () => {
+    render(
+      <AppContent>
+        <div data-testid="test-child">Test Content</div>
+      </AppContent>,
+    );
+
+    expect(screen.getByTestId("test-child")).toBeInTheDocument();
+    expect(screen.getByText("Test Content")).toBeInTheDocument();
+  });
+
+  it("applies custom className when provided", () => {
+    render(
+      <AppContent className="custom-class">
+        <div>Content</div>
+      </AppContent>,
+    );
+
+    const main = screen.getByRole("main");
+    expect(main).toHaveClass("custom-class");
+  });
+
+  it("renders error fallback when child component throws", () => {
+    vi.spyOn(console, "error").mockImplementation(() => null);
+
+    const ErrorComponent = () => {
+      throw new Error("Test error");
+    };
+
+    render(
+      <AppContent>
+        <ErrorComponent />
+      </AppContent>,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "We’ve been notified of the issue. Refresh the page to try again.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("maintains error boundary around main content", () => {
+    render(
+      <AppContent>
+        <div>Safe Content</div>
+      </AppContent>,
+    );
+
+    const main = screen.getByRole("main");
+    expect(main).toBeInTheDocument();
+
+    const error = screen.queryByText("Something went wrong");
+    expect(error).not.toBeInTheDocument();
+  });
+});

--- a/src/components/app/AppContent/AppContent.tsx
+++ b/src/components/app/AppContent/AppContent.tsx
@@ -1,3 +1,6 @@
+import { Empty } from "@/components/common";
+import { AlertCircle } from "lucide-react";
+import { PostHogErrorBoundary } from "posthog-js/react";
 import { tv } from "tailwind-variants";
 
 type AppContentProps = {
@@ -9,5 +12,20 @@ export const AppContent = ({ children, className }: AppContentProps) => {
   const styles = tv({
     base: "flex-1 w-full max-w-[960px] mx-auto",
   });
-  return <main className={styles({ className })}>{children}</main>;
+
+  const fallback = () => {
+    return (
+      <Empty
+        title="Something went wrong"
+        subtitle="We've been notified of the issue. Refresh the page to try again."
+        icon={AlertCircle}
+      />
+    );
+  };
+
+  return (
+    <PostHogErrorBoundary fallback={fallback}>
+      <main className={styles({ className })}>{children}</main>
+    </PostHogErrorBoundary>
+  );
 };

--- a/src/components/app/AppSidebar/AppSidebar.test.tsx
+++ b/src/components/app/AppSidebar/AppSidebar.test.tsx
@@ -72,4 +72,37 @@ describe("AppSidebar", () => {
     expect(screen.getByText("Main Content")).toBeInTheDocument();
     expect(screen.getByText("Footer Content")).toBeInTheDocument();
   });
+
+  it("renders error fallback when child component throws", () => {
+    vi.spyOn(console, "error").mockImplementation(() => null);
+
+    const ErrorComponent = () => {
+      throw new Error("Test error");
+    };
+
+    render(
+      <AppSidebar>
+        <ErrorComponent />
+      </AppSidebar>,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "We’ve been notified of the issue. Refresh the page to try again.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("maintains error boundary around content", () => {
+    render(
+      <AppSidebar>
+        <div>Safe Content</div>
+      </AppSidebar>,
+    );
+
+    expect(screen.getByText("Safe Content")).toBeInTheDocument();
+    const error = screen.queryByText("Something went wrong");
+    expect(error).not.toBeInTheDocument();
+  });
 });

--- a/src/components/app/AppSidebar/AppSidebar.tsx
+++ b/src/components/app/AppSidebar/AppSidebar.tsx
@@ -1,3 +1,7 @@
+import { Empty } from "@/components/common";
+import { AlertCircle } from "lucide-react";
+import { PostHogErrorBoundary } from "posthog-js/react";
+
 type AppSidebarProps = {
   header?: React.ReactNode;
   children: React.ReactNode;
@@ -5,19 +9,31 @@ type AppSidebarProps = {
 };
 
 export const AppSidebar = ({ header, children, footer }: AppSidebarProps) => {
+  const fallback = () => {
+    return (
+      <Empty
+        title="Something went wrong"
+        icon={AlertCircle}
+        subtitle="We've been notified of the issue. Refresh the page to try again."
+      />
+    );
+  };
+
   return (
     <div className="w-72 lg:w-80 xl:w-[22rem] flex flex-col shrink-0 sticky top-0 h-screen max-h-full align-self-stretch overflow-y-auto bg-sidebar border-r border-gray-a4">
-      {header && (
-        <div className="app-padding h-header flex items-center shrink-0 sticky top-0 bg-sidebar z-20">
-          {header}
-        </div>
-      )}
-      <div className="app-padding flex-1">{children}</div>
-      {footer && (
-        <div className="h-header shrink-0 flex items-center sticky bottom-0 bg-sidebar">
-          {footer}
-        </div>
-      )}
+      <PostHogErrorBoundary fallback={fallback}>
+        {header && (
+          <div className="app-padding h-header flex items-center shrink-0 sticky top-0 bg-sidebar z-20">
+            {header}
+          </div>
+        )}
+        <div className="app-padding flex-1">{children}</div>
+        {footer && (
+          <div className="h-header shrink-0 flex items-center sticky bottom-0 bg-sidebar">
+            {footer}
+          </div>
+        )}
+      </PostHogErrorBoundary>
     </div>
   );
 };

--- a/src/components/common/Empty/Empty.tsx
+++ b/src/components/common/Empty/Empty.tsx
@@ -36,7 +36,7 @@ export function Empty({
         className,
       )}
     >
-      <Icon size={40} className="text-gray-8 shrink-0 stroke-[1.5px]" />
+      <Icon size={40} className="text-gray-9 shrink-0 stroke-2" />
       <Heading className="font-semibold text-xl">{smartquotes(title)}</Heading>
       {subtitle && (
         <p className="text-gray-dim -mt-3 text-center">

--- a/src/components/common/Empty/Empty.tsx
+++ b/src/components/common/Empty/Empty.tsx
@@ -39,7 +39,9 @@ export function Empty({
       <Icon size={40} className="text-gray-8 shrink-0 stroke-[1.5px]" />
       <Heading className="font-semibold text-xl">{smartquotes(title)}</Heading>
       {subtitle && (
-        <p className="text-gray-dim -mt-4">{smartquotes(subtitle)}</p>
+        <p className="text-gray-dim -mt-3 text-center">
+          {smartquotes(subtitle)}
+        </p>
       )}
       <div className="flex gap-2">
         {button && <Button {...button} />}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,11 +6,11 @@ import { api } from "@convex/_generated/api";
 import type { Jurisdiction, Role } from "@convex/constants";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { ConvexReactClient, useQuery } from "convex/react";
-import { ArrowLeft, TriangleAlert } from "lucide-react";
+import { ArrowLeft, CircleAlert, TriangleAlert } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
 import { ThemeProvider } from "next-themes";
 import { posthog } from "posthog-js";
-import { PostHogProvider } from "posthog-js/react";
+import { PostHogErrorBoundary, PostHogProvider } from "posthog-js/react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { HelmetProvider } from "react-helmet-async";
@@ -88,6 +88,15 @@ posthog.init(import.meta.env.VITE_REACT_APP_PUBLIC_POSTHOG_KEY, {
   },
 });
 
+const fallback = () => (
+  <Empty
+    title="Something went wrong"
+    subtitle="We’ve been notified of the issue. Refresh the page to try again."
+    icon={CircleAlert}
+    className="min-h-dvh"
+  />
+);
+
 const rootElement = document.getElementById("root")!;
 if (!rootElement.innerHTML) {
   const root = createRoot(rootElement);
@@ -98,7 +107,9 @@ if (!rootElement.innerHTML) {
           <ConvexAuthProvider client={convex}>
             <ThemeProvider attribute="class" disableTransitionOnChange>
               <LazyMotion strict features={domAnimation}>
-                <InnerApp />
+                <PostHogErrorBoundary fallback={fallback}>
+                  <InnerApp />
+                </PostHogErrorBoundary>
               </LazyMotion>
             </ThemeProvider>
           </ConvexAuthProvider>

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import fs from "node:fs";
 import path from "node:path";
+import { Component, type ReactNode } from "react";
 import { afterEach, beforeEach, vi } from "vitest";
 
 vi.mock("convex/react", () => ({
@@ -42,6 +43,23 @@ vi.mock("posthog-js/react", () => ({
   usePostHog: vi.fn(() => ({
     captureException: vi.fn(),
   })),
+  PostHogErrorBoundary: class ErrorBoundary extends Component<{
+    children: ReactNode;
+    fallback: (props: { error: Error }) => ReactNode;
+  }> {
+    state = { hasError: false, error: null };
+
+    static getDerivedStateFromError(error: Error) {
+      return { hasError: true, error };
+    }
+
+    render() {
+      if (this.state.hasError) {
+        return this.props.fallback({ error: this.state.error! });
+      }
+      return this.props.children;
+    }
+  },
 }));
 
 // Mock encryption functions


### PR DESCRIPTION
## What changed?
Fixes #116. Add error boundaries around `AppSidebar` and `AppContent` and report any errors to PostHog.

## Why?
Prevent the entire app from crashing if something goes wrong. Display a more appealing looking error.

## How was this change made?
Added `PostHogErrorBoundary` to the two primary components used within the app.

## How was this tested?
Wrote new tests, inserted a dummy component which errors in order to force state.