### PR TITLE
fix: Form width overflow

### DIFF
--- a/.changeset/fluffy-pigs-give.md
+++ b/.changeset/fluffy-pigs-give.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Prevent multi-column address fields from overflowing width on mobile

--- a/src/components/forms/AddressField/AddressField.tsx
+++ b/src/components/forms/AddressField/AddressField.tsx
@@ -68,8 +68,8 @@ export function AddressField({
   };
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="grid gap-4 grid-cols-[1fr_auto] [grid-template-areas:'street_street''city_city''state_zip''county_county']">
+    <div className="flex flex-col gap-4 @container">
+      <div className="grid gap-4 grid-cols-[1fr_auto] [grid-template-areas:'street_street''city_city''state_state''zip_zip''county_county'] @md:[grid-template-areas:'street_street''city_city''state_zip''county_county']">
         <Controller
           control={control}
           name={names[type].street}


### PR DESCRIPTION
## What changed?
Address fields were overflowing on mobile following #588. This fixes it.

## Why?
The new `Combobox` did not shrink as much as the previous `Select`, leading to page overflow.

## How was this change made?
Updated the address field display logic to put ZIP on its on line for narrow viewports instead of continuing to use a two-column layout.

## How was this tested?
Manually with Simulator.