### PR TITLE
chore: Update labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,17 +7,25 @@ backend:
 bug:
 - head-branch: ['^fix', 'fix']
 
+content:
+- changed-files:
+  - any-glob-to-any-file: ['src/forms/**']
+
 dependencies:
 - changed-files:
   - any-glob-to-any-file: package.json
 
 documentation:
 - changed-files:
-  - any-glob-to-any-file: docs/**
+  - any-glob-to-any-file: ['docs/**', 'CONTRIBUTING.md', 'README.md', 'SECURITY.md']
+
+email:
+- changed-files:
+  - any-glob-to-any-file: ['emails/**']
 
 frontend:
 - changed-files:
-  - any-glob-to-any-file: src/**
+  - any-glob-to-any-file: ['src/**', 'index.html']
 
 testing:
 - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -33,4 +33,4 @@ testing:
 
 workflows:
 - changed-files:
-  - any-glob-to-any-file: ['.github/workflows/**', '.husky/**', 'biome.json']
+  - any-glob-to-any-file: ['.github/workflows/**', '.github/labeler.yml', '.github/dependabot.yml', '.husky/**', 'biome.json']


### PR DESCRIPTION
## What changed?
Update auto-labeler logic to handle content (changes to forms). Add a new label for email, and tag documentation when changing the any of the root .md files.