### PR TITLE
chore: Improve chunking and dynamically load certain imports

### DIFF
--- a/.changeset/giant-animals-thank.md
+++ b/.changeset/giant-animals-thank.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Reduce initial bundle size and dynamically load utilities more intelligently to improve app speed

--- a/src/components/app/SignInWrapper/SignInWrapper.tsx
+++ b/src/components/app/SignInWrapper/SignInWrapper.tsx
@@ -8,7 +8,7 @@ interface SignInWrapperProps {
 
 export const SignInWrapper = ({ children, className }: SignInWrapperProps) => {
   return (
-    <div className="flex flex-col w-96 max-w-full mx-auto min-h-dvh items-center justify-center gap-8 p-4">
+    <div className="flex flex-col w-96 max-w-full mx-auto min-h-dvh items-center justify-center gap-8 px-6 py-12">
       <Link href="https://namesake.fyi">
         <Logo />
       </Link>

--- a/src/components/forms/AddressField/AddressField.tsx
+++ b/src/components/forms/AddressField/AddressField.tsx
@@ -55,7 +55,6 @@ export function AddressField({
       return;
     }
 
-    // Dynamically import typed-usa-states only when counties are needed
     import(/* webpackChunkName: "usa-states" */ "typed-usa-states")
       .then((module) => {
         const state = module.usaStatesWithCounties.find(
@@ -66,7 +65,6 @@ export function AddressField({
         }
       })
       .catch(() => {
-        // Handle import error gracefully
         setCounties([]);
       });
   }, [includeCounty, selectedState]);

--- a/src/components/forms/AddressField/AddressField.tsx
+++ b/src/components/forms/AddressField/AddressField.tsx
@@ -55,7 +55,7 @@ export function AddressField({
       return;
     }
 
-    import(/* webpackChunkName: "usa-states" */ "typed-usa-states")
+    import("typed-usa-states")
       .then((module) => {
         const state = module.usaStatesWithCounties.find(
           (state) => state.abbreviation === selectedState,

--- a/src/components/forms/AddressField/AddressField.tsx
+++ b/src/components/forms/AddressField/AddressField.tsx
@@ -2,7 +2,6 @@ import type { MaskitoOptions } from "@maskito/core";
 import { maskitoTransform } from "@maskito/core";
 import { useEffect, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
-import { usaStatesWithCounties } from "typed-usa-states";
 import { ComboBox, ComboBoxItem, TextField } from "@/components/common";
 import { type FieldName, JURISDICTIONS } from "@/constants";
 
@@ -51,14 +50,25 @@ export function AddressField({
   const selectedState = watch(names[type].state);
 
   useEffect(() => {
-    if (!includeCounty || !selectedState) setCounties([]);
-
-    const state = usaStatesWithCounties.find(
-      (state) => state.abbreviation === selectedState,
-    );
-    if (state) {
-      setCounties(state.counties ?? []);
+    if (!includeCounty || !selectedState) {
+      setCounties([]);
+      return;
     }
+
+    // Dynamically import typed-usa-states only when counties are needed
+    import(/* webpackChunkName: "usa-states" */ "typed-usa-states")
+      .then((module) => {
+        const state = module.usaStatesWithCounties.find(
+          (state) => state.abbreviation === selectedState,
+        );
+        if (state) {
+          setCounties(state.counties ?? []);
+        }
+      })
+      .catch(() => {
+        // Handle import error gracefully
+        setCounties([]);
+      });
   }, [includeCounty, selectedState]);
 
   // Input mask: enforce ZIP code format of 12345-1234

--- a/src/forms/__tests__/utils.test.ts
+++ b/src/forms/__tests__/utils.test.ts
@@ -11,7 +11,6 @@ import {
   loadPdfs,
 } from "../utils";
 
-// Mock getPdfDefinition from @/forms
 vi.mock("@/forms", () => ({
   getPdfDefinition: vi.fn(),
 }));

--- a/src/forms/__tests__/utils.test.ts
+++ b/src/forms/__tests__/utils.test.ts
@@ -8,7 +8,15 @@ import {
   fetchPdf,
   fillPdf,
   getPdfForm,
+  loadPdfs,
 } from "../utils";
+
+// Mock getPdfDefinition from @/forms
+vi.mock("@/forms", () => ({
+  getPdfDefinition: vi.fn(),
+}));
+
+import { getPdfDefinition } from "@/forms";
 
 describe("PDF utilities", () => {
   const testPdfDefinition = definePdf({
@@ -415,6 +423,97 @@ describe("PDF utilities", () => {
       expect(fetch).toHaveBeenCalledWith("public/forms/test-form.pdf");
       expect(fetch).toHaveBeenCalledWith("public/forms/test-form-2.pdf");
       expect(fetch).toHaveBeenCalledWith("/forms/pdf-cover-logo.png");
+    });
+  });
+
+  describe("loadPdfs", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("should load PDFs for all included pdfIds", async () => {
+      const mockPdf1 = {
+        id: "test-form-1" as any,
+        title: "Test Form 1",
+        jurisdiction: "MA",
+        pdfPath: "public/forms/test-form-1.pdf",
+        fields: () => ({}),
+      };
+
+      const mockPdf2 = {
+        id: "test-form-2" as any,
+        title: "Test Form 2",
+        jurisdiction: "MA",
+        pdfPath: "public/forms/test-form-2.pdf",
+        fields: () => ({}),
+      };
+
+      (getPdfDefinition as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(mockPdf1)
+        .mockResolvedValueOnce(mockPdf2);
+
+      const result = await loadPdfs([
+        { pdfId: "test-form-1" as any },
+        { pdfId: "test-form-2" as any },
+      ]);
+
+      expect(result).toEqual([mockPdf1, mockPdf2]);
+      expect(getPdfDefinition).toHaveBeenCalledTimes(2);
+      expect(getPdfDefinition).toHaveBeenCalledWith("test-form-1");
+      expect(getPdfDefinition).toHaveBeenCalledWith("test-form-2");
+    });
+
+    it("should exclude PDFs when include is false", async () => {
+      const mockPdf = {
+        id: "test-form-1" as any,
+        title: "Test Form 1",
+        jurisdiction: "MA",
+        pdfPath: "public/forms/test-form-1.pdf",
+        fields: () => ({}),
+      };
+
+      (getPdfDefinition as ReturnType<typeof vi.fn>).mockResolvedValue(mockPdf);
+
+      const result = await loadPdfs([
+        { pdfId: "test-form-1" as any, include: true },
+        { pdfId: "test-form-2" as any, include: false },
+        { pdfId: "test-form-3" as any }, // defaults to true
+      ]);
+
+      expect(result).toHaveLength(2);
+      expect(getPdfDefinition).toHaveBeenCalledTimes(2);
+      expect(getPdfDefinition).toHaveBeenCalledWith("test-form-1");
+      expect(getPdfDefinition).toHaveBeenCalledWith("test-form-3");
+      expect(getPdfDefinition).not.toHaveBeenCalledWith("test-form-2");
+    });
+
+    it("should return empty array when all PDFs are excluded", async () => {
+      const result = await loadPdfs([
+        { pdfId: "test-form-1" as any, include: false },
+        { pdfId: "test-form-2" as any, include: false },
+      ]);
+
+      expect(result).toEqual([]);
+      expect(getPdfDefinition).not.toHaveBeenCalled();
+    });
+
+    it("should handle empty input array", async () => {
+      const result = await loadPdfs([]);
+
+      expect(result).toEqual([]);
+      expect(getPdfDefinition).not.toHaveBeenCalled();
+    });
+
+    it("should handle getPdfDefinition errors", async () => {
+      (getPdfDefinition as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("PDF not found"),
+      );
+
+      await expect(
+        loadPdfs([{ pdfId: "nonexistent-form" as any }]),
+      ).rejects.toThrow("PDF not found");
+
+      expect(getPdfDefinition).toHaveBeenCalledWith("nonexistent-form");
     });
   });
 });

--- a/src/hooks/usePasswordStrength.ts
+++ b/src/hooks/usePasswordStrength.ts
@@ -1,34 +1,38 @@
 import { type ZxcvbnResult, zxcvbnAsync, zxcvbnOptions } from "@zxcvbn-ts/core";
 import { useDeferredValue, useEffect, useState } from "react";
 
-const loadOptions = async () => {
-  const zxcvbnCommonPackage = await import(
-    /* webpackChunkName: "zxcvbnCommonPackage" */ "@zxcvbn-ts/language-common"
-  );
-  const zxcvbnEnPackage = await import(
-    /* webpackChunkName: "zxcvbnEnPackage" */ "@zxcvbn-ts/language-en"
-  );
-  return {
-    dictionary: {
-      ...zxcvbnCommonPackage.dictionary,
-      ...zxcvbnEnPackage.dictionary,
-    },
-    translations: zxcvbnEnPackage.translations,
-  };
-};
-
-loadOptions().then((options) => {
-  zxcvbnOptions.setOptions(options);
-});
-
 export function usePasswordStrength(password: string) {
   const [result, setResult] = useState<ZxcvbnResult>();
   const deferredPassword = useDeferredValue(password);
 
+  const loadOptions = async () => {
+    const zxcvbnCommonPackage = await import(
+      /* webpackChunkName: "zxcvbnCommonPackage" */ "@zxcvbn-ts/language-common"
+    );
+    const zxcvbnEnPackage = await import(
+      /* webpackChunkName: "zxcvbnEnPackage" */ "@zxcvbn-ts/language-en"
+    );
+
+    return {
+      dictionary: {
+        ...zxcvbnCommonPackage.default.dictionary,
+        ...zxcvbnEnPackage.default.dictionary,
+      },
+      graphs: zxcvbnCommonPackage.default.adjacencyGraphs,
+      translations: zxcvbnEnPackage.default.translations,
+    };
+  };
+
   useEffect(() => {
-    if (password) {
-      zxcvbnAsync(deferredPassword).then((response) => setResult(response));
+    if (!password) {
+      setResult(undefined);
+      return;
     }
+
+    loadOptions().then((options) => {
+      zxcvbnOptions.setOptions(options);
+      zxcvbnAsync(deferredPassword).then((response) => setResult(response));
+    });
   }, [password, deferredPassword]);
 
   return result;

--- a/src/hooks/usePasswordStrength.ts
+++ b/src/hooks/usePasswordStrength.ts
@@ -1,38 +1,30 @@
 import { type ZxcvbnResult, zxcvbnAsync, zxcvbnOptions } from "@zxcvbn-ts/core";
 import { useDeferredValue, useEffect, useState } from "react";
 
+const loadOptions = async () => {
+  const zxcvbnCommonPackage = await import("@zxcvbn-ts/language-common");
+  const zxcvbnEnPackage = await import("@zxcvbn-ts/language-en");
+  return {
+    dictionary: {
+      ...zxcvbnCommonPackage.dictionary,
+      ...zxcvbnEnPackage.dictionary,
+    },
+    translations: zxcvbnEnPackage.translations,
+  };
+};
+
+loadOptions().then((options) => {
+  zxcvbnOptions.setOptions(options);
+});
+
 export function usePasswordStrength(password: string) {
   const [result, setResult] = useState<ZxcvbnResult>();
   const deferredPassword = useDeferredValue(password);
 
-  const loadOptions = async () => {
-    const zxcvbnCommonPackage = await import(
-      /* webpackChunkName: "zxcvbnCommonPackage" */ "@zxcvbn-ts/language-common"
-    );
-    const zxcvbnEnPackage = await import(
-      /* webpackChunkName: "zxcvbnEnPackage" */ "@zxcvbn-ts/language-en"
-    );
-
-    return {
-      dictionary: {
-        ...zxcvbnCommonPackage.default.dictionary,
-        ...zxcvbnEnPackage.default.dictionary,
-      },
-      graphs: zxcvbnCommonPackage.default.adjacencyGraphs,
-      translations: zxcvbnEnPackage.default.translations,
-    };
-  };
-
   useEffect(() => {
-    if (!password) {
-      setResult(undefined);
-      return;
-    }
-
-    loadOptions().then((options) => {
-      zxcvbnOptions.setOptions(options);
+    if (password) {
       zxcvbnAsync(deferredPassword).then((response) => setResult(response));
-    });
+    }
   }, [password, deferredPassword]);
 
   return result;

--- a/src/routes/_authenticated/forms/ma-court-order.tsx
+++ b/src/routes/_authenticated/forms/ma-court-order.tsx
@@ -23,12 +23,7 @@ import {
 } from "@/components/forms";
 import { QuestCostsTable } from "@/components/quests";
 import { BIRTHPLACES, type FieldName, type FieldType } from "@/constants";
-import affidavitOfIndigency from "@/forms/ma/affidavit-of-indigency";
-import cjd400MotionToImpound from "@/forms/ma/cjd400-motion-to-impound";
-import cjd400MotionToWaivePublication from "@/forms/ma/cjd400-motion-to-waive-publication";
-import cjp27PetitionToChangeNameOfAdult from "@/forms/ma/cjp27-petition-to-change-name-of-adult";
-import cjp34CoriAndWmsReleaseRequest from "@/forms/ma/cjp34-cori-and-wms-release-request";
-import { downloadMergedPdf } from "@/forms/utils";
+import { downloadMergedPdf, loadPdfs } from "@/forms/utils";
 import { useForm } from "@/hooks/useForm";
 
 export const Route = createFileRoute("/_authenticated/forms/ma-court-order")({
@@ -91,22 +86,22 @@ function RouteComponent() {
     event.preventDefault();
 
     try {
-      const pdfs = [
-        cjp27PetitionToChangeNameOfAdult,
-        cjp34CoriAndWmsReleaseRequest,
-      ];
-
-      if (form.watch("shouldWaivePublicationRequirement") === true) {
-        pdfs.push(cjd400MotionToWaivePublication);
-      }
-
-      if (form.watch("shouldImpoundCourtRecords") === true) {
-        pdfs.push(cjd400MotionToImpound);
-      }
-
-      if (form.watch("shouldApplyForFeeWaiver") === true) {
-        pdfs.push(affidavitOfIndigency);
-      }
+      const pdfs = await loadPdfs([
+        { pdfId: "cjp27-petition-to-change-name-of-adult" },
+        { pdfId: "cjp34-cori-and-wms-release-request" },
+        {
+          pdfId: "cjd400-motion-to-waive-publication",
+          include: form.watch("shouldWaivePublicationRequirement") === true,
+        },
+        {
+          pdfId: "cjd400-motion-to-impound-records",
+          include: form.watch("shouldImpoundCourtRecords") === true,
+        },
+        {
+          pdfId: "affidavit-of-indigency",
+          include: form.watch("shouldApplyForFeeWaiver") === true,
+        },
+      ]);
 
       await downloadMergedPdf({
         title: "Massachusetts Court Order",

--- a/src/routes/_authenticated/forms/social-security.tsx
+++ b/src/routes/_authenticated/forms/social-security.tsx
@@ -25,8 +25,7 @@ import {
   type FieldName,
   type FieldType,
 } from "@/constants";
-import ss5ApplicationForSocialSecurityCard from "@/forms/federal/ss5-application-for-social-security-card";
-import { downloadMergedPdf } from "@/forms/utils";
+import { downloadMergedPdf, loadPdfs } from "@/forms/utils";
 import { useForm } from "@/hooks/useForm";
 
 export const Route = createFileRoute("/_authenticated/forms/social-security")({
@@ -77,7 +76,9 @@ function RouteComponent() {
     event.preventDefault();
 
     try {
-      const pdfs = [ss5ApplicationForSocialSecurityCard];
+      const pdfs = await loadPdfs([
+        { pdfId: "ss5-application-for-social-security-card" },
+      ]);
 
       await downloadMergedPdf({
         title: "Social Security Card",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,89 @@ export default defineConfig({
         assetFileNames: "assets/[name].[hash][extname]",
         chunkFileNames: "assets/[name].[hash].js",
         entryFileNames: "assets/[name].[hash].js",
+        manualChunks(id: string) {
+          // Convex
+          if (
+            id.includes("convex") ||
+            id.includes("convex-helpers") ||
+            id.includes("@convex-dev") ||
+            id.includes("better-auth")
+          ) {
+            return "convex";
+          }
+
+          // Core component primitives
+          if (
+            id.includes("@radix-ui") ||
+            id.includes("react-aria") ||
+            id.includes("react-aria-components")
+          ) {
+            return "react-aria";
+          }
+
+          // Styling and animation utilities
+          if (
+            id.includes("motion") ||
+            id.includes("tw-animate-css") ||
+            id.includes("tailwind") ||
+            id.includes("tailwind-merge") ||
+            id.includes("tailwind-variants") ||
+            id.includes("tailwindcss")
+          ) {
+            return "ui-styling";
+          }
+
+          // Icons and visual components
+          if (
+            id.includes("@maskito") ||
+            id.includes("lucide-react") ||
+            id.includes("react-random-reveal") ||
+            id.includes("sonner")
+          ) {
+            return "ui-components";
+          }
+
+          // Tiptap Editor
+          if (
+            id.includes("@tiptap") ||
+            id.includes("@namesake/tiptap-extensions")
+          ) {
+            return "@tiptap";
+          }
+
+          // Password core and common dictionaries
+          if (
+            id.includes("@zxcvbn-ts/core") ||
+            id.includes("@zxcvbn-ts/language-common")
+          ) {
+            return "zxcvbn-core";
+          }
+
+          // Password english dictionary (large!)
+          if (id.includes("@zxcvbn-ts/language-en")) {
+            return "zxcvbn-en";
+          }
+
+          // USA states and counties dictionary
+          if (id.includes("typed-usa-states")) {
+            return "usa-states";
+          }
+
+          // Language name mappings dictionary
+          if (id.includes("language-name-map")) {
+            return "language-names";
+          }
+
+          // PDF lib
+          if (id.includes("@cantoo/pdf-lib")) {
+            return "pdf";
+          }
+
+          // Analytics
+          if (id.includes("posthog-js")) {
+            return "analytics";
+          }
+        },
       },
     },
   },


### PR DESCRIPTION
## What changed?

Split the main bundle into multiple smaller chunks that can be loaded asynchronously.

| Before | After |
|--------|--------|
| ![CleanShot 2025-06-24 at 14 23 42@2x](https://github.com/user-attachments/assets/5effe339-2d8e-4d2b-a72e-33d85dcdc5c1) | ![CleanShot 2025-06-24 at 14 22 01@2x](https://github.com/user-attachments/assets/e13569ef-7a58-40ba-83a2-19335ceae29e) |
| ![CleanShot 2025-06-24 at 14 23 07@2x](https://github.com/user-attachments/assets/864ad0e3-4681-4c58-8537-f50b103663c8) | ![CleanShot 2025-06-24 at 14 21 21@2x](https://github.com/user-attachments/assets/32d88f72-62bb-460f-ab65-fec89ca40beb) | 

## Why?
Running `npx vite-bundle-visualizer` surfaced a warning about chunks larger than 500kb, and indeed, most of the application was contained in two large `index` chunks, one 1,216.42 kB and one 2,776.07 kB.

This unnecessarily loaded libraries like `typed-usa-states` (used for the State and County select component) and `language-name-map` (language select) along with larger utilities like `pdf-lib` even if they were not used.

## How was this change made?
1. Used dynamic imports for certain components to prevent their library being loaded until the component is invoked (`typed-usa-states`, `pdf-lib`)
2. Specified manual chunks to use when building with Vite, causing the chunks to only load if necessary instead of all being bundled and downloaded at once

## How was this tested?
All existing tests pass, manually verified that PDF downloads work.

## Anything else?
Yay performance 🚀 