### PR TITLE
feat: Display optional costs in cost breakdown

### DIFF
--- a/.changeset/funny-views-rest.md
+++ b/.changeset/funny-views-rest.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix cost and time tooltips not displaying on mobile devices

--- a/.changeset/tasty-ties-move.md
+++ b/.changeset/tasty-ties-move.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Display optional costs within cost breakdown

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -5,6 +5,16 @@ import type { DataModel } from "./_generated/dataModel.js";
 export const migrations = new Migrations<DataModel>(components.migrations);
 export const run = migrations.runner();
 
+// Backfill `isRequired` as true for all quests
+export const setQuestCostsRequired = migrations.define({
+  table: "quests",
+  migrateOne: async (ctx, quest) => {
+    await ctx.db.patch(quest._id, {
+      costs: quest.costs?.map((c) => ({ ...c, isRequired: true })),
+    });
+  },
+});
+
 // Set the updatedAt timestamp for quests where it is undefined.
 export const setQuestsUpdatedTimestamp = migrations.define({
   table: "quests",

--- a/convex/model/questsModel.ts
+++ b/convex/model/questsModel.ts
@@ -183,7 +183,7 @@ export async function setCosts(
   }: {
     questId: Id<"quests">;
     userId: Id<"users">;
-    costs?: Array<{ cost: number; description: string }>;
+    costs?: Array<{ cost: number; description: string; isRequired?: boolean }>;
   },
 ) {
   return await update(ctx, questId, userId, { costs });

--- a/convex/quests.ts
+++ b/convex/quests.ts
@@ -154,7 +154,13 @@ export const setCosts = userMutation({
   args: {
     questId: v.id("quests"),
     costs: v.optional(
-      v.array(v.object({ cost: v.number(), description: v.string() })),
+      v.array(
+        v.object({
+          cost: v.number(),
+          description: v.string(),
+          isRequired: v.optional(v.boolean()),
+        }),
+      ),
     ),
   },
   handler: async (ctx, args) => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -37,6 +37,7 @@ const quests = defineTable({
       v.object({
         cost: v.number(),
         description: v.string(),
+        isRequired: v.optional(v.boolean()),
       }),
     ),
   ),

--- a/src/components/quests/QuestCostsBadge/QuestCostsBadge.tsx
+++ b/src/components/quests/QuestCostsBadge/QuestCostsBadge.tsx
@@ -8,6 +8,8 @@ import {
   Popover,
   Switch,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Tooltip,
   TooltipTrigger,
 } from "@/components/common";
@@ -15,7 +17,7 @@ import type { Cost } from "@/constants";
 import { api } from "@convex/_generated/api";
 import type { Doc } from "@convex/_generated/dataModel";
 import { useMutation } from "convex/react";
-import { HelpCircle, Pencil } from "lucide-react";
+import { CircleDollarSign, CircleOff, HelpCircle, Pencil } from "lucide-react";
 import { Plus, Trash } from "lucide-react";
 import { memo, useState } from "react";
 import { Fragment } from "react/jsx-runtime";
@@ -40,7 +42,10 @@ const CostInput = memo(function CostInput({
         prefix="$"
         value={cost.cost}
         onChange={(value) =>
-          onChange({ cost: value, description: cost.description })
+          onChange({
+            ...cost,
+            cost: value,
+          })
         }
         minValue={0}
         maxValue={2000}
@@ -51,17 +56,53 @@ const CostInput = memo(function CostInput({
         className="flex-1 min-w-0"
         placeholder="Description"
         value={cost.description}
-        onChange={(value) => onChange({ cost: cost.cost, description: value })}
+        onChange={(value) =>
+          onChange({
+            ...cost,
+            description: value,
+          })
+        }
         isRequired
         maxLength={32}
       />
-      <Button
-        type="button"
-        variant="secondary"
-        onPress={() => onRemove(cost)}
-        icon={Trash}
-        aria-label="Remove"
-      />
+      <ToggleButtonGroup
+        selectionMode="single"
+        disallowEmptySelection
+        selectedKeys={cost.isRequired ? ["required"] : ["optional"]}
+        onSelectionChange={(keys) =>
+          onChange({
+            ...cost,
+            isRequired: keys.has("required"),
+          })
+        }
+      >
+        <TooltipTrigger>
+          <ToggleButton
+            id="required"
+            icon={CircleDollarSign}
+            aria-label="Required cost"
+          />
+          <Tooltip>Required cost</Tooltip>
+        </TooltipTrigger>
+        <TooltipTrigger>
+          <ToggleButton
+            id="optional"
+            icon={CircleOff}
+            aria-label="Optional cost"
+          />
+          <Tooltip>Optional cost</Tooltip>
+        </TooltipTrigger>
+      </ToggleButtonGroup>
+      <TooltipTrigger>
+        <Button
+          type="button"
+          variant="secondary"
+          onPress={() => onRemove(cost)}
+          icon={Trash}
+          aria-label="Remove"
+        />
+        <Tooltip>Remove cost</Tooltip>
+      </TooltipTrigger>
     </div>
   );
 });
@@ -107,27 +148,49 @@ export const QuestCostsBadge = ({
   const getTotalCosts = (costs?: Cost[]) => {
     if (!costs || costs.length === 0) return "Free";
 
-    const total = costs.reduce((acc, cost) => acc + cost.cost, 0);
-    return total > 0
-      ? total.toLocaleString("en-US", {
-          style: "currency",
-          currency: "USD",
-          maximumFractionDigits: 0,
-        })
-      : "Free";
+    const formatCurrency = (amount: number) =>
+      amount.toLocaleString("en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 0,
+      });
+
+    const requiredTotal = costs
+      .filter((cost) => cost.isRequired !== false)
+      .reduce((acc, cost) => acc + cost.cost, 0);
+
+    const totalWithOptional = costs.reduce((acc, cost) => acc + cost.cost, 0);
+
+    if (requiredTotal === 0) {
+      return "Free";
+    }
+
+    if (requiredTotal === totalWithOptional) {
+      return formatCurrency(requiredTotal);
+    }
+
+    return `${formatCurrency(requiredTotal)}–${formatCurrency(totalWithOptional)}`;
   };
 
   return (
     <Badge size="lg">
       {getTotalCosts(costs)}
       {costs && costs.length > 0 && (
-        <TooltipTrigger>
-          <BadgeButton label="Cost details" icon={HelpCircle} />
-          <Tooltip placement="bottom">
-            <dl className="grid grid-cols-[1fr_auto] py-1">
-              {costs.map(({ cost, description }) => (
+        <DialogTrigger>
+          <TooltipTrigger>
+            <BadgeButton label="Cost details" icon={HelpCircle} />
+            <Tooltip>See cost details</Tooltip>
+          </TooltipTrigger>
+          <Popover placement="bottom" className="py-3 px-3.5">
+            <dl className="grid grid-cols-[1fr_auto]">
+              {costs.map(({ cost, description, isRequired }) => (
                 <Fragment key={description}>
-                  <dt className="pr-4">{description}</dt>
+                  <dt className="pr-4">
+                    {description}
+                    {!isRequired && (
+                      <span className="text-gray-dim italic"> optional</span>
+                    )}
+                  </dt>
                   <dd className="text-right tabular-nums">
                     {cost.toLocaleString("en-US", {
                       style: "currency",
@@ -142,8 +205,8 @@ export const QuestCostsBadge = ({
                 {getTotalCosts(costs)}
               </dd>
             </dl>
-          </Tooltip>
-        </TooltipTrigger>
+          </Popover>
+        </DialogTrigger>
       )}
       {editable && (
         <DialogTrigger>
@@ -155,7 +218,7 @@ export const QuestCostsBadge = ({
             />
             <Tooltip>Edit costs</Tooltip>
           </TooltipTrigger>
-          <Popover isOpen={isEditing} className="p-4 w-80">
+          <Popover isOpen={isEditing} className="p-4 w-full max-w-md">
             <Form onSubmit={handleSubmit} className="w-full">
               {costsInput && (
                 <div className="flex flex-col gap-2 w-full">
@@ -179,7 +242,7 @@ export const QuestCostsBadge = ({
                     onPress={() =>
                       setCostsInput([
                         ...(costsInput ?? []),
-                        { cost: 0, description: "" },
+                        { cost: 0, description: "", isRequired: true },
                       ])
                     }
                     icon={Plus}
@@ -193,7 +256,9 @@ export const QuestCostsBadge = ({
                   isSelected={!costsInput}
                   onChange={(isSelected) =>
                     setCostsInput(
-                      isSelected ? null : [{ cost: 0, description: "" }],
+                      isSelected
+                        ? null
+                        : [{ cost: 0, description: "", isRequired: true }],
                     )
                   }
                   className="justify-self-start mr-auto"

--- a/src/components/quests/QuestTimeBadge/QuestTimeBadge.tsx
+++ b/src/components/quests/QuestTimeBadge/QuestTimeBadge.tsx
@@ -150,12 +150,15 @@ export const QuestTimeBadge = ({
     <Badge size="lg">
       {formattedTime}
       {timeRequired?.description && (
-        <TooltipTrigger>
-          <BadgeButton label="Details" icon={HelpCircle} />
-          <Tooltip placement="bottom">
+        <DialogTrigger>
+          <TooltipTrigger>
+            <BadgeButton label="Details" icon={HelpCircle} />
+            <Tooltip>See details</Tooltip>
+          </TooltipTrigger>
+          <Popover placement="bottom" className="p-3">
             <p className="text-sm max-w-xs">{timeRequired.description}</p>
-          </Tooltip>
-        </TooltipTrigger>
+          </Popover>
+        </DialogTrigger>
       )}
       {editable && (
         <DialogTrigger>

--- a/src/constants/quests.ts
+++ b/src/constants/quests.ts
@@ -206,6 +206,7 @@ export const STATUS_ORDER: Status[] = Object.keys(STATUS) as Status[];
 export type Cost = {
   cost: number;
   description: string;
+  isRequired?: boolean;
 };
 
 /**


### PR DESCRIPTION
## What changed?
Based on feedback from Luke, adds an `isRequired` field to the schema for `costs` on a quest. Allows toggling between required (default) and optional costs when editing a quest, and splits out required costs from optional costs to display a range of potential costs.

![CleanShot 2025-04-30 at 21 15 48@2x](https://github.com/user-attachments/assets/e456b28c-0b1f-4387-9776-d3307af08df7)
![CleanShot 2025-04-30 at 21 16 02@2x](https://github.com/user-attachments/assets/036ab0dc-f9be-4bb7-85fb-bc5c4f02834a)

## Why?
Help clarify the cost of updating documents while allowing inserting other recommended costs (like for extra certified copies).

## How was this change made?
- Added `isRequired` to the `costs` column in the `quests` table
- Updated models and mutations
- Updated UI with a new toggle for required/optional
- Updated cost breakdown to split out the optional costs from required costs and display as a range

## How was this tested?
Updated unit tests.

## Anything else?
Moved the existing `Tooltip` used to display the cost breakdown and time description into a `Popover`. Resolves #528 