### PR TITLE
fix: Improve toast placement

### DIFF
--- a/.changeset/fair-lights-punch.md
+++ b/.changeset/fair-lights-punch.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Toast placement improved

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -74,8 +74,9 @@ function RootRoute() {
       <Toaster
         theme={theme as "light" | "dark" | "system"}
         offset={16}
+        mobileOffset={{ bottom: "60px" }}
         gap={8}
-        position="bottom-left"
+        position="bottom-right"
         toastOptions={{
           unstyled: true,
           classNames: {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -74,7 +74,7 @@ function RootRoute() {
       <Toaster
         theme={theme as "light" | "dark" | "system"}
         offset={16}
-        mobileOffset={{ bottom: "60px" }}
+        mobileOffset={{ bottom: "68px" }}
         gap={8}
         position="bottom-right"
         toastOptions={{


### PR DESCRIPTION
## What changed?
Modified `Toaster` properties to change the position of toasts to improve navigation.

https://github.com/user-attachments/assets/123e9916-086b-4c8b-8b76-bd7d52321179

https://github.com/user-attachments/assets/bd3dd6bb-237e-4db2-9634-37f04202cfb0

Fixes #601 

## Why?
Whenever the `toast` was displayed to provide feedback to the user, it was placed above the bottom navigation bar, making it impossible to use until the notification disappeared.

## How was this change made?
- Updated `Toaster` on `_root.tsx` to manage `position` property as bottom-right and `mobileOffset` as bottom: '60px'.

## How was this tested?
Manual.

## Anything else?
No.