### PR TITLE
chore: Remove `react-helmet-async`

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "react-aria": "^3.41.1",
     "react-aria-components": "^1.10.1",
     "react-dom": "^19.1.0",
-    "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.60.0",
     "react-random-reveal": "^2.0.1",
     "resend": "4.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,9 +137,6 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
-      react-helmet-async:
-        specifier: ^2.0.5
-        version: 2.0.5(react@19.1.0)
       react-hook-form:
         specifier: ^7.60.0
         version: 7.60.0(react@19.1.0)
@@ -3535,9 +3532,6 @@ packages:
   intl-messageformat@10.7.16:
     resolution: {integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==}
 
-  invariant@2.2.4:
-    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
-
   is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
 
@@ -4293,14 +4287,6 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  react-fast-compare@3.2.2:
-    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
-
-  react-helmet-async@2.0.5:
-    resolution: {integrity: sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==}
-    peerDependencies:
-      react: ^16.6.0 || ^17.0.0 || ^18.0.0
-
   react-hook-form@7.60.0:
     resolution: {integrity: sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==}
     engines: {node: '>=18.0.0'}
@@ -4455,9 +4441,6 @@ packages:
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
-
-  shallowequal@1.1.0:
-    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
   sharp@0.34.3:
     resolution: {integrity: sha512-eX2IQ6nFohW4DbvHIOLRB3MHFpYqaqvXd3Tp5e/T/dSH83fxaNJQRvDMhASmkNTsNTVF2/OOopzRCt7xokgPfg==}
@@ -8622,10 +8605,6 @@ snapshots:
       '@formatjs/icu-messageformat-parser': 2.11.2
       tslib: 2.8.1
 
-  invariant@2.2.4:
-    dependencies:
-      loose-envify: 1.4.0
-
   is-arrayish@0.3.2: {}
 
   is-binary-path@2.1.0:
@@ -9432,15 +9411,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  react-fast-compare@3.2.2: {}
-
-  react-helmet-async@2.0.5(react@19.1.0):
-    dependencies:
-      invariant: 2.2.4
-      react: 19.1.0
-      react-fast-compare: 3.2.2
-      shallowequal: 1.1.0
-
   react-hook-form@7.60.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -9615,8 +9585,6 @@ snapshots:
   seroval@1.3.2: {}
 
   set-cookie-parser@2.7.1: {}
-
-  shallowequal@1.1.0: {}
 
   sharp@0.34.3:
     dependencies:

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,7 +14,6 @@ import { posthog } from "posthog-js";
 import { PostHogErrorBoundary, PostHogProvider } from "posthog-js/react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { HelmetProvider } from "react-helmet-async";
 import { Logo, ThemeProvider } from "@/components/app";
 import { Empty } from "@/components/common";
 import type { Role } from "@/constants";
@@ -105,17 +104,15 @@ if (!rootElement.innerHTML) {
   root.render(
     <StrictMode>
       <PostHogProvider client={posthog}>
-        <HelmetProvider>
-          <ConvexBetterAuthProvider client={convex} authClient={authClient}>
-            <ThemeProvider attribute="class">
-              <LazyMotion strict features={domAnimation}>
-                <PostHogErrorBoundary fallback={fallback}>
-                  <InnerApp />
-                </PostHogErrorBoundary>
-              </LazyMotion>
-            </ThemeProvider>
-          </ConvexBetterAuthProvider>
-        </HelmetProvider>
+        <ConvexBetterAuthProvider client={convex} authClient={authClient}>
+          <ThemeProvider attribute="class">
+            <LazyMotion strict features={domAnimation}>
+              <PostHogErrorBoundary fallback={fallback}>
+                <InnerApp />
+              </PostHogErrorBoundary>
+            </LazyMotion>
+          </ThemeProvider>
+        </ConvexBetterAuthProvider>
       </PostHogProvider>
     </StrictMode>,
   );


### PR DESCRIPTION
## What changed?
Removes the `react-helmet-async` package and related `HelmetProvider`.

## Why?
React 19 includes native support for hoisting [document metadata](https://react.dev/blog/2024/12/05/react-19#support-for-metadata-tags) to the `head`, so `react-helmet-async` is no longer needed.

That, and the library [has been abandoned](https://github.com/staylor/react-helmet-async/issues/254) and was throwing warnings about peer dependencies:

<img width="1030" height="274" alt="CleanShot 2025-07-17 at 17 03 43@2x" src="https://github.com/user-attachments/assets/bbbd7083-bb51-4436-86ec-60e4e4f1d3c3" />

## How was this change made?
Uninstalled the dependency. Since we weren't actually setting custom titles anywhere it won't affect much!

## How was this tested?
N/A

## Anything else?
Filed a follow-up: https://github.com/namesakefyi/namesake/issues/704