### PR TITLE
fix: Add support for "prefers not to answer" in form fields

### DIFF
--- a/.changeset/slimy-mangos-grab.md
+++ b/.changeset/slimy-mangos-grab.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Support selecting 'prefer not to answer' for certain optional questions

--- a/src/components/forms/CheckboxGroupField/CheckboxGroupField.test.tsx
+++ b/src/components/forms/CheckboxGroupField/CheckboxGroupField.test.tsx
@@ -85,4 +85,59 @@ describe("CheckboxGroupField", () => {
     const childComponent = screen.getByTestId("child-component");
     expect(childComponent).toBeInTheDocument();
   });
+
+  it("renders prefer not to answer option when enabled", () => {
+    renderWithFormProvider(
+      <CheckboxGroupField
+        name="reasonForChangingName"
+        label="Test Label"
+        options={mockOptions}
+        includePreferNotToAnswer
+      />,
+    );
+
+    const preferNotToAnswer = screen.getByText("Prefer not to answer");
+    expect(preferNotToAnswer).toBeInTheDocument();
+  });
+
+  it("disables other options when prefer not to answer is selected", async () => {
+    renderWithFormProvider(
+      <CheckboxGroupField
+        name="reasonForChangingName"
+        label="Test Label"
+        options={mockOptions}
+        includePreferNotToAnswer
+      />,
+    );
+
+    // Select prefer not to answer
+    const preferNotToAnswer = screen.getByText("Prefer not to answer");
+    await userEvent.click(preferNotToAnswer);
+
+    // Check that all other options are disabled
+    for (const option of mockOptions) {
+      const checkbox = screen.getByRole("checkbox", {
+        name: option.label,
+      }) as HTMLInputElement;
+      expect(checkbox.disabled).toBe(true);
+      expect(checkbox.checked).toBe(false);
+    }
+
+    // Verify prefer not to answer is checked
+    const preferNotToAnswerCheckbox = screen.getByRole("checkbox", {
+      name: "Prefer not to answer",
+    }) as HTMLInputElement;
+    expect(preferNotToAnswerCheckbox.checked).toBe(true);
+
+    // Uncheck prefer not to answer
+    await userEvent.click(preferNotToAnswer);
+
+    // Verify all options are enabled
+    for (const option of mockOptions) {
+      const checkbox = screen.getByRole("checkbox", {
+        name: option.label,
+      }) as HTMLInputElement;
+      expect(checkbox.disabled).toBe(false);
+    }
+  });
 });

--- a/src/components/forms/CheckboxGroupField/CheckboxGroupField.tsx
+++ b/src/components/forms/CheckboxGroupField/CheckboxGroupField.tsx
@@ -4,7 +4,7 @@ import {
   type CheckboxGroupProps,
   type CheckboxProps,
 } from "@/components/common";
-import type { FieldName } from "@/constants";
+import { type FieldName, PREFER_NOT_TO_ANSWER } from "@/constants";
 import { smartquotes } from "@/utils/smartquotes";
 import { Controller, useFormContext } from "react-hook-form";
 
