### PR TITLE
feat: Add new `Tree` component from React Aria

### DIFF
--- a/src/components/common/Checkbox/Checkbox.tsx
+++ b/src/components/common/Checkbox/Checkbox.tsx
@@ -68,7 +68,7 @@ const checkboxStyles = tv({
 
 const boxStyles = tv({
   extend: focusRing,
-  base: "size-6 shrink-0 rounded-sm flex items-center justify-center border transition",
+  base: "size-6 shrink-0 rounded-md flex items-center justify-center border transition",
   variants: {
     isSelected: {
       false: "bg-element border-dim",

--- a/src/components/common/Tree/Tree.stories.tsx
+++ b/src/components/common/Tree/Tree.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta } from "@storybook/react-vite";
+import {
+  Code,
+  File,
+  FileText,
+  Folder,
+  FolderOpen,
+  Image,
+  Music,
+  Video,
+} from "lucide-react";
+import { Tree, TreeItem } from "./Tree";
+
+const meta: Meta<typeof Tree> = {
+  component: Tree,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+export const Example = (args: any) => (
+  <Tree
+    aria-label="Files"
+    style={{ height: "400px", width: "300px" }}
+    {...args}
+  >
+    <TreeItem id="documents" label="Documents">
+      <TreeItem id="project" label="Project" />
+    </TreeItem>
+    <TreeItem id="photos" label="Photos">
+      <TreeItem id="one" label="Image 1" />
+      <TreeItem id="two" label="Image 2" />
+    </TreeItem>
+  </Tree>
+);
+
+Example.args = {
+  onAction: null,
+  defaultExpandedKeys: ["documents", "photos", "project"],
+  selectionMode: "multiple",
+  defaultSelectedKeys: ["project"],
+};
+
+export const DisabledItems = (args: any) => <Example {...args} />;
+DisabledItems.args = {
+  ...Example.args,
+  disabledKeys: ["photos"],
+};
+
+export const WithIcons = (args: any) => (
+  <Tree
+    aria-label="File Explorer"
+    style={{ height: "400px", width: "350px" }}
+    {...args}
+  >
+    <TreeItem id="documents" label="Documents" icon={[Folder, FolderOpen]}>
+      <TreeItem id="readme" label="README.md" icon={FileText} />
+      <TreeItem id="config" label="config.json" icon={Code} />
+    </TreeItem>
+    <TreeItem id="media" label="Media" icon={[Folder, FolderOpen]}>
+      <TreeItem id="images" label="Images" icon={[Folder, FolderOpen]}>
+        <TreeItem id="photo1" label="vacation.jpg" icon={Image} />
+        <TreeItem id="photo2" label="portrait.png" icon={Image} />
+      </TreeItem>
+      <TreeItem id="audio" label="Audio" icon={[Folder, FolderOpen]}>
+        <TreeItem id="song1" label="favorite.mp3" icon={Music} />
+        <TreeItem id="song2" label="podcast.wav" icon={Music} />
+      </TreeItem>
+      <TreeItem id="video1" label="presentation.mp4" icon={Video} />
+    </TreeItem>
+    <TreeItem id="project" label="Project Files" icon={[Folder, FolderOpen]}>
+      <TreeItem id="src" label="src" icon={[Folder, FolderOpen]}>
+        <TreeItem id="main" label="main.tsx" icon={Code} />
+        <TreeItem id="utils" label="utils.ts" icon={Code} />
+      </TreeItem>
+      <TreeItem id="package" label="package.json" icon={File} />
+    </TreeItem>
+  </Tree>
+);
+
+WithIcons.args = {
+  onAction: null,
+  defaultExpandedKeys: ["documents", "media", "images", "project"],
+  selectionMode: "none",
+  defaultSelectedKeys: ["readme", "photo1"],
+};

--- a/src/components/common/Tree/Tree.stories.tsx
+++ b/src/components/common/Tree/Tree.stories.tsx
@@ -22,11 +22,7 @@ const meta: Meta<typeof Tree> = {
 export default meta;
 
 export const Example = (args: any) => (
-  <Tree
-    aria-label="Files"
-    style={{ height: "400px", width: "300px" }}
-    {...args}
-  >
+  <Tree title="Files" style={{ height: "400px", width: "300px" }} {...args}>
     <TreeItem id="documents" label="Documents">
       <TreeItem id="project" label="Project" />
     </TreeItem>
@@ -52,31 +48,41 @@ DisabledItems.args = {
 
 export const WithIcons = (args: any) => (
   <Tree
-    aria-label="File Explorer"
+    title="File Explorer"
     style={{ height: "400px", width: "350px" }}
     {...args}
   >
-    <TreeItem id="documents" label="Documents" icon={[Folder, FolderOpen]}>
-      <TreeItem id="readme" label="README.md" icon={FileText} />
-      <TreeItem id="config" label="config.json" icon={Code} />
+    <TreeItem
+      id="documents"
+      label="Documents"
+      icon={[Folder, FolderOpen]}
+      href="/"
+    >
+      <TreeItem id="readme" label="README.md" icon={FileText} href="/" />
+      <TreeItem id="config" label="config.json" icon={Code} href="/" />
     </TreeItem>
-    <TreeItem id="media" label="Media" icon={[Folder, FolderOpen]}>
-      <TreeItem id="images" label="Images" icon={[Folder, FolderOpen]}>
-        <TreeItem id="photo1" label="vacation.jpg" icon={Image} />
-        <TreeItem id="photo2" label="portrait.png" icon={Image} />
+    <TreeItem id="media" label="Media" icon={[Folder, FolderOpen]} href="/">
+      <TreeItem id="images" label="Images" icon={[Folder, FolderOpen]} href="/">
+        <TreeItem id="photo1" label="vacation.jpg" icon={Image} href="/" />
+        <TreeItem id="photo2" label="portrait.png" icon={Image} href="/" />
       </TreeItem>
-      <TreeItem id="audio" label="Audio" icon={[Folder, FolderOpen]}>
-        <TreeItem id="song1" label="favorite.mp3" icon={Music} />
-        <TreeItem id="song2" label="podcast.wav" icon={Music} />
+      <TreeItem id="audio" label="Audio" icon={[Folder, FolderOpen]} href="/">
+        <TreeItem id="song1" label="favorite.mp3" icon={Music} href="/" />
+        <TreeItem id="song2" label="podcast.wav" icon={Music} href="/" />
       </TreeItem>
-      <TreeItem id="video1" label="presentation.mp4" icon={Video} />
+      <TreeItem id="video1" label="presentation.mp4" icon={Video} href="/" />
     </TreeItem>
-    <TreeItem id="project" label="Project Files" icon={[Folder, FolderOpen]}>
-      <TreeItem id="src" label="src" icon={[Folder, FolderOpen]}>
-        <TreeItem id="main" label="main.tsx" icon={Code} />
-        <TreeItem id="utils" label="utils.ts" icon={Code} />
+    <TreeItem
+      id="project"
+      label="Project Files"
+      icon={[Folder, FolderOpen]}
+      href="/"
+    >
+      <TreeItem id="src" label="src" icon={[Folder, FolderOpen]} href="/">
+        <TreeItem id="main" label="main.tsx" icon={Code} href="/" />
+        <TreeItem id="utils" label="utils.ts" icon={Code} href="/" />
       </TreeItem>
-      <TreeItem id="package" label="package.json" icon={File} />
+      <TreeItem id="package" label="package.json" icon={File} href="/" />
     </TreeItem>
   </Tree>
 );

--- a/src/components/common/Tree/Tree.tsx
+++ b/src/components/common/Tree/Tree.tsx
@@ -29,9 +29,14 @@ const itemStyles = tv({
   },
 });
 
-export function Tree<T extends object>({ children, ...props }: TreeProps<T>) {
+export function Tree<T extends object>({
+  children,
+  title,
+  ...props
+}: TreeProps<T> & { title: string }) {
   return (
     <AriaTree
+      aria-label={title}
       {...props}
       className={composeTailwindRenderProps(props.className, "relative")}
     >
@@ -67,8 +72,9 @@ const chevron = tv({
   },
 });
 
-// Single icon or [default, expanded]
-type TreeItemIcon = LucideIcon | [LucideIcon, LucideIcon];
+type TreeItemIcon =
+  | LucideIcon // Single icon
+  | [LucideIcon, LucideIcon]; // [default, expanded]
 
 interface TreeItemContentProps
   extends Omit<AriaTreeItemContentProps, "children"> {
@@ -113,7 +119,7 @@ function TreeItemContent({ children, icon, ...props }: TreeItemContentProps) {
                 />
               </Button>
             ) : (
-              <div className="shrink-0 h-5 w-8" />
+              <div className="shrink-0 h-5 w-6.5" />
             )}
             {Icon && <Icon className="size-5 text-dim p-0.5 mr-1.5" />}
             {children}

--- a/src/components/common/Tree/Tree.tsx
+++ b/src/components/common/Tree/Tree.tsx
@@ -1,0 +1,140 @@
+import { ChevronRight, type LucideIcon } from "lucide-react";
+import type React from "react";
+import {
+  Tree as AriaTree,
+  TreeItem as AriaTreeItem,
+  TreeItemContent as AriaTreeItemContent,
+  type TreeItemContentProps as AriaTreeItemContentProps,
+  type TreeItemProps as AriaTreeItemProps,
+  type TreeProps,
+} from "react-aria-components";
+import { tv } from "tailwind-variants";
+import { Button, Checkbox } from "@/components/common";
+import { composeTailwindRenderProps, focusRing } from "@/components/utils";
+
+const itemStyles = tv({
+  extend: focusRing,
+  base: "relative flex group gap-3 cursor-default select-none p-2 text-sm text-normal rounded-md",
+  variants: {
+    isSelected: {
+      false: "hover:bg-theme-a3",
+      true: "bg-primary-a3 text-normal hover:bg-primary-a4 z-20 [&:has(+[data-selected])]:rounded-b-none [&+[data-selected]]:rounded-t-none",
+    },
+    isDisabled: {
+      true: "text-dim opacity-50 cursor-default forced-colors:text-[GrayText] z-10",
+    },
+    isFocusVisible: {
+      true: "rounded-md!",
+    },
+  },
+});
+
+export function Tree<T extends object>({ children, ...props }: TreeProps<T>) {
+  return (
+    <AriaTree
+      {...props}
+      className={composeTailwindRenderProps(props.className, "relative")}
+    >
+      {children}
+    </AriaTree>
+  );
+}
+
+const expandButton = tv({
+  extend: focusRing,
+  base: "shrink-0 size-5 p-0 rounded-md cursor-default mr-1.5",
+  variants: {
+    isSelected: {
+      true: "hover:bg-primary-a3",
+    },
+  },
+});
+
+const chevron = tv({
+  base: "h-5 w-8 transition-all duration-200 ease-in-out",
+  variants: {
+    isExpanded: {
+      true: "transform rotate-90",
+    },
+    isSelected: {
+      true: "text-primary-12/30 hover:text-primary-12",
+      false: "text-theme-12/30 hover:text-theme-12",
+    },
+    isDisabled: {
+      true: "text-dim forced-colors:text-[GrayText]",
+      false: "pointer-events-none",
+    },
+  },
+});
+
+// Single icon or [default, expanded]
+type TreeItemIcon = LucideIcon | [LucideIcon, LucideIcon];
+
+interface TreeItemContentProps
+  extends Omit<AriaTreeItemContentProps, "children"> {
+  icon?: TreeItemIcon;
+  children?: React.ReactNode;
+}
+
+function TreeItemContent({ children, icon, ...props }: TreeItemContentProps) {
+  return (
+    <AriaTreeItemContent {...props}>
+      {({
+        isSelected,
+        selectionMode,
+        selectionBehavior,
+        hasChildItems,
+        isExpanded,
+        isDisabled,
+      }) => {
+        const Icon = Array.isArray(icon)
+          ? isExpanded
+            ? icon[1]
+            : icon[0]
+          : icon;
+
+        return (
+          <div className="flex items-center">
+            {selectionMode === "multiple" && selectionBehavior === "toggle" && (
+              <Checkbox slot="selection" size="medium" className="mr-1.5" />
+            )}
+            <div className="shrink-0 w-[calc(calc(var(--tree-item-level)_-_1)_*_calc(var(--spacing)_*_3))]" />
+            {hasChildItems ? (
+              <Button
+                slot="chevron"
+                className={expandButton({ isSelected })}
+                isDisabled={isDisabled}
+                variant="ghost"
+                size="small"
+              >
+                <ChevronRight
+                  aria-hidden
+                  className={chevron({ isSelected, isExpanded, isDisabled })}
+                />
+              </Button>
+            ) : (
+              <div className="shrink-0 h-5 w-8" />
+            )}
+            {Icon && <Icon className="size-5 text-dim p-0.5 mr-1.5" />}
+            {children}
+          </div>
+        );
+      }}
+    </AriaTreeItemContent>
+  );
+}
+
+interface TreeItemProps extends Partial<AriaTreeItemProps> {
+  children?: React.ReactNode;
+  icon?: TreeItemIcon;
+  label: string;
+}
+
+export function TreeItem({ children, label, icon, ...props }: TreeItemProps) {
+  return (
+    <AriaTreeItem className={itemStyles} textValue={label} {...props}>
+      <TreeItemContent icon={icon}>{label}</TreeItemContent>
+      {children}
+    </AriaTreeItem>
+  );
+}


### PR DESCRIPTION
## What changed?
Adds and styles a `Tree` component in `/common` from `React Aria`.

https://github.com/user-attachments/assets/d2955d5e-66ce-43e6-a515-bf11023c47ae

## Why?
https://github.com/namesakefyi/namesake/issues/533 is a feature request from Luke to group documents together by their related quest. I figured to accomplish this it would be nice to use the [Tree component from React Aria](https://react-spectrum.adobe.com/react-aria/Tree.html). This gives us the ability to nest, collapse, reorder, select, deselect, etc.

## How was this change made?
Imported the starter Tailwind component from React Aria, then made tweaks to the styling and added support for default/expanded icons from Lucide.

## How was this tested?
Manually in Storybook. I trust that the Tree component is tested within React Aria and we don't need to rewrite our own.

## Anything else?
Can follow up this PR with a full fix for #533 

<img width="704" height="418" alt="CleanShot 2025-07-12 at 19 07 34@2x" src="https://github.com/user-attachments/assets/514fb1c9-1d82-467a-aa99-e1f938042881" />