### PR TITLE
fix: Update title with jurisdiction badge, tweak typography

### DIFF
--- a/.changeset/ripe-doors-follow.md
+++ b/.changeset/ripe-doors-follow.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix display of form titles and include jurisdiction badge alongside name

--- a/src/components/common/Banner/Banner.tsx
+++ b/src/components/common/Banner/Banner.tsx
@@ -12,6 +12,7 @@ export interface BannerProps {
   icon?: LucideIcon;
   variant?: "info" | "success" | "danger" | "warning";
   size?: "medium" | "large";
+  className?: string;
 }
 
 const bannerStyles = tv({
@@ -54,7 +55,13 @@ const iconStyles = tv({
   },
 });
 
-export function Banner({ children, icon: Icon, size, variant }: BannerProps) {
+export function Banner({
+  children,
+  icon: Icon,
+  size,
+  variant,
+  className,
+}: BannerProps) {
   const DefaultIcon = () => {
     switch (variant) {
       case "success":
@@ -71,7 +78,7 @@ export function Banner({ children, icon: Icon, size, variant }: BannerProps) {
   Icon = Icon ?? DefaultIcon();
 
   return (
-    <div role="alert" className={bannerStyles({ variant, size })}>
+    <div role="alert" className={bannerStyles({ variant, size, className })}>
       <Icon className={iconStyles({ variant, size })} />
       <div className="[&>_a]:underline">{children}</div>
     </div>

--- a/src/components/forms/FormContainer/FormContainer.tsx
+++ b/src/components/forms/FormContainer/FormContainer.tsx
@@ -1,5 +1,6 @@
-import { Banner, Container, Form } from "@/components/common";
+import { Badge, Banner, Container, Form } from "@/components/common";
 import { FormNavigation, FormSection } from "@/components/forms";
+import { JURISDICTIONS, type Jurisdiction } from "@/constants";
 import {
   FormSectionContext,
   type FormSectionData,
@@ -17,6 +18,9 @@ export interface FormContainerProps {
 
   /** An optional description to provide more context. */
   description?: string;
+
+  /** The jurisdiction (state) for the form. */
+  jurisdiction?: Jurisdiction;
 
   /** The contents of the page. */
   children?: React.ReactNode;
@@ -38,6 +42,7 @@ interface FormSectionProps {
 export function FormContainer({
   title,
   description,
+  jurisdiction,
   children,
   form,
   onSubmit,
@@ -60,14 +65,17 @@ export function FormContainer({
   return (
     <FormProvider {...form}>
       <FormSectionContext value={{ sections }}>
-        <FormNavigation title={title} />
+        <FormNavigation title={title} jurisdiction={jurisdiction} />
         <Container className="w-full max-w-[720px] flex-1 py-16 px-6">
           <Form
             onSubmit={onSubmit}
             autoComplete="on"
             className="gap-0 divide-y divide-gray-a3"
           >
-            <header className="flex flex-col gap-6 mb-8">
+            <header className="flex flex-col gap-1 mb-8">
+              {jurisdiction && (
+                <Badge size="lg">{JURISDICTIONS[jurisdiction]}</Badge>
+              )}
               <Heading className="text-4xl lg:text-5xl font-medium text-pretty">
                 {title}
               </Heading>
@@ -76,7 +84,12 @@ export function FormContainer({
                   {smartquotes(description)}
                 </p>
               )}
-              <Banner variant="success" icon={ShieldCheck} size="large">
+              <Banner
+                variant="success"
+                icon={ShieldCheck}
+                size="large"
+                className="mt-6"
+              >
                 Namesake takes your privacy seriously. All responses are
                 end-to-end encrypted. That means no one—not even Namesake—can
                 see your answers.

--- a/src/components/forms/FormNavigation/FormNavigation.tsx
+++ b/src/components/forms/FormNavigation/FormNavigation.tsx
@@ -1,4 +1,5 @@
 import {
+  Badge,
   Button,
   Link,
   Menu,
@@ -8,6 +9,7 @@ import {
   Tooltip,
   TooltipTrigger,
 } from "@/components/common";
+import type { Jurisdiction } from "@/constants";
 import { useFormSections } from "@/hooks/useFormSections";
 import { ArrowLeft, MenuIcon } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -16,9 +18,10 @@ import { useFormContext } from "react-hook-form";
 
 interface FormNavigationProps {
   title: string;
+  jurisdiction?: Jurisdiction;
 }
 
-export function FormNavigation({ title }: FormNavigationProps) {
+export function FormNavigation({ title, jurisdiction }: FormNavigationProps) {
   const { sections } = useFormSections();
   const [progress, setProgress] = useState(0);
   const { getValues, watch } = useFormContext();
@@ -43,7 +46,10 @@ export function FormNavigation({ title }: FormNavigationProps) {
         <Link button={{ variant: "icon" }} href={{ to: "/" }} aria-label="Back">
           <ArrowLeft className="size-5" />
         </Link>
-        <Heading className="text-xl truncate min-w-0 flex-1">{title}</Heading>
+        <Heading className="text-xl lg:text-2xl font-medium truncate min-w-0 flex-1">
+          {title}
+        </Heading>
+        {jurisdiction && <Badge>{jurisdiction}</Badge>}
       </div>
       <div className="flex gap-1 items-center">
         <ProgressBar

--- a/src/routes/_authenticated/documents/index.tsx
+++ b/src/routes/_authenticated/documents/index.tsx
@@ -24,12 +24,14 @@ function DocumentsIndexRoute() {
 
   if (pdfIds && pdfIds.length === 0) {
     return (
-      <Empty
-        title="No documents"
-        icon={FileText}
-        subtitle="See your completed documents here after filling out forms."
-        className="h-full"
-      />
+      <AppContent>
+        <Empty
+          title="No documents"
+          icon={FileText}
+          subtitle="Your documents will appear here after filling out forms."
+          className="h-full"
+        />
+      </AppContent>
     );
   }
 

--- a/src/routes/_authenticated/forms/ma-court-order.tsx
+++ b/src/routes/_authenticated/forms/ma-court-order.tsx
@@ -122,7 +122,8 @@ function RouteComponent() {
 
   return (
     <FormContainer
-      title="Massachusetts Court Order"
+      title="Court Order: Adult Name Change"
+      jurisdiction="MA"
       form={form}
       onSubmit={handleSubmit}
     >


### PR DESCRIPTION
## What changed?
Some small typography tweaks.

- Display the jurisdiction badge within the `FormContainer` and `FormNavigation`
- Center document empty state within the view

![CleanShot 2025-04-28 at 18 14 18@2x](https://github.com/user-attachments/assets/73f15851-4c96-4f26-9f4a-dfd1b244fc6e)