@@ -19,6 +19,7 @@ export interface CheckboxGroupFieldProps extends CheckboxGroupProps {
   label: string;
   labelHidden?: boolean;
   options: CheckboxOption[];
+  includePreferNotToAnswer?: boolean;
 }
 
 export function CheckboxGroupField({
@@ -27,9 +28,17 @@ export function CheckboxGroupField({
   labelHidden,
   options,
   children,
+  includePreferNotToAnswer,
   ...props
 }: CheckboxGroupFieldProps) {
-  const { control } = useFormContext();
+  const { control, setValue } = useFormContext();
+
+  const handlePreferNotToAnswer = (value: string[]) => {
+    if (value.includes(PREFER_NOT_TO_ANSWER)) {
+      // If "prefer not to answer" is checked, uncheck all other options
+      setValue(name, [PREFER_NOT_TO_ANSWER]);
+    }
+  };
 
   return (
     <div className="@container flex flex-col gap-4">
@@ -38,30 +47,49 @@ export function CheckboxGroupField({
         name={name}
         defaultValue={[]}
         shouldUnregister={true}
-        render={({ field, fieldState: { error, invalid } }) => (
-          <CheckboxGroup
-            {...field}
-            label={!labelHidden ? smartquotes(label) : undefined}
-            aria-label={labelHidden ? label : undefined}
-            size="large"
-            isInvalid={invalid}
-            errorMessage={error?.message}
-            {...props}
-          >
-            <span className="italic text-gray-dim text-sm">
-              Select all that apply:
-            </span>
-            {options?.map(({ label, ...option }) => (
-              <Checkbox
-                key={option.value}
-                {...option}
-                size="large"
-                label={label}
-                card
-              />
-            ))}
-          </CheckboxGroup>
-        )}
+        render={({ field, fieldState: { error, invalid } }) => {
+          const currentValue = field.value || [];
+          const isPreferNotToAnswerChecked =
+            currentValue.includes(PREFER_NOT_TO_ANSWER);
+
+          return (
+            <CheckboxGroup
+              {...field}
+              label={!labelHidden ? smartquotes(label) : undefined}
+              aria-label={labelHidden ? label : undefined}
+              size="large"
+              isInvalid={invalid}
+              errorMessage={error?.message}
+              onChange={(value) => {
+                field.onChange(value);
+                handlePreferNotToAnswer(value);
+              }}
+              {...props}
+            >
+              <span className="italic text-gray-dim text-sm">
+                Select all that apply:
+              </span>
+              {options?.map(({ label, ...option }) => (
+                <Checkbox
+                  key={option.value}
+                  {...option}
+                  size="large"
+                  label={label}
+                  card
+                  isDisabled={isPreferNotToAnswerChecked}
+                />
+              ))}
+              {includePreferNotToAnswer && (
+                <Checkbox
+                  value={PREFER_NOT_TO_ANSWER}
+                  size="large"
+                  label="Prefer not to answer"
+                  card
+                />
+              )}
+            </CheckboxGroup>
+          );
+        }}
       />
       {children}
     </div>

--- a/src/components/forms/RadioGroupField/RadioGroupField.test.tsx
+++ b/src/components/forms/RadioGroupField/RadioGroupField.test.tsx
@@ -81,4 +81,50 @@ describe("RadioGroupField", () => {
     const childComponent = screen.getByTestId("child-component");
     expect(childComponent).toBeInTheDocument();
   });
+
+  it("renders prefer not to answer option when includePreferNotToAnswer is true", () => {
+    renderWithFormProvider(
+      <RadioGroupField
+        name="pronouns"
+        label="Test Label"
+        options={mockOptions}
+        includePreferNotToAnswer
+      />,
+    );
+
+    const preferNotToAnswerOption = screen.getByText("Prefer not to answer");
+    expect(preferNotToAnswerOption).toBeInTheDocument();
+  });
+
+  it("does not render prefer not to answer option when includePreferNotToAnswer is false", () => {
+    renderWithFormProvider(
+      <RadioGroupField
+        name="pronouns"
+        label="Test Label"
+        options={mockOptions}
+      />,
+    );
+
+    const preferNotToAnswerOption = screen.queryByText("Prefer not to answer");
+    expect(preferNotToAnswerOption).not.toBeInTheDocument();
+  });
+
+  it("allows selecting prefer not to answer option", async () => {
+    renderWithFormProvider(
+      <RadioGroupField
+        name="pronouns"
+        label="Test Label"
+        options={mockOptions}
+        includePreferNotToAnswer={true}
+      />,
+    );
+
+    const preferNotToAnswerOption = screen.getByText("Prefer not to answer");
+    await userEvent.click(preferNotToAnswerOption);
+
+    const selectedRadio = screen.getByRole("radio", {
+      name: "Prefer not to answer",
+    }) as HTMLInputElement;
+    expect(selectedRadio.checked).toBe(true);
+  });
 });

--- a/src/components/forms/RadioGroupField/RadioGroupField.tsx
+++ b/src/components/forms/RadioGroupField/RadioGroupField.tsx
@@ -4,7 +4,7 @@ import {
   type RadioGroupProps,
   type RadioProps,
 } from "@/components/common";
-import type { FieldName } from "@/constants";
+import { type FieldName, PREFER_NOT_TO_ANSWER } from "@/constants";
 import { smartquotes } from "@/utils/smartquotes";
 import { Controller, useFormContext } from "react-hook-form";
 
@@ -19,6 +19,7 @@ export interface RadioGroupFieldProps extends RadioGroupProps {
   label: string;
   labelHidden?: boolean;
   options: RadioOption[];
+  includePreferNotToAnswer?: boolean;
 }
 
 export function RadioGroupField({
@@ -27,6 +28,7 @@ export function RadioGroupField({
   labelHidden,
   options,
   children,
+  includePreferNotToAnswer,
   ...props
 }: RadioGroupFieldProps) {
   const { control } = useFormContext();
@@ -54,6 +56,11 @@ export function RadioGroupField({
                 {label}
               </Radio>
             ))}
+            {includePreferNotToAnswer && (
+              <Radio value={PREFER_NOT_TO_ANSWER} size="large" card>
+                Prefer not to answer
+              </Radio>
+            )}
           </RadioGroup>
         )}
       />

--- a/src/components/forms/YesNoField/YesNoField.test.tsx
+++ b/src/components/forms/YesNoField/YesNoField.test.tsx
@@ -94,6 +94,56 @@ describe("YesNoField", () => {
     const childComponent = screen.getByTestId("child-component");
     expect(childComponent).toBeInTheDocument();
   });
+
+  it("renders prefer not to answer option when includePreferNotToAnswer is true", () => {
+    renderWithFormProvider(
+      <YesNoField
+        name="isCurrentlyUnhoused"
+        label="Are you currently unhoused?"
+        includePreferNotToAnswer
+      />,
+    );
+
+    const preferNotToAnswerOption = screen.getByRole("radio", {
+      name: "Prefer not to answer",
+    });
+    expect(preferNotToAnswerOption).toBeInTheDocument();
+  });
+
+  it("does not render prefer not to answer option by default", () => {
+    renderWithFormProvider(
+      <YesNoField
+        name="isCurrentlyUnhoused"
+        label="Are you currently unhoused?"
+      />,
+    );
+
+    const preferNotToAnswerOption = screen.queryByRole("radio", {
+      name: "Prefer not to answer",
+    });
+    expect(preferNotToAnswerOption).not.toBeInTheDocument();
+  });
+
+  it("allows selecting prefer not to answer option", async () => {
+    renderWithFormProvider(
+      <YesNoField
+        name="isCurrentlyUnhoused"
+        label="Are you currently unhoused?"
+        includePreferNotToAnswer
+      />,
+    );
+
+    const yesOption = screen.getByRole("radio", { name: "Yes" });
+    const noOption = screen.getByRole("radio", { name: "No" });
+    const preferNotToAnswerOption = screen.getByRole("radio", {
+      name: "Prefer not to answer",
+    });
+
+    await userEvent.click(preferNotToAnswerOption);
+    expect(preferNotToAnswerOption).toBeChecked();
+    expect(yesOption).not.toBeChecked();
+    expect(noOption).not.toBeChecked();
+  });
 });
 
 describe("getYesNoStringFromBoolean", () => {
@@ -103,6 +153,12 @@ describe("getYesNoStringFromBoolean", () => {
 
   it("returns 'no' if the value is false", () => {
     expect(getYesNoStringFromBoolean(false)).toBe("no");
+  });
+
+  it("returns 'preferNotToAnswer' if the value is 'preferNotToAnswer'", () => {
+    expect(getYesNoStringFromBoolean("preferNotToAnswer")).toBe(
+      "preferNotToAnswer",
+    );
   });
 
   it("returns null if the value is undefined", () => {
@@ -119,8 +175,17 @@ describe("getBooleanValueFromYesNoString", () => {
     expect(getBooleanValueFromYesNoString("yes")).toBe(true);
   });
 
-  it("returns false otherwise", () => {
+  it("returns false if the value is 'no'", () => {
     expect(getBooleanValueFromYesNoString("no")).toBe(false);
+  });
+
+  it("returns 'preferNotToAnswer' if the value is 'preferNotToAnswer'", () => {
+    expect(getBooleanValueFromYesNoString("preferNotToAnswer")).toBe(
+      "preferNotToAnswer",
+    );
+  });
+
+  it("returns false for other values", () => {
     expect(getBooleanValueFromYesNoString("")).toBe(false);
     expect(getBooleanValueFromYesNoString("garbage")).toBe(false);
     expect(getBooleanValueFromYesNoString(null as any)).toBe(false);

--- a/src/components/forms/YesNoField/YesNoField.tsx
+++ b/src/components/forms/YesNoField/YesNoField.tsx
@@ -1,15 +1,18 @@
 import { Radio, RadioGroup, type RadioGroupProps } from "@/components/common";
-import type { FieldName } from "@/constants";
+import { type FieldName, PREFER_NOT_TO_ANSWER } from "@/constants";
 import { smartquotes } from "@/utils/smartquotes";
 import { Controller, useFormContext } from "react-hook-form";
+
+type YesNoValue = boolean | typeof PREFER_NOT_TO_ANSWER;
 
 /**
  * Converts a boolean value to a string value.
  * @param value - The boolean value to convert.
- * @returns "yes" if the value is true, "no" if the value is false, null if the value is undefined or null.
+ * @returns "yes" if the value is true, "no" if the value is false, "preferNotToAnswer" if the value is null.
  */
-export const getYesNoStringFromBoolean = (value: boolean) => {
+export const getYesNoStringFromBoolean = (value: YesNoValue) => {
   if (value === undefined || value === null) return null;
+  if (value === PREFER_NOT_TO_ANSWER) return PREFER_NOT_TO_ANSWER;
   if (value) return "yes";
   return "no";
 };
@@ -17,9 +20,10 @@ export const getYesNoStringFromBoolean = (value: boolean) => {
 /**
  * Converts a string value to a boolean value.
  * @param value - The string value to convert.
- * @returns true if the value is "yes", false if the value is "no".
+ * @returns true if the value is "yes", false if the value is "no", null if the value is "preferNotToAnswer".
  */
-export const getBooleanValueFromYesNoString = (value: string) => {
+export const getBooleanValueFromYesNoString = (value: string): YesNoValue => {
+  if (value === PREFER_NOT_TO_ANSWER) return PREFER_NOT_TO_ANSWER;
   return value === "yes";
 };
 
@@ -30,6 +34,7 @@ export interface YesNoFieldProps extends RadioGroupProps {
   labelHidden?: boolean;
   yesLabel?: string;
   noLabel?: string;
+  includePreferNotToAnswer?: boolean;
 }
 
 export function YesNoField({
@@ -40,6 +45,7 @@ export function YesNoField({
   noLabel,
   children,
   defaultValue,
+  includePreferNotToAnswer,
 }: YesNoFieldProps) {
   const { control, setValue } = useFormContext();
 
@@ -69,6 +75,11 @@ export function YesNoField({
             <Radio value="no" size="large" card>
               {smartquotes(noLabel ?? "No")}
             </Radio>
+            {includePreferNotToAnswer && (
+              <Radio value={PREFER_NOT_TO_ANSWER} size="large" card>
+                Prefer not to answer
+              </Radio>
+            )}
           </RadioGroup>
         )}
       />

--- a/src/constants/fields.ts
+++ b/src/constants/fields.ts
@@ -218,3 +218,5 @@ export type FormData = {
 };
 
 export const COMMON_PRONOUNS = ["they/them", "she/her", "he/him"];
+
+export const PREFER_NOT_TO_ANSWER = "preferNotToAnswer";

--- a/src/routes/_authenticated/forms/social-security.tsx
+++ b/src/routes/_authenticated/forms/social-security.tsx
@@ -189,6 +189,7 @@ function RouteComponent() {
           label="Are you Hispanic or Latino?"
           yesLabel="I am Hispanic or Latino"
           noLabel="I am not Hispanic or Latino"
+          includePreferNotToAnswer
         />
       </FormSection>
       <FormSection
@@ -199,6 +200,7 @@ function RouteComponent() {
           name="race"
           label="Race"
           labelHidden
+          includePreferNotToAnswer
           options={[
             {
               label: "Native Hawaiian",


### PR DESCRIPTION
## What changed?
Allow users to opt out of answering certain questions. Resolves #579.

https://github.com/user-attachments/assets/45f715ba-aa40-4139-bf4b-a151561bdc30

## Why?
Certain form questions are optional, but radio groups cannot be deselected, and checkbox groups require some extra work to uncheck and disable all the other checkboxes.

## How was this change made?
1. Add a new `includePreferNotToAnswer` boolean prop for `CheckboxGroupField`, `RadioGroupField`, and `YesNoField`. Use the same naming and labeling scheme, and always include the item at the end of the list
2. For `CheckboxGroupField`, disable and deselect all other checkbox items
3. Update tests
4. Update the social security form questions for ethnicity and race to include "Prefer not to answer"

## How was this tested?
Wrote new unit tests and updated existing ones. Tested manually.

## Anything else?
Dove into the history of radio buttons on the web and why they are not de-selectable. Considered adding some JS to allow click-to-disable on radio buttons, but ultimately felt that (at least from a user psych perspective) most people will want to answer every question in a form, even if their answer is "I don't want to answer". This shouldn't affect any backend logic. Verified that "prefer not to answer" responses save and display correctly within the user responses view, and don't crash creating a PDF.