### PR TITLE
fix: Only deploy Storybook on pushes to main

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,10 +1,9 @@
 name: Storybook
 
 on:
-  pull_request:
-    branches: main
   push:
     branches: main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## What changed?
Only deploy Storybook when pushed to `main` or on manual workflow dispatch. Do not attempt deploying on pushes to branches or pull requests.

## Why?
Storybook deploys are failing for external contributors on pull requests ([example](https://github.com/namesakefyi/namesake/actions/runs/15344045173/job/43188858234)) because of missing API keys in the workflow. We don't need to deploy Storybook on every pull request, it'll be fine if it only runs on merges to main.