### PR TITLE
fix: Select font weight

### DIFF
--- a/src/components/common/ListBox/ListBox.tsx
+++ b/src/components/common/ListBox/ListBox.tsx
@@ -92,7 +92,7 @@ export function DropdownItem(props: ListBoxItemProps) {
     >
       {composeRenderProps(props.children, (children, { isSelected }) => (
         <>
-          <span className="flex items-center flex-1 gap-2 font-normal truncate">
+          <span className="flex items-center flex-1 gap-2 truncate">
             {children}
           </span>
           {isSelected && (


### PR DESCRIPTION
## What changed?
Fixes #585. Makes the font weight for `Select` properly inherit from `Button`

Before:
![CleanShot 2025-05-24 at 00 21 04@2x](https://github.com/user-attachments/assets/a385f824-d91c-48a5-be92-cfbb7fa13393)

After:
![CleanShot 2025-05-24 at 00 20 52@2x](https://github.com/user-attachments/assets/78c5a765-4f98-4c52-84d1-193ec9d41643)

## Why?
Visual polish.