### PR TITLE
fix: Prevent `RouterProvider` from appending link to self

### DIFF
--- a/.changeset/eighty-icons-drive.md
+++ b/.changeset/eighty-icons-drive.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix router provider appending link to self

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -68,9 +68,7 @@ function RootRoute() {
             : { ...path, ...options },
         )
       }
-      useHref={(path) =>
-        typeof path === "string" ? path : router.buildLocation(path).href
-      }
+      useHref={(path) => router.buildLocation(path).href}
     >
       <Outlet />
       <PostHogPageView />


### PR DESCRIPTION
## What changed?
Followup to #567.

## Why?
We should always use `router.buildLocation()` to prevent links from being appended to themselves.

## How was this change made?
Remove `useHref` check for `typeof string`.