### PR TITLE
chore: Improve seed script

### DIFF
--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import { JURISDICTIONS } from "../src/constants";
 import { internalMutation } from "./_generated/server";
 
 const seed = internalMutation(async (ctx) => {
@@ -7,38 +7,96 @@ const seed = internalMutation(async (ctx) => {
     return;
   }
 
-  const users = await ctx.db.query("users").collect();
   const quests = await ctx.db.query("quests").collect();
-  if (users.length > 0 || quests.length > 0) {
-    console.error("Data already exists, skipping seeding");
-    return;
-  }
 
-  console.log("Seeding data...");
+  if (quests.length > 0) {
+    console.log("Quest data already exists, skipping seeding quests");
+  } else {
+    console.log("Seeding quest data...");
 
-  for (let i = 0; i < 10; i++) {
-    faker.seed();
+    const systemUserId = await ctx.db.insert("users", {
+      name: "System",
+      email: "system@namesake.fyi",
+      emailVerified: true,
+      role: "admin",
+    });
 
-    try {
-      const firstName = faker.person.firstName();
-      const lastName = faker.person.lastName();
-      await ctx.db.insert("users", {
-        name: firstName,
-        email: faker.internet.email({
-          firstName: firstName,
-          lastName: lastName,
-        }),
-        image: faker.image.avatar(),
-        role: "admin",
-        emailVerified: faker.datatype.boolean(),
+    console.log("Created system user");
+
+    for (const jurisdiction of Object.keys(JURISDICTIONS)) {
+      const slug = `court-order-${jurisdiction.toLowerCase()}`;
+
+      await ctx.db.insert("quests", {
+        title: "Court Order",
+        slug,
+        category: "courtOrder",
+        jurisdiction,
+        creationUser: systemUserId,
+        updatedAt: Date.now(),
+        updatedBy: systemUserId,
       });
-      console.log(`Created user ${firstName} ${lastName}`);
-    } catch (e) {
-      throw new Error(`Failed to seed data: ${e}`);
-    }
-  }
 
-  console.log("Finished seeding data");
+      console.log(
+        `Created quest: Court Order (${JURISDICTIONS[jurisdiction]})`,
+      );
+    }
+
+    for (const jurisdiction of Object.keys(JURISDICTIONS)) {
+      const slug = `state-id-${jurisdiction.toLowerCase()}`;
+
+      await ctx.db.insert("quests", {
+        title: "State ID",
+        slug,
+        category: "stateId",
+        jurisdiction,
+        creationUser: systemUserId,
+        updatedAt: Date.now(),
+        updatedBy: systemUserId,
+      });
+
+      console.log(`Created quest: State ID (${JURISDICTIONS[jurisdiction]})`);
+    }
+
+    for (const jurisdiction of Object.keys(JURISDICTIONS)) {
+      const slug = `birth-certificate-${jurisdiction.toLowerCase()}`;
+
+      await ctx.db.insert("quests", {
+        title: "Birth Certificate",
+        slug,
+        category: "birthCertificate",
+        jurisdiction,
+        creationUser: systemUserId,
+        updatedAt: Date.now(),
+        updatedBy: systemUserId,
+      });
+
+      console.log(
+        `Created quest: Birth Certificate (${JURISDICTIONS[jurisdiction]})`,
+      );
+    }
+
+    await ctx.db.insert("quests", {
+      title: "Social Security",
+      slug: "social-security",
+      category: "socialSecurity",
+      creationUser: systemUserId,
+      updatedAt: Date.now(),
+      updatedBy: systemUserId,
+    });
+
+    console.log("Created quest: Social Security");
+
+    await ctx.db.insert("quests", {
+      title: "US Passport",
+      slug: "passport",
+      category: "passport",
+      creationUser: systemUserId,
+      updatedAt: Date.now(),
+      updatedBy: systemUserId,
+    });
+
+    console.log("Created quest: Social Security");
+  }
 });
 
 export default seed;


### PR DESCRIPTION
## What changed?
Fixes #410 (partially). Seeds empty quests for all jurisdictions within all core categories.

## Why?
Make it easier to dev locally.

## Anything else?
Also removes the dummy users from the seed script, which weren't being used.