### PR TITLE
fix: Fix indicator sizing

### DIFF
--- a/.changeset/fair-ideas-pay.md
+++ b/.changeset/fair-ideas-pay.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix incorrect sizing of tab indicator

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -24,13 +24,6 @@ const tabsStyles = tv({
       horizontal: "flex-col",
       vertical: "flex-row w-[800px]",
     },
-    size: {
-      small: "gap-2",
-      medium: "gap-4",
-    },
-  },
-  defaultVariants: {
-    size: "medium",
   },
 });
 
@@ -58,10 +51,6 @@ const tabListStyles = tv({
       horizontal: "grid-flow-col auto-cols-fr",
       vertical: "grid-flow-row auto-rows-fr",
     },
-    size: {
-      small: "gap-2",
-      medium: "gap-4",
-    },
   },
 });
 
@@ -70,7 +59,6 @@ export function TabList<T extends object>({
   ...props
 }: TabListProps<T>) {
   const state = use(TabListStateContext);
-  const size = useContext(TabsSizeContext);
 
   const tabList = state?.collection;
   const activeTab = state?.selectedKey ?? "";
@@ -84,7 +72,7 @@ export function TabList<T extends object>({
       className={composeRenderProps(
         `${className} ${styles["tab-list"]}`,
         (className, renderProps) =>
-          tabListStyles({ ...renderProps, size, className }),
+          tabListStyles({ ...renderProps, className }),
       )}
       style={{
         ["--count" as string]: count,


### PR DESCRIPTION
## What changed?
Fixes #634.

![CleanShot 2025-06-22 at 17 03 49@2x](https://github.com/user-attachments/assets/f71f6453-90d9-40a9-8887-4d582b558da4)

## Why?
A gap was introduced to the tabs which shouldn't have been. This removes the gap.

## How was this change made?
Deleted "size" prop from tab container styles where it wasn't necessary.

## How was this tested?
Manual / visual testing.