### PR TITLE
fix: Prevent Convex and Biome from fighting over `convex.json`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,7 @@
     "useIgnoreFile": true
   },
   "files": {
-    "ignore": ["convex/_generated", "routeTree.gen.ts"]
+    "ignore": ["convex/_generated", "routeTree.gen.ts", "convex.json"]
   },
   "formatter": {
     "enabled": true,

--- a/convex.json
+++ b/convex.json
@@ -1,5 +1,7 @@
 {
   "node": {
-    "externalPackages": ["@react-email/render"]
+    "externalPackages": [
+      "@react-email/render"
+    ]
   }
 }


### PR DESCRIPTION
## What changed?
Add `convex.json` to Biome's ignore list.

## Why?
Biome and Convex were conflicting on how `convex.json` should be formatted; one would format it and the other would revert it.