### PR TITLE
fix: Re-add missing placeholder call-to-action

### DIFF
--- a/.changeset/hot-guests-act.md
+++ b/.changeset/hot-guests-act.md
@@ -1,0 +1,5 @@
+---
+"namesake": patch
+---
+
+Fix missing call-to-action button for quests not on a user's list

--- a/src/components/quests/QuestCallToAction/QuestCallToAction.test.tsx
+++ b/src/components/quests/QuestCallToAction/QuestCallToAction.test.tsx
@@ -180,4 +180,39 @@ describe("QuestCallToAction", () => {
     expect(loadingButton).toBeDisabled();
     expect(loadingButton).toHaveClass("w-64");
   });
+
+  it("shows 'Add to my quests' button when userQuest is null", () => {
+    render(
+      <QuestCallToAction
+        data={{ quest: mockQuest, userQuest: null }}
+        onAddQuest={mockOnAddQuest}
+      />,
+    );
+    expect(screen.getByText("Add to my quests")).toBeInTheDocument();
+  });
+
+  it("shows 'Add to my quests' button when userQuest is undefined", () => {
+    render(
+      <QuestCallToAction
+        data={{ quest: mockQuest, userQuest: undefined }}
+        onAddQuest={mockOnAddQuest}
+      />,
+    );
+    expect(screen.getByText("Add to my quests")).toBeInTheDocument();
+  });
+
+  it("handles adding to my quests when userQuest is null", async () => {
+    const user = userEvent.setup();
+    mockOnAddQuest.mockResolvedValueOnce(undefined);
+
+    render(
+      <QuestCallToAction
+        data={{ quest: mockQuest, userQuest: null }}
+        onAddQuest={mockOnAddQuest}
+      />,
+    );
+    await user.click(screen.getByText("Add to my quests"));
+
+    expect(mockOnAddQuest).toHaveBeenCalled();
+  });
 });

--- a/src/components/quests/QuestCallToAction/QuestCallToAction.tsx
+++ b/src/components/quests/QuestCallToAction/QuestCallToAction.tsx
@@ -141,7 +141,11 @@ const QuestCTAButton = ({
         ? data.userQuest?.completedAt
         : undefined;
 
-  if ("quest" in data && !("userQuest" in data) && onAddQuest) {
+  if (
+    "quest" in data &&
+    (!("userQuest" in data) || !data.userQuest) &&
+    onAddQuest
+  ) {
     return (
       <Button
         className={sharedButtonStyles()}


### PR DESCRIPTION
## What changed?
#659 refactored `QuestCallToAction` which introduced a regression to the "Add to my quests" button. This fixes it.

## How was this tested?
Adds a new test to validate this issue doesn't recur. Validated manually.