### PR TITLE
fix: Highlight color contrast

### DIFF
--- a/.changeset/better-windows-greet.md
+++ b/.changeset/better-windows-greet.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix low-contrast highlight color when viewing dark theme using light OS theme

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -23,10 +23,6 @@ body,
 }
 
 ::selection {
-  @apply bg-amber-5 text-gray-12;
-}
-
-.dark ::selection {
   @apply bg-purple-5 text-gray-12;
 }
 


### PR DESCRIPTION
## What changed?
Fixes #586.

## Why?
Highlight colors for text selection had very low contrast when using the dark theme on a light OS.

## How was this change made?
Removed the custom highlight color for dark mode, instead use the same shade for all selection and let Radix colors change automatically.

## How was this tested?
Visual testing to confirm:

| Mode | Before | After |
|--------|--------|--------|
| Light OS, Light Theme | ![CleanShot 2025-05-23 at 17 23 52@2x](https://github.com/user-attachments/assets/cd7610fc-c37e-4189-b5ab-7baf72203b0e) | ![CleanShot 2025-05-23 at 17 21 50@2x](https://github.com/user-attachments/assets/154249e0-03e5-4f15-ac2b-bbe482e1faa4) |
| Light OS, Dark Theme | ![CleanShot 2025-05-23 at 17 24 35@2x](https://github.com/user-attachments/assets/798c8fd0-d6bf-4a7d-b51c-f2c2f3d76573) | ![CleanShot 2025-05-23 at 17 21 15@2x](https://github.com/user-attachments/assets/86f87ccd-1ab9-4c52-bfd4-494b1a427467) |
| Dark OS, Light Theme | ![CleanShot 2025-05-23 at 17 23 26@2x](https://github.com/user-attachments/assets/353a4220-5140-48b3-be73-2287a2eb5f38) | ![CleanShot 2025-05-23 at 17 22 19@2x](https://github.com/user-attachments/assets/a16d9393-b3aa-49f0-b24e-e3f9fcd3b555) |
| Dark OS, Dark Theme | ![CleanShot 2025-05-23 at 17 23 05@2x](https://github.com/user-attachments/assets/f6b10319-19da-4a7e-9d31-29a78144556d) | ![CleanShot 2025-05-23 at 17 22 42@2x](https://github.com/user-attachments/assets/575289b9-6739-4a67-91cd-af3988398007) | 

## Anything else?
It's all purple now.