### PR TITLE
fix: Remove stray "null" from password error banner

### DIFF
--- a/.changeset/hungry-cats-bet.md
+++ b/.changeset/hungry-cats-bet.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix unintended 'null' string in password error banner

--- a/src/routes/_unauthenticated/signin.tsx
+++ b/src/routes/_unauthenticated/signin.tsx
@@ -80,9 +80,11 @@ const SignIn = () => {
 
     try {
       if (flow === "signUp" && passwordState && passwordState.score < 3) {
-        setError(
-          `Please choose a stronger password. ${passwordState.feedback.warning}`,
-        );
+        let errorMessage = "Please choose a stronger password.";
+        if (passwordState.feedback.warning) {
+          errorMessage += ` ${passwordState.feedback.warning}`;
+        }
+        setError(errorMessage);
         setIsSubmitting(false);
         return;
       }


### PR DESCRIPTION
## What changed?
Fixes #574.

![CleanShot 2025-05-24 at 12 14 22@2x](https://github.com/user-attachments/assets/f5fac2ab-4294-47b8-a66f-f37af6c72655)

## Why?
"null" was displaying when the warning message returned, well, null.

## How was this change made?
Only append the warning message if a warning exists.

## How was this tested?
Tested locally.