### PR TITLE
fix: Disclosures and steps alignment

### DIFF
--- a/.changeset/metal-cases-warn.md
+++ b/.changeset/metal-cases-warn.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix alignment of disclosures and keep disclosues closed by default when viewing quests

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@faker-js/faker": "^9.7.0",
     "@maskito/core": "^3.7.2",
     "@maskito/react": "^3.7.2",
-    "@namesake/tiptap-extensions": "^1.0.0",
+    "@namesake/tiptap-extensions": "^2.0.1",
     "@radix-ui/colors": "^3.0.0",
     "@tailwindcss/vite": "^4.1.4",
     "@tanstack/react-router": "^1.117.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^3.7.2
         version: 3.7.2(@maskito/core@3.7.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@namesake/tiptap-extensions':
-        specifier: ^1.0.0
-        version: 1.0.0(@tiptap/core@2.11.7(@tiptap/pm@2.11.7))
+        specifier: ^2.0.1
+        version: 2.0.1(@tiptap/core@2.11.7(@tiptap/pm@2.11.7))
       '@radix-ui/colors':
         specifier: ^3.0.0
         version: 3.0.0
@@ -1394,8 +1394,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@namesake/tiptap-extensions@1.0.0':
-    resolution: {integrity: sha512-g+3AoXaNPHHzQi/55A+RjjIqxmtXsmCU+W8qep0ccS15BW1W1eCZQSMDUHWJcL4n6D9dhhZFOAMOah1W2jnsEg==}
+  '@namesake/tiptap-extensions@2.0.1':
+    resolution: {integrity: sha512-zswlycxeDuSsl9K317jed+SOf1kqV7vqOMbKpKwr6uMd1Iyg/mZyMnrrwovEjhhFMMV9QWlIhWClqSOkuLu/WQ==}
     peerDependencies:
       '@tiptap/core': ^2.11.9
 
@@ -6517,7 +6517,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@namesake/tiptap-extensions@1.0.0(@tiptap/core@2.11.7(@tiptap/pm@2.11.7))':
+  '@namesake/tiptap-extensions@2.0.1(@tiptap/core@2.11.7(@tiptap/pm@2.11.7))':
     dependencies:
       '@tiptap/core': 2.11.7(@tiptap/pm@2.11.7)
 

--- a/src/components/common/Editor/extensions/constants.ts
+++ b/src/components/common/Editor/extensions/constants.ts
@@ -1,13 +1,4 @@
-import {
-  Disclosure,
-  DisclosureContent,
-  DisclosureTitle,
-  Disclosures,
-  StepContent,
-  StepItem,
-  StepTitle,
-  Steps,
-} from "@namesake/tiptap-extensions";
+import { DisclosuresKit, StepsKit } from "@namesake/tiptap-extensions";
 import type { Extensions } from "@tiptap/core";
 import Blockquote from "@tiptap/extension-blockquote";
 import Bold from "@tiptap/extension-bold";
@@ -85,15 +76,5 @@ export const EXTENSION_GROUPS: Record<ExtensionGroup, Extensions> = {
     ListItem,
     OrderedList,
   ],
-  advanced: [
-    Steps,
-    StepItem,
-    StepTitle,
-    StepContent,
-    Disclosure,
-    Disclosures,
-    DisclosureTitle,
-    DisclosureContent,
-    Button,
-  ],
+  advanced: [StepsKit, DisclosuresKit, Button],
 };

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -74,7 +74,7 @@
 
   ol[data-type="steps"]:not(:where(.not-prose *)) {
     counter-reset: steps;
-    @apply flex flex-col;
+    @apply flex flex-col -ml-1;
 
     &:not(:first-child) {
       @apply mt-6;
@@ -88,6 +88,10 @@
     counter-increment: steps;
     position: relative;
     padding-inline-start: calc(var(--step-number-size) + var(--step-number-gap));
+
+    @media (width < 800px) {
+      --step-number-gap: 8px;
+    }
     
     &::before {
       all: unset;
@@ -101,6 +105,7 @@
       position: absolute;
       left: 0;
       top: 0;
+      font-size: 1.1em;
       content: counter(steps);
       @apply bg-gray-a4;
     }
@@ -149,7 +154,7 @@
   }
 
   details {
-    --indent: calc(var(--spacing) * 4);
+    --indent: 1.5em;
   }
 
   details[open] + details {
@@ -158,7 +163,7 @@
 
   summary {
     --summary-inline-padding: 0.3em;
-    @apply rounded-md font-medium relative list-none;
+    @apply rounded-md font-semibold relative list-none;
     inline-size: fit-content;
     padding-inline: calc(var(--indent) + var(--summary-inline-padding)) calc(var(--summary-inline-padding) * 1.5);
     margin-inline: calc(var(--summary-inline-padding) * -1);
@@ -176,6 +181,7 @@
     scale: 0.65;
     transition: rotate 0.15s ease-out;
     opacity: 0.5;
+    margin-inline-start: 0.05em;
   }
 
   details[open] summary:before {


### PR DESCRIPTION
## What changed?
Fixes #541. Aligns step titles with page title. Aligns disclosure titles with lists. Updates disclosures extension package to ensure that disclosures are closed by default when not editing.

![CleanShot 2025-05-03 at 19 58 48@2x](https://github.com/user-attachments/assets/098414b8-a354-45a7-81f3-eedbf390e893)
![CleanShot 2025-05-03 at 20 01 11@2x](https://github.com/user-attachments/assets/cd977146-b804-4f7f-a194-73ec506b0eb9)

## Why?
Design polish.

## How was this change made?
Updated package. Modified CSS.

## How was this tested?
Manual visual testing.

## Anything else?
Should follow-up with making the editor toolbar sticky.