### PR TITLE
chore: Update workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,6 +49,8 @@ jobs:
   test:
     name: Unit Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -7,5 +7,7 @@ on:
 jobs:
   congrats:
     uses: namesakefyi/congratsbot/.github/workflows/congratsbot.yml@main
+    permissions:
+      contents: read
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}


### PR DESCRIPTION
## What changed?
Update workflow permissions to the minimum necessary.

## Why?
Fix security issues in the repo. 