### PR TITLE
fix: Update link logic to remove `useHref` and pre-populate internal links

### DIFF
--- a/.changeset/fluffy-teams-dress.md
+++ b/.changeset/fluffy-teams-dress.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix links from quests to forms

--- a/.changeset/fluffy-teams-dress.md
+++ b/.changeset/fluffy-teams-dress.md
@@ -2,4 +2,4 @@
 "namesake": patch
 ---
 
-Fix links from quests to forms
+Fix links from quests to forms and make it easier to select internal links

--- a/src/components/common/Editor/extensions/ButtonComponent.test.tsx
+++ b/src/components/common/Editor/extensions/ButtonComponent.test.tsx
@@ -4,7 +4,6 @@ import type { NodeViewProps } from "@tiptap/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ButtonComponent from "./ButtonComponent";
 
-// Mock the NodeViewContent component
 vi.mock("@tiptap/react", () => ({
   NodeViewWrapper: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="node-view-wrapper">{children}</div>
@@ -12,7 +11,6 @@ vi.mock("@tiptap/react", () => ({
   NodeViewContent: () => <span data-testid="button-content">Button Text</span>,
 }));
 
-// Mock the router
 vi.mock("@tanstack/react-router", () => ({
   useRouter: () => ({
     routesByPath: {
@@ -88,7 +86,7 @@ describe("ButtonComponent", () => {
     expect(screen.getByRole("textbox", { name: "URL" })).toBeInTheDocument();
   });
 
-  it("opens popover with Namesake tab selected when URL is a form path", async () => {
+  it("opens popover with Internal tab selected when URL is a form path", async () => {
     const props = {
       ...baseMockProps,
       node: {
@@ -102,7 +100,7 @@ describe("ButtonComponent", () => {
     await userEvent.click(button);
 
     expect(screen.getByRole("tab", { selected: true })).toHaveTextContent(
-      "Namesake",
+      "Internal",
     );
     const select = screen.getByRole("button", { name: /Select path/i });
     expect(select).toBeInTheDocument();
@@ -114,13 +112,11 @@ describe("ButtonComponent", () => {
     const button = screen.getByRole("button");
     await userEvent.click(button);
 
-    // Switch to Namesake tab
-    await userEvent.click(screen.getByRole("tab", { name: "Namesake" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Internal" }));
     expect(
       screen.getByRole("button", { name: /Select path/i }),
     ).toBeInTheDocument();
 
-    // Switch back to External tab
     await userEvent.click(screen.getByRole("tab", { name: "External" }));
     expect(screen.getByRole("textbox", { name: "URL" })).toBeInTheDocument();
   });
@@ -185,10 +181,8 @@ describe("ButtonComponent", () => {
     const button = screen.getByRole("button");
     await userEvent.click(button);
 
-    // Switch to Namesake tab
-    await userEvent.click(screen.getByRole("tab", { name: "Namesake" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Internal" }));
 
-    // Select a form path
     const select = screen.getByRole("button", { name: /Select path/i });
     await userEvent.click(select);
     await userEvent.keyboard("{arrowdown}");

--- a/src/components/common/Editor/extensions/ButtonComponent.test.tsx
+++ b/src/components/common/Editor/extensions/ButtonComponent.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { NodeViewProps } from "@tiptap/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import ButtonComponent from "./ButtonComponent";
 
 // Mock the NodeViewContent component
@@ -10,6 +10,16 @@ vi.mock("@tiptap/react", () => ({
     <div data-testid="node-view-wrapper">{children}</div>
   ),
   NodeViewContent: () => <span data-testid="button-content">Button Text</span>,
+}));
+
+// Mock the router
+vi.mock("@tanstack/react-router", () => ({
+  useRouter: () => ({
+    routesByPath: {
+      "/forms/social-security": {},
+      "/forms/ma-court-order": {},
+    },
+  }),
 }));
 
 describe("ButtonComponent", () => {
@@ -41,6 +51,10 @@ describe("ButtonComponent", () => {
     HTMLAttributes: {},
   };
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders button with URL in editable mode", () => {
     render(<ButtonComponent {...baseMockProps} />);
 
@@ -59,21 +73,59 @@ describe("ButtonComponent", () => {
     };
     render(<ButtonComponent {...props} />);
 
-    expect(screen.getByText("No URL")).toBeInTheDocument();
+    expect(screen.getByText("No link")).toBeInTheDocument();
   });
 
-  it("opens popover when clicking the button in editable mode", async () => {
+  it("opens popover with external URL tab selected by default", async () => {
     render(<ButtonComponent {...baseMockProps} />);
 
     const button = screen.getByRole("button");
     await userEvent.click(button);
 
-    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { selected: true })).toHaveTextContent(
+      "External",
+    );
     expect(screen.getByRole("textbox", { name: "URL" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
   });
 
-  it("updates URL when submitting the form", async () => {
+  it("opens popover with Namesake tab selected when URL is a form path", async () => {
+    const props = {
+      ...baseMockProps,
+      node: {
+        ...baseMockProps.node,
+        attrs: { href: "/forms/social-security" },
+      } as any,
+    };
+    render(<ButtonComponent {...props} />);
+
+    const button = screen.getByRole("button");
+    await userEvent.click(button);
+
+    expect(screen.getByRole("tab", { selected: true })).toHaveTextContent(
+      "Namesake",
+    );
+    const select = screen.getByRole("button", { name: /Select path/i });
+    expect(select).toBeInTheDocument();
+  });
+
+  it("allows switching between tabs", async () => {
+    render(<ButtonComponent {...baseMockProps} />);
+
+    const button = screen.getByRole("button");
+    await userEvent.click(button);
+
+    // Switch to Namesake tab
+    await userEvent.click(screen.getByRole("tab", { name: "Namesake" }));
+    expect(
+      screen.getByRole("button", { name: /Select path/i }),
+    ).toBeInTheDocument();
+
+    // Switch back to External tab
+    await userEvent.click(screen.getByRole("tab", { name: "External" }));
+    expect(screen.getByRole("textbox", { name: "URL" })).toBeInTheDocument();
+  });
+
+  it("updates external URL when submitting the form", async () => {
     const mockRun = vi.fn();
     const props = {
       ...baseMockProps,
@@ -81,8 +133,8 @@ describe("ButtonComponent", () => {
         ...baseMockProps.editor,
         chain: () => ({
           focus: () => ({
-            updateAttributes: () => ({
-              run: mockRun,
+            updateAttributes: (_type: string, attrs: { href: string }) => ({
+              run: () => mockRun(attrs),
             }),
           }),
         }),
@@ -98,13 +150,54 @@ describe("ButtonComponent", () => {
     const button = screen.getByRole("button");
     await userEvent.click(button);
 
-    const input = screen.getByRole("textbox");
+    const input = screen.getByRole("textbox", { name: "URL" });
+    await userEvent.clear(input);
     await userEvent.type(input, "https://newurl.com");
 
     const submitButton = screen.getByRole("button", { name: "Apply" });
     await userEvent.click(submitButton);
 
-    expect(mockRun).toHaveBeenCalled();
+    expect(mockRun).toHaveBeenCalledWith({ href: "https://newurl.com" });
+  });
+
+  it("updates form path when submitting the form", async () => {
+    const mockRun = vi.fn();
+    const props = {
+      ...baseMockProps,
+      editor: {
+        ...baseMockProps.editor,
+        chain: () => ({
+          focus: () => ({
+            updateAttributes: (_type: string, attrs: { href: string }) => ({
+              run: () => mockRun(attrs),
+            }),
+          }),
+        }),
+      } as any,
+      node: {
+        ...baseMockProps.node,
+        attrs: { href: "" },
+      } as any,
+    };
+
+    render(<ButtonComponent {...props} />);
+
+    const button = screen.getByRole("button");
+    await userEvent.click(button);
+
+    // Switch to Namesake tab
+    await userEvent.click(screen.getByRole("tab", { name: "Namesake" }));
+
+    // Select a form path
+    const select = screen.getByRole("button", { name: /Select path/i });
+    await userEvent.click(select);
+    await userEvent.keyboard("{arrowdown}");
+    await userEvent.keyboard("{enter}");
+
+    const submitButton = screen.getByRole("button", { name: "Apply" });
+    await userEvent.click(submitButton);
+
+    expect(mockRun).toHaveBeenCalledWith({ href: "/forms/social-security" });
   });
 
   it("renders as plain link in non-editable mode", () => {
@@ -133,7 +226,7 @@ describe("ButtonComponent", () => {
     });
   });
 
-  it("shows 'Click to add URL' tooltip when URL is empty", async () => {
+  it("shows 'Click to add link' tooltip when URL is empty", async () => {
     const props = {
       ...baseMockProps,
       node: {
@@ -147,7 +240,7 @@ describe("ButtonComponent", () => {
     await userEvent.hover(button);
 
     await waitFor(() => {
-      expect(screen.getByText("Click to add URL")).toBeInTheDocument();
+      expect(screen.getByText("Click to add link")).toBeInTheDocument();
     });
   });
 });

--- a/src/components/common/Editor/extensions/ButtonComponent.tsx
+++ b/src/components/common/Editor/extensions/ButtonComponent.tsx
@@ -24,7 +24,7 @@ import { LinkIcon, Unlink } from "lucide-react";
 import { useRef, useState } from "react";
 import { useInteractOutside } from "react-aria";
 
-type LinkType = "namesake" | "external";
+type LinkType = "internal" | "external";
 
 export default function ButtonComponent({ editor, node }: NodeViewProps) {
   const { routesByPath } = useRouter();
@@ -40,7 +40,7 @@ export default function ButtonComponent({ editor, node }: NodeViewProps) {
   );
   const [isOpen, setIsOpen] = useState(false);
   const [selectedTab, setSelectedTab] = useState<LinkType>(
-    node.attrs.href?.startsWith("/forms/") ? "namesake" : "external",
+    node.attrs.href?.startsWith("/forms/") ? "internal" : "external",
   );
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -53,7 +53,7 @@ export default function ButtonComponent({ editor, node }: NodeViewProps) {
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const href = selectedTab === "namesake" ? form : url;
+    const href = selectedTab === "internal" ? form : url;
     editor.chain().focus().updateAttributes("button", { href }).run();
     setIsOpen(false);
   };
@@ -78,7 +78,7 @@ export default function ButtonComponent({ editor, node }: NodeViewProps) {
     ) {
       return url;
     }
-    if (selectedTab === "namesake" && form) {
+    if (selectedTab === "internal" && form) {
       return form;
     }
     return "Click to add link";
@@ -125,11 +125,11 @@ export default function ButtonComponent({ editor, node }: NodeViewProps) {
                 className="gap-2"
               >
                 <TabList>
-                  <Tab id="namesake">Namesake</Tab>
+                  <Tab id="internal">Internal</Tab>
                   <Tab id="external">External</Tab>
                 </TabList>
                 <TabPanel
-                  id="namesake"
+                  id="internal"
                   className="flex flex-row items-start gap-1 w-full"
                 >
                   <Select

--- a/src/components/common/Editor/extensions/ButtonComponent.tsx
+++ b/src/components/common/Editor/extensions/ButtonComponent.tsx
@@ -4,26 +4,40 @@ import {
   Form,
   Link,
   Popover,
+  Select,
+  SelectItem,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
   TextField,
   Tooltip,
   TooltipTrigger,
 } from "@/components/common";
+import { useRouter } from "@tanstack/react-router";
 import {
   NodeViewContent,
   type NodeViewProps,
   NodeViewWrapper,
 } from "@tiptap/react";
 import { LinkIcon, Unlink } from "lucide-react";
-import { useRef, useState } from "react";
+import { type Key, useRef, useState } from "react";
 import { useInteractOutside } from "react-aria";
 
 export default function ButtonComponent({ editor, node }: NodeViewProps) {
+  const { routesByPath } = useRouter();
   const [url, setUrl] = useState<string | null>(
     node.attrs.href && node.attrs.href.length > 0
       ? node.attrs.href
       : "https://",
   );
+  const [form, setForm] = useState<string | null>(
+    node.attrs.href?.startsWith("/forms/") ? node.attrs.href : null,
+  );
   const [isOpen, setIsOpen] = useState(false);
+  const [selectedTab, setSelectedTab] = useState<"namesake" | "external">(
+    node.attrs.href?.startsWith("/forms/") ? "namesake" : "external",
+  );
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -34,7 +48,11 @@ export default function ButtonComponent({ editor, node }: NodeViewProps) {
   });
 
   const handleSave = () => {
-    editor.chain().focus().updateAttributes("button", { href: url }).run();
+    if (form) {
+      editor.chain().focus().updateAttributes("button", { href: form }).run();
+    } else if (url) {
+      editor.chain().focus().setLink({ href: url }).run();
+    }
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -45,6 +63,10 @@ export default function ButtonComponent({ editor, node }: NodeViewProps) {
 
   const handleOpenChange = (isOpen: boolean) => {
     setIsOpen(isOpen);
+  };
+
+  const handleFormSelect = (value: Key) => {
+    setForm(value.toString());
   };
 
   return (
@@ -85,24 +107,67 @@ export default function ButtonComponent({ editor, node }: NodeViewProps) {
             shouldCloseOnInteractOutside={() => false} // Manually handling
             UNSTABLE_portalContainer={containerRef.current ?? undefined}
           >
-            <Form onSubmit={handleSubmit}>
-              <div className="flex flex-row items-start gap-1 w-full">
-                <TextField
-                  aria-label="URL"
-                  type="url"
-                  value={url ?? ""}
-                  onChange={setUrl}
-                  className="flex-1"
-                  prefix={
-                    <LinkIcon className="size-4 text-gray-9 ml-2 -mr-0.5" />
-                  }
-                  size="small"
-                />
-                <Button type="submit" variant="primary" size="small">
-                  Apply
-                </Button>
-              </div>
-            </Form>
+            <Tabs
+              selectedKey={selectedTab}
+              onSelectionChange={(key) =>
+                setSelectedTab(key as "namesake" | "external")
+              }
+              className="gap-2"
+            >
+              <TabList>
+                <Tab id="namesake">Namesake</Tab>
+                <Tab id="external">External</Tab>
+              </TabList>
+              <TabPanel id="namesake">
+                <Form
+                  onSubmit={handleSubmit}
+                  className="flex flex-row items-start gap-1 w-full"
+                >
+                  <Select
+                    aria-label="Select path"
+                    selectedKey={form}
+                    onSelectionChange={handleFormSelect}
+                    placeholder="Select path"
+                    className="flex-1"
+                    items={Object.entries(routesByPath)
+                      .filter(([path]) => path.startsWith("/forms/"))
+                      .map(([path]) => ({
+                        value: path,
+                        label: path,
+                      }))}
+                  >
+                    {(item) => (
+                      <SelectItem key={item.value} id={item.value}>
+                        {item.label}
+                      </SelectItem>
+                    )}
+                  </Select>
+                  <Button type="submit" variant="primary">
+                    Apply
+                  </Button>
+                </Form>
+              </TabPanel>
+              <TabPanel id="external">
+                <Form
+                  onSubmit={handleSubmit}
+                  className="flex flex-row items-start gap-1 w-full"
+                >
+                  <TextField
+                    aria-label="URL"
+                    type="url"
+                    value={url ?? ""}
+                    onChange={setUrl}
+                    className="flex-1"
+                    prefix={
+                      <LinkIcon className="size-4 text-gray-9 ml-2 -mr-0.5" />
+                    }
+                  />
+                  <Button type="submit" variant="primary">
+                    Apply
+                  </Button>
+                </Form>
+              </TabPanel>
+            </Tabs>
           </Popover>
         </div>
       ) : (

--- a/src/components/common/Editor/extensions/ButtonComponent.tsx
+++ b/src/components/common/Editor/extensions/ButtonComponent.tsx
@@ -136,7 +136,7 @@ export default function ButtonComponent({ editor, node }: NodeViewProps) {
                     aria-label="Select path"
                     selectedKey={form}
                     onSelectionChange={(value) => {
-                      setForm(value.toString());
+                      setForm(value?.toString() ?? null);
                     }}
                     placeholder="Select path"
                     className="flex-1"

--- a/src/components/settings/SettingsNav/SettingsNav.tsx
+++ b/src/components/settings/SettingsNav/SettingsNav.tsx
@@ -80,7 +80,7 @@ export const SettingsNav = ({ className }: { className?: string }) => {
         </NavItem>
       </NavGroup>
       <NavGroup>
-        <NavItem href="/signout" icon={LogOut}>
+        <NavItem href={{ to: "/signout" }} icon={LogOut}>
           Sign out
         </NavItem>
       </NavGroup>

--- a/src/components/settings/SettingsNav/SettingsNav.tsx
+++ b/src/components/settings/SettingsNav/SettingsNav.tsx
@@ -80,7 +80,7 @@ export const SettingsNav = ({ className }: { className?: string }) => {
         </NavItem>
       </NavGroup>
       <NavGroup>
-        <NavItem href={{ to: "/signout" }} icon={LogOut}>
+        <NavItem href="/signout" icon={LogOut}>
           Sign out
         </NavItem>
       </NavGroup>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -68,9 +68,6 @@ function RootRoute() {
             : { ...path, ...options },
         )
       }
-      useHref={(path) =>
-        typeof path === "string" ? path : router.buildLocation(path).href
-      }
     >
       <Outlet />
       <PostHogPageView />


### PR DESCRIPTION
## What changed?
Followup to #567 and #571. Remove `useHref` when setting links because we are passing in the full `ToOptions` object instead of just `to`.

Updates the popover form for setting links within a quest. Resolves #527.

![CleanShot 2025-05-21 at 17 36 37@2x](https://github.com/user-attachments/assets/cfe5c8e0-0392-4f75-9b33-22bddb1d79b7)
![CleanShot 2025-05-21 at 17 36 42@2x](https://github.com/user-attachments/assets/0689e946-cad7-4b7b-9921-7c6547cd7ace)

## Why?
The links within quests to forms were not working correctly, and the UX for actually setting the links was poor because it required a full URL instead of providing links to internal routes.

## How was this tested?
Updated unit tests for `ButtonComponent` to accommodate new logic.
Manually tested changing links and viewing content.

## Anything else?
Modified the size of the inputs and the tooltip text to change "URL" to "link".