### PR TITLE
fix: Prevent theme color selector from overflowing on mobile

### DIFF
--- a/.changeset/silly-tools-send.md
+++ b/.changeset/silly-tools-send.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix swatch controls overflow on mobile

--- a/index.html
+++ b/index.html
@@ -4,8 +4,6 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <meta name="theme-color" content="#fcfcfd" media="(prefers-color-scheme: light)" />
-  <meta name="theme-color" content="#18191b" media="(prefers-color-scheme: dark)" />
   <link rel="icon" href="/favicon.ico" sizes="32x32" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/src/components/settings/DeleteAccountSetting/DeleteAccountSetting.test.tsx
+++ b/src/components/settings/DeleteAccountSetting/DeleteAccountSetting.test.tsx
@@ -26,7 +26,7 @@ describe("DeleteAccountSetting", () => {
       screen.getByRole("button", { name: "Delete account" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Permanently delete your Namesake account and data."),
+      screen.getByText("Permanently delete your Namesake account."),
     ).toBeInTheDocument();
   });
 

--- a/src/components/settings/DeleteAccountSetting/DeleteAccountSetting.tsx
+++ b/src/components/settings/DeleteAccountSetting/DeleteAccountSetting.tsx
@@ -106,7 +106,7 @@ export const DeleteAccountSetting = () => {
   return (
     <SettingsItem
       label="Delete account"
-      description="Permanently delete your Namesake account and data."
+      description="Permanently delete your Namesake account."
     >
       <Button onPress={() => setIsDeleteAccountModalOpen(true)} icon={Trash}>
         Delete account

--- a/src/components/settings/EditBirthplaceSetting/EditBirthplaceSetting.tsx
+++ b/src/components/settings/EditBirthplaceSetting/EditBirthplaceSetting.tsx
@@ -55,7 +55,7 @@ export const EditBirthplaceSetting = ({ user }: EditBirthplaceSettingProps) => {
   return (
     <SettingsItem
       label="Birthplace"
-      description="Where were you born? This helps select the form for your birth certificate."
+      description="This helps select the form for your birth certificate."
     >
       <Form onSubmit={handleSubmit} className="gap-2 items-end">
         <Select

--- a/src/components/settings/EditResidenceSetting/EditResidenceSetting.tsx
+++ b/src/components/settings/EditResidenceSetting/EditResidenceSetting.tsx
@@ -57,7 +57,7 @@ export const EditResidenceSetting = ({ user }: EditResidenceSettingProps) => {
   return (
     <SettingsItem
       label="Residence"
-      description="This helps select the forms for your court order and state ID."
+      description="This helps select state‑specific forms."
     >
       <Form onSubmit={handleSubmit} className="gap-2 items-end">
         <Select

--- a/src/components/settings/EditResidenceSetting/EditResidenceSetting.tsx
+++ b/src/components/settings/EditResidenceSetting/EditResidenceSetting.tsx
@@ -57,7 +57,7 @@ export const EditResidenceSetting = ({ user }: EditResidenceSettingProps) => {
   return (
     <SettingsItem
       label="Residence"
-      description="Where do you live? This helps select the forms for your court order and state ID."
+      description="This helps select the forms for your court order and state ID."
     >
       <Form onSubmit={handleSubmit} className="gap-2 items-end">
         <Select

--- a/src/components/settings/EditThemeSetting/EditThemeSetting.tsx
+++ b/src/components/settings/EditThemeSetting/EditThemeSetting.tsx
@@ -33,9 +33,9 @@ export const EditThemeSetting = () => {
   });
 
   return (
-    <Card className="@container flex justify-center p-0">
-      <div className="flex flex-col @xl:flex-row gap-6 w-full">
-        <div className="flex flex-col gap-2 pt-6 px-6">
+    <Card className="@container px-0 pt-6 pb-4">
+      <div className="flex flex-col @[38rem]:flex-row justify-center gap-6 w-full min-w-0">
+        <div className="flex flex-col gap-2">
           <ToggleButtonGroup
             selectionMode="single"
             disallowEmptySelection
@@ -57,8 +57,8 @@ export const EditThemeSetting = () => {
             {THEMES[theme ?? "system"].label}
           </div>
         </div>
-        <div className="flex flex-col gap-2 pb-5">
-          <div className="overflow-x-auto px-4 w-full no-scrollbar">
+        <div className="flex flex-col gap-2">
+          <div className="overflow-x-auto px-4 @[38rem]:px-0 w-full no-scrollbar">
             <ToggleButtonGroup
               selectionMode="single"
               disallowEmptySelection

--- a/src/components/settings/EditThemeSetting/EditThemeSetting.tsx
+++ b/src/components/settings/EditThemeSetting/EditThemeSetting.tsx
@@ -16,7 +16,7 @@ export const EditThemeSetting = () => {
   };
 
   const swatchStyles = tv({
-    base: "w-full h-full rounded-full",
+    base: "size-full rounded-full",
     variants: {
       color: {
         rainbow: "bg-rainbow",
@@ -33,9 +33,9 @@ export const EditThemeSetting = () => {
   });
 
   return (
-    <Card className="@container flex justify-center pb-4">
-      <div className="flex flex-col @xl:flex-row gap-6">
-        <div className="flex flex-col gap-2">
+    <Card className="@container flex justify-center p-0">
+      <div className="flex flex-col @xl:flex-row gap-6 w-full">
+        <div className="flex flex-col gap-2 pt-6 px-6">
           <ToggleButtonGroup
             selectionMode="single"
             disallowEmptySelection
@@ -57,29 +57,31 @@ export const EditThemeSetting = () => {
             {THEMES[theme ?? "system"].label}
           </div>
         </div>
-        <div className="flex flex-col gap-2">
-          <ToggleButtonGroup
-            selectionMode="single"
-            disallowEmptySelection
-            selectedKeys={new Set([color ?? "violet"])}
-            onSelectionChange={handleColorChange}
-            className="w-max mx-auto rounded-full"
-          >
-            {Object.entries(THEME_COLORS).map(([themeColor, { label }]) => (
-              <ToggleButton
-                id={themeColor}
-                key={themeColor}
-                aria-label={label}
-                className="rounded-full p-2 w-10"
-              >
-                <div
-                  className={swatchStyles({
-                    color: themeColor as ThemeColor,
-                  })}
-                />
-              </ToggleButton>
-            ))}
-          </ToggleButtonGroup>
+        <div className="flex flex-col gap-2 pb-5">
+          <div className="overflow-x-auto px-4 w-full no-scrollbar">
+            <ToggleButtonGroup
+              selectionMode="single"
+              disallowEmptySelection
+              selectedKeys={new Set([color ?? "violet"])}
+              onSelectionChange={handleColorChange}
+              className="w-max mx-auto rounded-full"
+            >
+              {Object.entries(THEME_COLORS).map(([themeColor, { label }]) => (
+                <ToggleButton
+                  id={themeColor}
+                  key={themeColor}
+                  aria-label={label}
+                  className="rounded-full p-2 w-10"
+                >
+                  <div
+                    className={swatchStyles({
+                      color: themeColor as ThemeColor,
+                    })}
+                  />
+                </ToggleButton>
+              ))}
+            </ToggleButtonGroup>
+          </div>
           <div className="font-medium flex gap-2 justify-center">
             {THEME_COLORS[color ?? "violet"].label}
             <span className="italic text-dim">

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -90,3 +90,14 @@ body,
     -webkit-text-fill-color: inherit;
   }
 }
+
+@layer utilities {
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+}


### PR DESCRIPTION
## What changed?

Add scroll overflow.

https://github.com/user-attachments/assets/2b13197d-dc7a-4acf-9a71-447cb6fcc164

## Why?

This was happening:

![CleanShot 2025-06-11 at 22 28 28@2x](https://github.com/user-attachments/assets/fffc5d49-acc2-441b-8b1f-198663ebf08a)

## How was this change made?
Modified DOM.

## How was this tested?
Manual local testing.

## Anything else?
- Removed explicit meta `theme-color` from `head` to see if browsers will automatically match the color themes based on body background
- Shorten some settings descriptions
- Add `no-scrollbar` utility which hides the scrollbar from the browser