### PR TITLE
fix: HTTP actions subdomain

### DIFF
--- a/.changeset/common-jars-read.md
+++ b/.changeset/common-jars-read.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Resolve HTTP actions requests to proper subdomain

--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 AUTH_RESEND_KEY=
 AUTH_EMAIL=no-reply@namesake.fyi
-VITE_CONVEX_URL=https://convex.namesake.fyi
+VITE_CONVEX_URL=https://actions.namesake.fyi
 VITE_CONVEX_SITE_URL=https://api.namesake.fyi
 VITE_REACT_APP_PUBLIC_POSTHOG_KEY=phc_BZLdVJiV451pPNUSXFQL7vlYOZN1Y6MwGhH7QrIQOTp
 VITE_REACT_APP_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 AUTH_RESEND_KEY=
 AUTH_EMAIL=no-reply@namesake.fyi
-VITE_CONVEX_URL=https://actions.namesake.fyi
-VITE_CONVEX_SITE_URL=https://api.namesake.fyi
+VITE_CONVEX_URL=https://api.namesake.fyi
+VITE_CONVEX_SITE_URL=https://actions.namesake.fyi
 VITE_REACT_APP_PUBLIC_POSTHOG_KEY=phc_BZLdVJiV451pPNUSXFQL7vlYOZN1Y6MwGhH7QrIQOTp
 VITE_REACT_APP_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -16,10 +16,10 @@ import * as AuthModel from "./model/authModel";
 
 const resend = new Resend(process.env.AUTH_RESEND_KEY);
 
-const actionsEndpoint =
+const siteUrl =
   process.env.NODE_ENV === "development"
     ? "http://localhost:5173"
-    : process.env.CONVEX_SITE_URL || "https://actions.namesake.fyi";
+    : "https://app.namesake.fyi";
 
 const trustedOrigins = [
   "http://localhost:5173",
@@ -37,7 +37,7 @@ export const betterAuthComponent = new BetterAuth(components.betterAuth, {
 export const createAuth = (ctx: GenericCtx) =>
   betterAuth({
     database: convexAdapter(ctx, betterAuthComponent),
-    plugins: [convex(), crossDomain({ siteUrl: actionsEndpoint })],
+    plugins: [convex(), crossDomain({ siteUrl })],
     emailAndPassword: {
       enabled: true,
       sendResetPassword: async ({ user, url }, _request) => {

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -19,18 +19,14 @@ const resend = new Resend(process.env.AUTH_RESEND_KEY);
 const siteUrl =
   process.env.NODE_ENV === "development"
     ? "http://localhost:5173"
-    : process.env.CONVEX_SITE_URL || "https://api.namesake.fyi";
-
-console.log("crossDomain siteUrl", siteUrl);
+    : process.env.CONVEX_SITE_URL || "https://actions.namesake.fyi";
 
 const trustedOrigins = [
   "http://localhost:5173",
   "https://app.namesake.fyi",
   process.env.CONVEX_CLOUD_URL || "https://api.namesake.fyi",
-  process.env.CONVEX_SITE_URL || "https://convex.namesake.fyi",
+  process.env.CONVEX_SITE_URL || "https://actions.namesake.fyi",
 ];
-
-console.log("trustedOrigins", trustedOrigins);
 
 // Typesafe way to pass the functions below into the component
 const authFunctions: AuthFunctions = internal.auth;

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -16,7 +16,7 @@ import * as AuthModel from "./model/authModel";
 
 const resend = new Resend(process.env.AUTH_RESEND_KEY);
 
-const siteUrl =
+const actionsEndpoint =
   process.env.NODE_ENV === "development"
     ? "http://localhost:5173"
     : process.env.CONVEX_SITE_URL || "https://actions.namesake.fyi";
@@ -28,10 +28,8 @@ const trustedOrigins = [
   process.env.CONVEX_SITE_URL || "https://actions.namesake.fyi",
 ];
 
-// Typesafe way to pass the functions below into the component
 const authFunctions: AuthFunctions = internal.auth;
 
-// Initialize the component
 export const betterAuthComponent = new BetterAuth(components.betterAuth, {
   authFunctions,
 });
@@ -39,7 +37,7 @@ export const betterAuthComponent = new BetterAuth(components.betterAuth, {
 export const createAuth = (ctx: GenericCtx) =>
   betterAuth({
     database: convexAdapter(ctx, betterAuthComponent),
-    plugins: [convex(), crossDomain({ siteUrl })],
+    plugins: [convex(), crossDomain({ siteUrl: actionsEndpoint })],
     emailAndPassword: {
       enabled: true,
       sendResetPassword: async ({ user, url }, _request) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,7 +24,6 @@ const deploymentURL = import.meta.env.VITE_CONVEX_URL;
 const convex = new ConvexReactClient(deploymentURL);
 
 const baseURL = import.meta.env.VITE_CONVEX_SITE_URL;
-console.log("authClient baseURL (VITE_CONVEX_SITE_URL)", baseURL);
 
 export const authClient = createAuthClient({
   baseURL,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,13 +20,12 @@ import { Empty } from "@/components/common";
 import type { Role } from "@/constants";
 import { routeTree } from "./routeTree.gen";
 
-const deploymentURL = import.meta.env.VITE_CONVEX_URL;
-const convex = new ConvexReactClient(deploymentURL);
+const apiEndpoint = import.meta.env.VITE_CONVEX_URL;
+const convex = new ConvexReactClient(apiEndpoint);
 
-const baseURL = import.meta.env.VITE_CONVEX_SITE_URL;
-
+const actionsEndpoint = import.meta.env.VITE_CONVEX_SITE_URL;
 export const authClient = createAuthClient({
-  baseURL,
+  baseURL: actionsEndpoint,
   plugins: [convexClient(), crossDomainClient()],
 });
 


### PR DESCRIPTION
## What changed?
- Updates/renames the `convex.namesake` subdomain to `actions.namesake` for clarity.
- Fixes auth setup to point to the HTTP actions subdomain rather than the Convex API subdomain

## Why?
Environments, man.