### PR TITLE
chore: Exclude chore commits from Congratsbot

### DIFF
--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -11,3 +11,5 @@ jobs:
       contents: read
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}
+    with:
+      exclude: '["^chore\\(deps\\)", "^chore:"]'


### PR DESCRIPTION
## What changed?
Exclude `chore:` and `chore(deps)` commits from posting to Congratsbot via the Discord webhook.

## Why?
We update multiple dependencies at least once a week and the messages get noisy.

## How was this change made?
Updated the congratsbot repo with support for `exclude` which accepts an array of regex strings.

## How was this tested?
I'm about to! This should merge *without* posting to Discord. Let's see if it works.