### PR TITLE
feat: Allow removing quest badges for costs, time required, and state

### DIFF
--- a/.changeset/tidy-toys-bathe.md
+++ b/.changeset/tidy-toys-bathe.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Allow removing quest badges for costs, time required, and state

--- a/convex/model/questsModel.ts
+++ b/convex/model/questsModel.ts
@@ -1,8 +1,4 @@
-import {
-  type Category,
-  DEFAULT_TIME_REQUIRED,
-  type Jurisdiction,
-} from "../../src/constants";
+import type { Category, Jurisdiction } from "../../src/constants";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
 
@@ -139,7 +135,6 @@ export async function create(
     category,
     jurisdiction,
     slug: finalSlug,
-    timeRequired: DEFAULT_TIME_REQUIRED,
     creationUser: userId,
     updatedAt: Date.now(),
     updatedBy: userId,

--- a/convex/quests.ts
+++ b/convex/quests.ts
@@ -1,9 +1,5 @@
 import { v } from "convex/values";
-import {
-  type Category,
-  DEFAULT_TIME_REQUIRED,
-  type Jurisdiction,
-} from "../src/constants";
+import type { Category, Jurisdiction } from "../src/constants";
 import { query } from "./_generated/server";
 import { userMutation, userQuery } from "./helpers";
 import * as Quests from "./model/questsModel";
@@ -108,7 +104,6 @@ export const create = userMutation({
       category: args.category,
       jurisdiction: args.jurisdiction,
       slug: finalSlug,
-      timeRequired: DEFAULT_TIME_REQUIRED,
       creationUser: ctx.userId,
       updatedAt: Date.now(),
       updatedBy: ctx.userId,

--- a/src/components/quests/QuestCategoryBadge/QuestCategoryBadge.test.tsx
+++ b/src/components/quests/QuestCategoryBadge/QuestCategoryBadge.test.tsx
@@ -96,6 +96,7 @@ describe("QuestCategoryBadge", () => {
 
     // Menu should be visible with category options
     expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getByText("Categories")).toBeInTheDocument();
     expect(
       screen.getByRole("menuitemradio", { name: "Education" }),
     ).toBeInTheDocument();
@@ -126,9 +127,10 @@ describe("QuestCategoryBadge", () => {
     });
   });
 
-  it("handles update failure", async () => {
+  it("handles update failure with specific error message", async () => {
     const user = userEvent.setup();
-    mockSetCategory.mockRejectedValueOnce(new Error("Update failed"));
+    const error = new Error("Network error");
+    mockSetCategory.mockRejectedValueOnce(error);
 
     render(<QuestCategoryBadge quest={mockQuest} editable={true} />);
 
@@ -136,6 +138,7 @@ describe("QuestCategoryBadge", () => {
     await user.click(screen.getByText("Passport"));
 
     expect(toast.error).toHaveBeenCalledWith("Couldn't update state.");
+    expect(toast.error).toHaveBeenCalledTimes(1);
   });
 
   it("maintains current selection on update failure", async () => {
@@ -172,5 +175,20 @@ describe("QuestCategoryBadge", () => {
     for (const item of menuItems) {
       expect(item.querySelector("svg")).toBeInTheDocument();
     }
+  });
+
+  it("initializes with correct category selection", async () => {
+    render(<QuestCategoryBadge quest={mockQuest} editable={true} />);
+
+    // Open the menu
+    await userEvent.click(
+      screen.getByRole("button", { name: "Edit category" }),
+    );
+
+    // Check that the initial category is selected
+    const educationMenuItem = screen.getByRole("menuitemradio", {
+      name: "Education",
+    });
+    expect(educationMenuItem).toBeChecked();
   });
 });

--- a/src/components/quests/QuestCategoryBadge/QuestCategoryBadge.test.tsx
+++ b/src/components/quests/QuestCategoryBadge/QuestCategoryBadge.test.tsx
@@ -127,10 +127,9 @@ describe("QuestCategoryBadge", () => {
     });
   });
 
-  it("handles update failure with specific error message", async () => {
+  it("handles update failure", async () => {
     const user = userEvent.setup();
-    const error = new Error("Network error");
-    mockSetCategory.mockRejectedValueOnce(error);
+    mockSetCategory.mockRejectedValueOnce(new Error("Update failed"));
 
     render(<QuestCategoryBadge quest={mockQuest} editable={true} />);
 
@@ -138,7 +137,6 @@ describe("QuestCategoryBadge", () => {
     await user.click(screen.getByText("Passport"));
 
     expect(toast.error).toHaveBeenCalledWith("Couldn't update state.");
-    expect(toast.error).toHaveBeenCalledTimes(1);
   });
 
   it("maintains current selection on update failure", async () => {

--- a/src/components/quests/QuestCategoryBadge/QuestCategoryBadge.tsx
+++ b/src/components/quests/QuestCategoryBadge/QuestCategoryBadge.tsx
@@ -3,6 +3,7 @@ import {
   BadgeButton,
   Menu,
   MenuItem,
+  MenuSection,
   MenuTrigger,
   Tooltip,
   TooltipTrigger,
@@ -49,7 +50,7 @@ export const QuestCategoryBadge = ({
   };
 
   return (
-    <Badge size="lg">
+    <Badge size="lg" icon={CATEGORIES[quest.category as Category]?.icon}>
       {CATEGORIES[quest.category as Category]?.label ?? "Unknown"}
       {editable && (
         <MenuTrigger>
@@ -57,20 +58,23 @@ export const QuestCategoryBadge = ({
             <BadgeButton icon={Pencil} label="Edit category" />
             <Tooltip>Edit category</Tooltip>
           </TooltipTrigger>
-          <Menu
-            disallowEmptySelection
-            selectionMode="single"
-            selectedKeys={category}
-            onSelectionChange={handleChange}
-          >
-            {Object.entries(CATEGORIES).map(([key, { label, icon }]) => {
-              const Icon = icon ?? CircleHelp;
-              return (
-                <MenuItem key={key} id={key} textValue={key} icon={Icon}>
-                  {label}
-                </MenuItem>
-              );
-            })}
+          <Menu>
+            <MenuSection
+              selectionMode="single"
+              disallowEmptySelection
+              selectedKeys={category}
+              onSelectionChange={handleChange}
+              title="Categories"
+            >
+              {Object.entries(CATEGORIES).map(([key, { label, icon }]) => {
+                const Icon = icon ?? CircleHelp;
+                return (
+                  <MenuItem key={key} id={key} textValue={key} icon={Icon}>
+                    {label}
+                  </MenuItem>
+                );
+              })}
+            </MenuSection>
           </Menu>
         </MenuTrigger>
       )}

--- a/src/components/quests/QuestCostsBadge/QuestCostsBadge.test.tsx
+++ b/src/components/quests/QuestCostsBadge/QuestCostsBadge.test.tsx
@@ -282,4 +282,39 @@ describe("QuestCostsBadge", () => {
     });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
+
+  it("toggles cost required/optional status correctly", async () => {
+    const user = userEvent.setup();
+    render(<QuestCostsBadge quest={mockQuest} editable={true} />);
+
+    await user.click(screen.getByRole("button", { name: "Edit costs" }));
+
+    // Find the toggle button group for the first cost
+    const toggleButtons = screen.getAllByRole("radio", {
+      name: /Required cost|Optional cost/,
+    });
+
+    // Initially, the first cost should be required
+    expect(toggleButtons[0]).toBeChecked();
+    expect(toggleButtons[1]).not.toBeChecked();
+
+    // Click the optional button
+    await user.click(toggleButtons[1]);
+
+    // Verify the toggle state changed
+    expect(toggleButtons[0]).not.toBeChecked();
+    expect(toggleButtons[1]).toBeChecked();
+
+    // Save the changes
+    await user.click(screen.getByText("Save"));
+
+    // Verify the mutation was called with the updated cost
+    expect(mockSetCosts).toHaveBeenCalledWith({
+      costs: [
+        { cost: 100, description: "Application fee", isRequired: false },
+        { cost: 50, description: "Certified copies", isRequired: true },
+      ],
+      questId: mockQuest._id,
+    });
+  });
 });

--- a/src/components/quests/QuestCostsBadge/QuestCostsBadge.test.tsx
+++ b/src/components/quests/QuestCostsBadge/QuestCostsBadge.test.tsx
@@ -38,8 +38,8 @@ describe("QuestCostsBadge", () => {
     slug: "zero-cost-quest",
     updatedAt: 1234567890,
     costs: [
-      { cost: 0, description: "Free application" },
-      { cost: 0, description: "No filing fee" },
+      { cost: 0, description: "Free application", isRequired: true },
+      { cost: 0, description: "No filing fee", isRequired: true },
     ],
   } as Doc<"quests">;
 
@@ -164,26 +164,6 @@ describe("QuestCostsBadge", () => {
     expect(descriptionInputs[1].value).toBe("Certified copies");
   });
 
-  it("toggles between free and paid costs", async () => {
-    const user = userEvent.setup();
-    render(<QuestCostsBadge quest={mockQuest} editable={true} />);
-
-    await user.click(screen.getByRole("button", { name: "Edit costs" }));
-
-    // Toggle to free
-    const freeSwitch = screen.getByRole("switch", { name: "Free" });
-    await user.click(freeSwitch);
-
-    // Cost inputs should be removed
-    expect(screen.queryByLabelText("Cost")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("For")).not.toBeInTheDocument();
-
-    // Toggle back to paid
-    await user.click(freeSwitch);
-    expect(screen.getByLabelText("Cost")).toBeInTheDocument();
-    expect(screen.getByLabelText("For")).toBeInTheDocument();
-  });
-
   it("adds and removes cost items", async () => {
     const user = userEvent.setup();
     render(<QuestCostsBadge quest={mockQuest} editable={true} />);
@@ -286,6 +266,20 @@ describe("QuestCostsBadge", () => {
 
     // Check if popover was closed without saving
     expect(mockSetCosts).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("handles remove costs", async () => {
+    const user = userEvent.setup();
+    render(<QuestCostsBadge quest={mockQuest} editable={true} />);
+
+    await user.click(screen.getByRole("button", { name: "Edit costs" }));
+    await user.click(screen.getByText("Remove"));
+
+    expect(mockSetCosts).toHaveBeenCalledWith({
+      costs: undefined,
+      questId: mockQuest._id,
+    });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 });

--- a/src/components/quests/QuestCostsBadge/QuestCostsBadge.tsx
+++ b/src/components/quests/QuestCostsBadge/QuestCostsBadge.tsx
@@ -122,7 +122,7 @@ export const QuestCostsBadge = ({
 
   if (!quest) return null;
 
-  const handleDelete = () => {
+  const handleRemove = () => {
     setCosts({ costs: undefined, questId: quest._id });
     setIsEditing(false);
   };
@@ -261,7 +261,7 @@ export const QuestCostsBadge = ({
                 <Button
                   variant="secondary"
                   size="small"
-                  onPress={handleDelete}
+                  onPress={handleRemove}
                   className="mr-auto"
                 >
                   Remove

--- a/src/components/quests/QuestCostsBadge/QuestCostsBadge.tsx
+++ b/src/components/quests/QuestCostsBadge/QuestCostsBadge.tsx
@@ -6,14 +6,13 @@ import {
   Form,
   NumberField,
   Popover,
-  Switch,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
   Tooltip,
   TooltipTrigger,
 } from "@/components/common";
-import type { Cost } from "@/constants";
+import { type Cost, DEFAULT_COSTS } from "@/constants";
 import { api } from "@convex/_generated/api";
 import type { Doc } from "@convex/_generated/dataModel";
 import { useMutation } from "convex/react";
@@ -117,14 +116,19 @@ export const QuestCostsBadge = ({
   editable = false,
 }: QuestCostsBadgeProps) => {
   const [isEditing, setIsEditing] = useState(false);
-  const [costsInput, setCostsInput] = useState(quest?.costs ?? null);
+  const [costsInput, setCostsInput] = useState(quest?.costs ?? DEFAULT_COSTS);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const setCosts = useMutation(api.quests.setCosts);
 
   if (!quest) return null;
 
+  const handleDelete = () => {
+    setCosts({ costs: undefined, questId: quest._id });
+    setIsEditing(false);
+  };
+
   const handleCancel = () => {
-    setCostsInput(quest.costs ?? null);
+    setCostsInput(quest.costs ?? DEFAULT_COSTS);
     setIsEditing(false);
   };
 
@@ -172,9 +176,11 @@ export const QuestCostsBadge = ({
     return `${formatCurrency(requiredTotal)}–${formatCurrency(totalWithOptional)}`;
   };
 
+  if (!costs && !editable) return null;
+
   return (
     <Badge size="lg">
-      {getTotalCosts(costs)}
+      {costs ? getTotalCosts(costs) : "Add costs"}
       {costs && costs.length > 0 && (
         <DialogTrigger>
           <TooltipTrigger>
@@ -212,11 +218,11 @@ export const QuestCostsBadge = ({
         <DialogTrigger>
           <TooltipTrigger>
             <BadgeButton
-              icon={Pencil}
+              icon={costs ? Pencil : Plus}
               onPress={() => setIsEditing(true)}
-              label="Edit costs"
+              label={costs ? "Edit costs" : "Add costs"}
             />
-            <Tooltip>Edit costs</Tooltip>
+            <Tooltip>{costs ? "Edit costs" : "Add costs"}</Tooltip>
           </TooltipTrigger>
           <Popover isOpen={isEditing} className="p-4 w-full max-w-md">
             <Form onSubmit={handleSubmit} className="w-full">
@@ -252,19 +258,14 @@ export const QuestCostsBadge = ({
                 </div>
               )}
               <div className="flex w-full justify-end gap-2">
-                <Switch
-                  isSelected={!costsInput}
-                  onChange={(isSelected) =>
-                    setCostsInput(
-                      isSelected
-                        ? null
-                        : [{ cost: 0, description: "", isRequired: true }],
-                    )
-                  }
-                  className="justify-self-start mr-auto"
+                <Button
+                  variant="secondary"
+                  size="small"
+                  onPress={handleDelete}
+                  className="mr-auto"
                 >
-                  Free
-                </Switch>
+                  Remove
+                </Button>
                 <Button variant="secondary" size="small" onPress={handleCancel}>
                   Cancel
                 </Button>

--- a/src/components/quests/QuestJurisdictionBadge/QuestJurisdictionBadge.test.tsx
+++ b/src/components/quests/QuestJurisdictionBadge/QuestJurisdictionBadge.test.tsx
@@ -59,7 +59,7 @@ describe("QuestJurisdictionBadge", () => {
     render(<QuestJurisdictionBadge quest={mockQuest} editable={true} />);
 
     const editButton = screen.getByRole("button", {
-      name: "Edit jurisdiction",
+      name: "Edit state",
     });
     expect(editButton).toBeInTheDocument();
   });
@@ -67,14 +67,14 @@ describe("QuestJurisdictionBadge", () => {
   it("hides edit button when editable prop is false", () => {
     render(<QuestJurisdictionBadge quest={mockQuest} editable={false} />);
     expect(
-      screen.queryByRole("button", { name: "Edit jurisdiction" }),
+      screen.queryByRole("button", { name: "Edit state" }),
     ).not.toBeInTheDocument();
   });
 
   it("hides edit button for federal quests even when editable is true", () => {
     render(<QuestJurisdictionBadge quest={mockFederalQuest} editable={true} />);
     expect(
-      screen.queryByRole("button", { name: "Edit jurisdiction" }),
+      screen.queryByRole("button", { name: "Edit state" }),
     ).not.toBeInTheDocument();
   });
 
@@ -82,10 +82,11 @@ describe("QuestJurisdictionBadge", () => {
     const user = userEvent.setup();
     render(<QuestJurisdictionBadge quest={mockQuest} editable={true} />);
 
-    await user.click(screen.getByRole("button", { name: "Edit jurisdiction" }));
+    await user.click(screen.getByRole("button", { name: "Edit state" }));
 
     // Menu should be visible with state options
     expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getByText("States")).toBeInTheDocument();
     expect(
       screen.getByRole("menuitemradio", { name: "California" }),
     ).toBeInTheDocument();
@@ -98,6 +99,7 @@ describe("QuestJurisdictionBadge", () => {
     expect(
       screen.getByRole("menuitemradio", { name: "New York" }),
     ).not.toBeChecked();
+    expect(screen.getByText("Remove")).toBeInTheDocument();
   });
 
   it("updates jurisdiction on selection", async () => {
@@ -107,8 +109,8 @@ describe("QuestJurisdictionBadge", () => {
     render(<QuestJurisdictionBadge quest={mockQuest} editable={true} />);
 
     // Open menu and select new jurisdiction
-    await user.click(screen.getByRole("button", { name: "Edit jurisdiction" }));
-    await user.click(screen.getByText("New York"));
+    await user.click(screen.getByRole("button", { name: "Edit state" }));
+    await user.click(screen.getByRole("menuitemradio", { name: "New York" }));
 
     expect(mockSetJurisdiction).toHaveBeenCalledWith({
       questId: mockQuest._id,
@@ -122,8 +124,8 @@ describe("QuestJurisdictionBadge", () => {
 
     render(<QuestJurisdictionBadge quest={mockQuest} editable={true} />);
 
-    await user.click(screen.getByRole("button", { name: "Edit jurisdiction" }));
-    await user.click(screen.getByText("New York"));
+    await user.click(screen.getByRole("button", { name: "Edit state" }));
+    await user.click(screen.getByRole("menuitemradio", { name: "New York" }));
 
     expect(toast.error).toHaveBeenCalledWith("Couldn't update state.");
   });
@@ -134,10 +136,25 @@ describe("QuestJurisdictionBadge", () => {
 
     render(<QuestJurisdictionBadge quest={mockQuest} editable={true} />);
 
-    await user.click(screen.getByRole("button", { name: "Edit jurisdiction" }));
-    await user.click(screen.getByText("New York"));
+    await user.click(screen.getByRole("button", { name: "Edit state" }));
+    await user.click(screen.getByRole("menuitemradio", { name: "New York" }));
 
     // Should still show California after failed update
     expect(screen.getByText("California")).toBeInTheDocument();
+  });
+
+  it("removes jurisdiction when Remove is clicked", async () => {
+    const user = userEvent.setup();
+    mockSetJurisdiction.mockResolvedValueOnce(undefined);
+
+    render(<QuestJurisdictionBadge quest={mockQuest} editable={true} />);
+
+    await user.click(screen.getByRole("button", { name: "Edit state" }));
+    await user.click(screen.getByText("Remove"));
+
+    expect(mockSetJurisdiction).toHaveBeenCalledWith({
+      questId: mockQuest._id,
+      jurisdiction: undefined,
+    });
   });
 });

--- a/src/components/quests/QuestJurisdictionBadge/QuestJurisdictionBadge.test.tsx
+++ b/src/components/quests/QuestJurisdictionBadge/QuestJurisdictionBadge.test.tsx
@@ -157,4 +157,14 @@ describe("QuestJurisdictionBadge", () => {
       jurisdiction: undefined,
     });
   });
+
+  it("displays 'Unknown' when jurisdiction is invalid", () => {
+    const questWithoutJurisdiction = {
+      ...mockQuest,
+      jurisdiction: "invalid",
+    };
+
+    render(<QuestJurisdictionBadge quest={questWithoutJurisdiction} />);
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
 });

--- a/src/components/quests/QuestJurisdictionBadge/QuestJurisdictionBadge.tsx
+++ b/src/components/quests/QuestJurisdictionBadge/QuestJurisdictionBadge.tsx
@@ -69,8 +69,7 @@ export const QuestJurisdictionBadge = ({
   const getJurisdictionLabel = () => {
     if (isFederal) return "United States";
     if (hasJurisdiction)
-      return JURISDICTIONS[[...jurisdiction][0] as Jurisdiction];
-    return "Unknown";
+      return JURISDICTIONS[[...jurisdiction][0] as Jurisdiction] ?? "Unknown";
   };
 
   if (!hasJurisdiction && !editable) return null;

--- a/src/components/quests/QuestJurisdictionBadge/QuestJurisdictionBadge.tsx
+++ b/src/components/quests/QuestJurisdictionBadge/QuestJurisdictionBadge.tsx
@@ -3,6 +3,8 @@ import {
   BadgeButton,
   Menu,
   MenuItem,
+  MenuSection,
+  MenuSeparator,
   MenuTrigger,
   Tooltip,
   TooltipTrigger,
@@ -16,7 +18,7 @@ import {
 import { api } from "@convex/_generated/api";
 import type { Doc } from "@convex/_generated/dataModel";
 import { useMutation } from "convex/react";
-import { Pencil } from "lucide-react";
+import { CircleX, Pencil, Plus } from "lucide-react";
 import { useState } from "react";
 import type { Selection } from "react-aria-components";
 import { toast } from "sonner";
@@ -39,6 +41,14 @@ export const QuestJurisdictionBadge = ({
 
   if (!quest) return null;
 
+  const handleRemove = () => {
+    setJurisdiction(new Set());
+    updateJurisdiction({
+      questId: quest._id,
+      jurisdiction: undefined,
+    });
+  };
+
   const handleChange = async (keys: Selection) => {
     if (keys !== ALL && keys.size === 1) {
       try {
@@ -54,30 +64,47 @@ export const QuestJurisdictionBadge = ({
   };
 
   const isFederal = FEDERAL_CATEGORIES.includes(quest.category as Category);
+  const hasJurisdiction = isFederal || [...jurisdiction][0] !== undefined;
 
-  const jurisdictionLabel = isFederal
-    ? "United States"
-    : JURISDICTIONS[[...jurisdiction][0] as Jurisdiction];
+  const getJurisdictionLabel = () => {
+    if (isFederal) return "United States";
+    if (hasJurisdiction)
+      return JURISDICTIONS[[...jurisdiction][0] as Jurisdiction];
+    return "Unknown";
+  };
+
+  if (!hasJurisdiction && !editable) return null;
 
   return (
     <Badge size="lg">
-      {jurisdictionLabel}
+      {hasJurisdiction ? getJurisdictionLabel() : "Add state"}
       {editable && !isFederal && (
         <MenuTrigger>
           <TooltipTrigger>
-            <BadgeButton icon={Pencil} label="Edit jurisdiction" />
-            <Tooltip>Edit state</Tooltip>
+            <BadgeButton
+              icon={hasJurisdiction ? Pencil : Plus}
+              label={hasJurisdiction ? "Edit state" : "Add state"}
+            />
+            <Tooltip>{hasJurisdiction ? "Edit state" : "Add state"}</Tooltip>
           </TooltipTrigger>
-          <Menu
-            selectionMode="single"
-            onSelectionChange={handleChange}
-            selectedKeys={jurisdiction}
-          >
-            {Object.entries(JURISDICTIONS).map(([value, label]) => (
-              <MenuItem key={value} id={value}>
-                {label}
-              </MenuItem>
-            ))}
+          <Menu placement="bottom end">
+            <MenuSection
+              selectionMode="single"
+              disallowEmptySelection
+              selectedKeys={jurisdiction}
+              onSelectionChange={handleChange}
+              title="States"
+            >
+              {Object.entries(JURISDICTIONS).map(([value, label]) => (
+                <MenuItem key={value} id={value}>
+                  {label}
+                </MenuItem>
+              ))}
+            </MenuSection>
+            <MenuSeparator />
+            <MenuItem onAction={handleRemove} icon={CircleX}>
+              Remove
+            </MenuItem>
           </Menu>
         </MenuTrigger>
       )}

--- a/src/components/quests/QuestPageBadges/QuestPageBadges.test.tsx
+++ b/src/components/quests/QuestPageBadges/QuestPageBadges.test.tsx
@@ -46,7 +46,7 @@ describe("QuestPageBadges", () => {
       screen.queryByRole("button", { name: "Edit category" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Edit jurisdiction" }),
+      screen.queryByRole("button", { name: "Edit state" }),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Edit costs" }),
@@ -63,7 +63,7 @@ describe("QuestPageBadges", () => {
       screen.getByRole("button", { name: "Edit category" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Edit jurisdiction" }),
+      screen.getByRole("button", { name: "Edit state" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Edit costs" }),
@@ -89,9 +89,13 @@ describe("QuestPageBadges", () => {
     // Check if category badge is rendered
     expect(screen.getByText("Education")).toBeInTheDocument();
 
-    // Check if other badges show default/empty states
-    expect(screen.getByText("Unknown")).toBeInTheDocument(); // For jurisdiction
-    expect(screen.getByText("Free")).toBeInTheDocument(); // For costs
+    // Check if other badges are not rendered
+    expect(
+      screen.queryByRole("button", { name: "Edit state" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Edit costs" }),
+    ).not.toBeInTheDocument();
   });
 
   it("handles overflow", () => {

--- a/src/components/quests/QuestTimeBadge/QuestTimeBadge.test.tsx
+++ b/src/components/quests/QuestTimeBadge/QuestTimeBadge.test.tsx
@@ -51,9 +51,16 @@ describe("QuestTimeBadge", () => {
     expect(screen.getByText("2–4 weeks")).toBeInTheDocument();
   });
 
-  it("displays 'Unknown' when timeRequired is not set", () => {
-    render(<QuestTimeBadge quest={mockQuestNoTimeRequired} />);
-    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  it("returns null when timeRequired is not set and not editable", () => {
+    const { container } = render(
+      <QuestTimeBadge quest={mockQuestNoTimeRequired} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows 'Add time required' when timeRequired is not set and editable", () => {
+    render(<QuestTimeBadge quest={mockQuestNoTimeRequired} editable={true} />);
+    expect(screen.getByText("Add time required")).toBeInTheDocument();
   });
 
   it("does not show description popover when description is not available", () => {
@@ -287,6 +294,25 @@ describe("QuestTimeBadge", () => {
 
     // Check if popover was closed without saving
     expect(mockSetTimeRequired).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("handles removing time required", async () => {
+    const user = userEvent.setup();
+    mockSetTimeRequired.mockResolvedValueOnce(undefined);
+
+    render(<QuestTimeBadge quest={mockQuest} editable={true} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Edit time required" }),
+    );
+
+    await user.click(screen.getByText("Remove"));
+
+    expect(mockSetTimeRequired).toHaveBeenCalledWith({
+      timeRequired: undefined,
+      questId: "quest123",
+    });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 });

--- a/src/components/quests/QuestTimeBadge/QuestTimeBadge.test.tsx
+++ b/src/components/quests/QuestTimeBadge/QuestTimeBadge.test.tsx
@@ -161,9 +161,10 @@ describe("QuestTimeBadge", () => {
       screen.getByRole("button", { name: "Edit time required" }),
     );
 
-    const descriptionInput = screen.getByLabelText("Description");
-    await user.clear(descriptionInput);
-    await user.type(descriptionInput, "New description");
+    // Select a different unit
+    const unitSelect = screen.getByLabelText("Unit");
+    await user.click(unitSelect);
+    await user.click(screen.getByRole("option", { name: "Months" }));
 
     await user.click(screen.getByText("Save"));
 
@@ -171,8 +172,8 @@ describe("QuestTimeBadge", () => {
       timeRequired: {
         min: 2,
         max: 4,
-        unit: "weeks",
-        description: "New description",
+        unit: "months",
+        description: "Processing time varies by court",
       },
       questId: "quest123",
     });

--- a/src/components/quests/QuestTimeBadge/QuestTimeBadge.tsx
+++ b/src/components/quests/QuestTimeBadge/QuestTimeBadge.tsx
@@ -116,7 +116,7 @@ export const QuestTimeBadge = ({
 
   if (!quest) return null;
 
-  const handleDelete = () => {
+  const handleRemove = () => {
     setTimeRequired({
       timeRequired: undefined,
       questId: quest._id,
@@ -197,7 +197,7 @@ export const QuestTimeBadge = ({
                 <Button
                   variant="secondary"
                   size="small"
-                  onPress={handleDelete}
+                  onPress={handleRemove}
                   className="mr-auto"
                 >
                   Remove

--- a/src/components/quests/QuestTimeBadge/QuestTimeBadge.tsx
+++ b/src/components/quests/QuestTimeBadge/QuestTimeBadge.tsx
@@ -12,11 +12,16 @@ import {
   Tooltip,
   TooltipTrigger,
 } from "@/components/common";
-import { TIME_UNITS, type TimeRequired, type TimeUnit } from "@/constants";
+import {
+  DEFAULT_TIME_REQUIRED,
+  TIME_UNITS,
+  type TimeRequired,
+  type TimeUnit,
+} from "@/constants";
 import { api } from "@convex/_generated/api";
 import type { Doc } from "@convex/_generated/dataModel";
 import { useMutation } from "convex/react";
-import { HelpCircle, Pencil } from "lucide-react";
+import { HelpCircle, Pencil, Plus } from "lucide-react";
 import { memo, useState } from "react";
 import { toast } from "sonner";
 
@@ -103,13 +108,21 @@ export const QuestTimeBadge = ({
   editable = false,
 }: QuestTimeBadgeProps) => {
   const [isEditing, setIsEditing] = useState(false);
-  const [timeInput, setTimeInput] = useState<TimeRequired | null>(
-    (quest?.timeRequired as TimeRequired) ?? null,
+  const [timeInput, setTimeInput] = useState<TimeRequired>(
+    (quest?.timeRequired as TimeRequired) ?? DEFAULT_TIME_REQUIRED,
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const setTimeRequired = useMutation(api.quests.setTimeRequired);
 
   if (!quest) return null;
+
+  const handleDelete = () => {
+    setTimeRequired({
+      timeRequired: undefined,
+      questId: quest._id,
+    });
+    setIsEditing(false);
+  };
 
   const handleCancel = () => {
     setTimeInput((quest.timeRequired as TimeRequired) ?? null);
@@ -146,9 +159,11 @@ export const QuestTimeBadge = ({
 
   const formattedTime = getFormattedTime(timeRequired as TimeRequired);
 
+  if (!timeRequired && !editable) return null;
+
   return (
     <Badge size="lg">
-      {formattedTime}
+      {timeRequired ? formattedTime : "Add time required"}
       {timeRequired?.description && (
         <DialogTrigger>
           <TooltipTrigger>
@@ -164,21 +179,29 @@ export const QuestTimeBadge = ({
         <DialogTrigger>
           <TooltipTrigger>
             <BadgeButton
-              icon={Pencil}
+              icon={timeRequired ? Pencil : Plus}
               onPress={() => setIsEditing(true)}
-              label="Edit time required"
+              label={timeRequired ? "Edit time required" : "Add time required"}
             />
-            <Tooltip>Edit time required</Tooltip>
+            <Tooltip>
+              {timeRequired ? "Edit time required" : "Add time required"}
+            </Tooltip>
           </TooltipTrigger>
           <Popover isOpen={isEditing} className="p-4">
             <Form onSubmit={handleSubmit} className="w-full">
-              {timeInput && (
-                <TimeRequiredInput
-                  timeRequired={timeInput}
-                  onChange={setTimeInput}
-                />
-              )}
+              <TimeRequiredInput
+                timeRequired={timeInput}
+                onChange={setTimeInput}
+              />
               <div className="flex w-full justify-end gap-2">
+                <Button
+                  variant="secondary"
+                  size="small"
+                  onPress={handleDelete}
+                  className="mr-auto"
+                >
+                  Remove
+                </Button>
                 <Button variant="secondary" size="small" onPress={handleCancel}>
                   Cancel
                 </Button>

--- a/src/constants/quests.ts
+++ b/src/constants/quests.ts
@@ -209,6 +209,14 @@ export type Cost = {
   isRequired?: boolean;
 };
 
+export const DEFAULT_COSTS: Cost[] = [
+  {
+    cost: 0,
+    description: "",
+    isRequired: true,
+  },
+];
+
 /**
  * Time units.
  * Used to display time required in quest details.
@@ -250,7 +258,7 @@ export type TimeRequired = {
 };
 
 export const DEFAULT_TIME_REQUIRED: TimeRequired = {
-  min: 5,
-  max: 10,
-  unit: "minutes",
+  min: 2,
+  max: 6,
+  unit: "weeks",
 };


### PR DESCRIPTION
## What changed?
Allows removing quest costs, time required, and state from edit mode. Previously:

- once a state was selected, you couldn't remove it — only select another state
- all quests with "0" costs would render a "Free" badge
- all quests would render "5-10 minutes" by default without a way to remove the time estimate

This support removing the above and updates the default logic for quests.

https://github.com/user-attachments/assets/bfeb1a7a-4e1d-4216-bc65-2b7a441d1b27

## Why?
We may want to hide quest costs, time required, or state for certain quests. For example:

- A placeholder quest for a state where we don't know the costs or time required yet
- A "getting started" quest where costs don't make sense
- A quest where an editor accidentally selected a state even though the quest doesn't need one

## How was this change made?
- Removed setting timeRequired by default on creation of a new quest
- Added "Remove" buttons to the popover forms for badges in quest edit mode
- Changed text to "Add state", "Add time required", and "Add costs" when none exist, and changed icon from a pencil to a plus
- Display category icon within category badge
- Increase default time required from 5-10 minutes to 2-6 weeks to get closer to a realistic estimate for some of the core flows

## How was this tested?
Updated all relevant tests

## Anything else?
No ticket for this one, needed to help with creating placeholder quests for #421 