### PR TITLE
fix: Prevent doc preview from overflowing

### DIFF
--- a/.changeset/red-times-shake.md
+++ b/.changeset/red-times-shake.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix docs from scrolling horizontally on mobile

--- a/src/routes/_authenticated/documents/$pdfId.tsx
+++ b/src/routes/_authenticated/documents/$pdfId.tsx
@@ -37,7 +37,7 @@ function RouteComponent() {
     base: "flex flex-col h-dvh flex-1",
     variants: {
       isMobile: {
-        true: "h-full-minus-mobile-nav",
+        true: "h-full-minus-mobile-nav w-screen",
         false: "h-dvh",
       },
     },


### PR DESCRIPTION
## What changed?
Fixes #581.

## Why?
Mobile bug from bug bash.

## How was this change made?
Added `w-screen` to limit width on mobile.