### PR TITLE
feat: Display page-specific titles

### DIFF
--- a/.changeset/tough-breads-heal.md
+++ b/.changeset/tough-breads-heal.md
@@ -1,0 +1,5 @@
+---
+"namesake": minor
+---
+
+Display the current page name in the tab title instead of just 'Namesake'

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -84,17 +84,6 @@ export declare const internal: FilterApi<
 
 export declare const components: {
   betterAuth: {
-    adapterTest: {
-      count: FunctionReference<"query", "internal", any, any>;
-      create: FunctionReference<"mutation", "internal", any, any>;
-      delete: FunctionReference<"mutation", "internal", any, any>;
-      deleteMany: FunctionReference<"mutation", "internal", any, any>;
-      findMany: FunctionReference<"query", "internal", any, any>;
-      findOne: FunctionReference<"query", "internal", any, any>;
-      isAuthenticated: FunctionReference<"query", "internal", {}, any>;
-      update: FunctionReference<"mutation", "internal", any, any>;
-      updateMany: FunctionReference<"mutation", "internal", any, any>;
-    };
     lib: {
       create: FunctionReference<
         "mutation",
@@ -102,640 +91,76 @@ export declare const components: {
         {
           input:
             | {
-                data: {
-                  banExpires?: number;
-                  banReason?: string;
-                  banned?: boolean;
-                  createdAt: number;
-                  displayUsername?: string;
-                  email: string;
-                  emailVerified: boolean;
-                  image?: string;
-                  isAnonymous?: boolean;
-                  name: string;
-                  phoneNumber?: string;
-                  phoneNumberVerified?: boolean;
-                  role?: string;
-                  stripeCustomerId?: string;
-                  twoFactorEnabled?: boolean;
-                  updatedAt: number;
-                  userId?: string;
-                  username?: string;
-                };
-                model: "user";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
+                createdAt: number;
+                email: string;
+                emailVerified: boolean;
+                image?: string;
+                name: string;
+                table: string;
+                twoFactorEnabled?: boolean;
+                updatedAt: number;
+                userId: string;
               }
             | {
-                data: {
-                  activeOrganizationId?: string;
-                  createdAt: number;
-                  expiresAt: number;
-                  impersonatedBy?: string;
-                  ipAddress?: string;
-                  token: string;
-                  updatedAt: number;
-                  userAgent?: string;
-                  userId: string;
-                };
-                model: "session";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
+                createdAt: number;
+                expiresAt: number;
+                ipAddress?: string;
+                table: string;
+                token: string;
+                updatedAt: number;
+                userAgent?: string;
+                userId: string;
               }
             | {
-                data: {
-                  accessToken?: string;
-                  accessTokenExpiresAt?: number;
-                  accountId: string;
-                  createdAt: number;
-                  idToken?: string;
-                  password?: string;
-                  providerId: string;
-                  refreshToken?: string;
-                  refreshTokenExpiresAt?: number;
-                  scope?: string;
-                  updatedAt: number;
-                  userId: string;
-                };
-                model: "account";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
+                accessToken?: string;
+                accessTokenExpiresAt?: number;
+                accountId: string;
+                createdAt: number;
+                idToken?: string;
+                password?: string;
+                providerId: string;
+                refreshToken?: string;
+                refreshTokenExpiresAt?: number;
+                scope?: string;
+                table: string;
+                updatedAt: number;
+                userId: string;
               }
             | {
-                data: {
-                  createdAt?: number;
-                  expiresAt: number;
-                  identifier: string;
-                  updatedAt?: number;
-                  value: string;
-                };
-                model: "verification";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
+                backupCodes: string;
+                secret: string;
+                table: string;
+                userId: string;
               }
             | {
-                data: { backupCodes: string; secret: string; userId: string };
-                model: "twoFactor";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
+                createdAt?: number;
+                expiresAt: number;
+                identifier: string;
+                table: string;
+                updatedAt?: number;
+                value: string;
               }
             | {
-                data: {
-                  aaguid?: string;
-                  backedUp: boolean;
-                  counter: number;
-                  createdAt?: number;
-                  credentialID: string;
-                  deviceType: string;
-                  name?: string;
-                  publicKey: string;
-                  transports?: string;
-                  userId: string;
-                };
-                model: "passkey";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                data: {
-                  createdAt: number;
-                  enabled?: boolean;
-                  expiresAt?: number;
-                  key: string;
-                  lastRefillAt?: number;
-                  lastRequest?: number;
-                  metadata?: string;
-                  name?: string;
-                  permissions?: string;
-                  prefix?: string;
-                  rateLimitEnabled?: boolean;
-                  rateLimitMax?: number;
-                  rateLimitTimeWindow?: number;
-                  refillAmount?: number;
-                  refillInterval?: number;
-                  remaining?: number;
-                  requestCount?: number;
-                  start?: string;
-                  updatedAt: number;
-                  userId: string;
-                };
-                model: "apikey";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                data: {
-                  clientId?: string;
-                  clientSecret?: string;
-                  createdAt?: number;
-                  disabled?: boolean;
-                  icon?: string;
-                  metadata?: string;
-                  name?: string;
-                  redirectURLs?: string;
-                  type?: string;
-                  updatedAt?: number;
-                  userId?: string;
-                };
-                model: "oauthApplication";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                data: {
-                  accessToken?: string;
-                  accessTokenExpiresAt?: number;
-                  clientId?: string;
-                  createdAt?: number;
-                  refreshToken?: string;
-                  refreshTokenExpiresAt?: number;
-                  scopes?: string;
-                  updatedAt?: number;
-                  userId?: string;
-                };
-                model: "oauthAccessToken";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                data: {
-                  clientId?: string;
-                  consentGiven?: boolean;
-                  createdAt?: number;
-                  scopes?: string;
-                  updatedAt?: number;
-                  userId?: string;
-                };
-                model: "oauthConsent";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                data: {
-                  createdAt: number;
-                  logo?: string;
-                  metadata?: string;
-                  name: string;
-                  slug?: string;
-                };
-                model: "organization";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                data: {
-                  createdAt: number;
-                  organizationId: string;
-                  role: string;
-                  teamId?: string;
-                  userId: string;
-                };
-                model: "member";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                data: {
-                  email: string;
-                  expiresAt: number;
-                  inviterId: string;
-                  organizationId: string;
-                  role?: string;
-                  status: string;
-                  teamId?: string;
-                };
-                model: "invitation";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                data: {
-                  createdAt: number;
-                  name: string;
-                  organizationId: string;
-                  updatedAt?: number;
-                };
-                model: "team";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                data: {
-                  domain: string;
-                  issuer: string;
-                  oidcConfig?: string;
-                  organizationId?: string;
-                  providerId: string;
-                  samlConfig?: string;
-                  userId?: string;
-                };
-                model: "ssoProvider";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                data: {
-                  createdAt: number;
-                  privateKey: string;
-                  publicKey: string;
-                };
-                model: "jwks";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                data: {
-                  cancelAtPeriodEnd?: boolean;
-                  periodEnd?: number;
-                  periodStart?: number;
-                  plan: string;
-                  referenceId: string;
-                  seats?: number;
-                  status?: string;
-                  stripeCustomerId?: string;
-                  stripeSubscriptionId?: string;
-                };
-                model: "subscription";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                data: { count?: number; key?: string; lastRequest?: number };
-                model: "rateLimit";
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
+                createdAt: number;
+                id?: string;
+                privateKey: string;
+                publicKey: string;
+                table: string;
               };
         },
         any
       >;
-      deleteMany: FunctionReference<
+      deleteAllForUser: FunctionReference<
+        "action",
+        "internal",
+        { table: string; userId: string },
+        any
+      >;
+      deleteAllForUserPage: FunctionReference<
         "mutation",
         "internal",
         {
-          limit?: number;
-          model: string;
-          offset?: number;
-          paginationOpts: {
+          paginationOpts?: {
             cursor: string | null;
             endCursor?: string | null;
             id?: number;
@@ -743,77 +168,46 @@ export declare const components: {
             maximumRowsRead?: number;
             numItems: number;
           };
-          select?: Array<string>;
-          sortBy?: { direction: "asc" | "desc"; field: string };
-          unique?: boolean;
-          where?: Array<{
-            connector?: "AND" | "OR";
-            field: string;
-            operator?:
-              | "lt"
-              | "lte"
-              | "gt"
-              | "gte"
-              | "eq"
-              | "in"
-              | "ne"
-              | "contains"
-              | "starts_with"
-              | "ends_with";
-            value:
-              | string
-              | number
-              | boolean
-              | Array<string>
-              | Array<number>
-              | null;
-          }>;
+          table: string;
+          userId: string;
         },
         any
       >;
-      deleteOne: FunctionReference<
+      deleteBy: FunctionReference<
         "mutation",
         "internal",
         {
-          limit?: number;
-          model: string;
-          offset?: number;
-          select?: Array<string>;
-          sortBy?: { direction: "asc" | "desc"; field: string };
+          field: string;
+          table: string;
           unique?: boolean;
-          where?: Array<{
-            connector?: "AND" | "OR";
-            field: string;
-            operator?:
-              | "lt"
-              | "lte"
-              | "gt"
-              | "gte"
-              | "eq"
-              | "in"
-              | "ne"
-              | "contains"
-              | "starts_with"
-              | "ends_with";
-            value:
-              | string
-              | number
-              | boolean
-              | Array<string>
-              | Array<number>
-              | null;
-          }>;
+          value:
+            | string
+            | number
+            | boolean
+            | Array<string>
+            | Array<number>
+            | null;
         },
         any
       >;
-      findMany: FunctionReference<
-        "query",
+      deleteExpiredSessions: FunctionReference<
+        "mutation",
+        "internal",
+        { expiresAt: number; userId: string },
+        any
+      >;
+      deleteOldVerifications: FunctionReference<
+        "action",
+        "internal",
+        { currentTimestamp: number },
+        any
+      >;
+      deleteOldVerificationsPage: FunctionReference<
+        "mutation",
         "internal",
         {
-          limit?: number;
-          model: string;
-          offset?: number;
-          paginationOpts: {
+          currentTimestamp: number;
+          paginationOpts?: {
             cursor: string | null;
             endCursor?: string | null;
             id?: number;
@@ -821,124 +215,83 @@ export declare const components: {
             maximumRowsRead?: number;
             numItems: number;
           };
-          select?: Array<string>;
-          sortBy?: { direction: "asc" | "desc"; field: string };
-          unique?: boolean;
-          where?: Array<{
-            connector?: "AND" | "OR";
-            field: string;
-            operator?:
-              | "lt"
-              | "lte"
-              | "gt"
-              | "gte"
-              | "eq"
-              | "in"
-              | "ne"
-              | "contains"
-              | "starts_with"
-              | "ends_with";
-            value:
-              | string
-              | number
-              | boolean
-              | Array<string>
-              | Array<number>
-              | null;
-          }>;
         },
         any
       >;
-      findOne: FunctionReference<
+      getAccountByAccountIdAndProviderId: FunctionReference<
+        "query",
+        "internal",
+        { accountId: string; providerId: string },
+        any
+      >;
+      getAccountsByUserId: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; userId: string },
+        any
+      >;
+      getBy: FunctionReference<
         "query",
         "internal",
         {
-          limit?: number;
-          model: string;
-          offset?: number;
-          select?: Array<string>;
-          sortBy?: { direction: "asc" | "desc"; field: string };
+          field: string;
+          table: string;
           unique?: boolean;
-          where?: Array<{
-            connector?: "AND" | "OR";
-            field: string;
-            operator?:
-              | "lt"
-              | "lte"
-              | "gt"
-              | "gte"
-              | "eq"
-              | "in"
-              | "ne"
-              | "contains"
-              | "starts_with"
-              | "ends_with";
-            value:
-              | string
-              | number
-              | boolean
-              | Array<string>
-              | Array<number>
-              | null;
-          }>;
+          value:
+            | string
+            | number
+            | boolean
+            | Array<string>
+            | Array<number>
+            | null;
+        },
+        any
+      >;
+      getByQuery: FunctionReference<
+        "query",
+        "internal",
+        {
+          field: string;
+          table: string;
+          unique?: boolean;
+          value:
+            | string
+            | number
+            | boolean
+            | Array<string>
+            | Array<number>
+            | null;
         },
         any
       >;
       getCurrentSession: FunctionReference<"query", "internal", {}, any>;
-      updateMany: FunctionReference<
+      getJwks: FunctionReference<"query", "internal", { limit?: number }, any>;
+      getSessionsByUserId: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; userId: string },
+        any
+      >;
+      listVerificationsByIdentifier: FunctionReference<
+        "query",
+        "internal",
+        {
+          identifier: string;
+          limit?: number;
+          sortBy?: { direction: "asc" | "desc"; field: string };
+        },
+        any
+      >;
+      update: FunctionReference<
         "mutation",
         "internal",
         {
           input:
             | {
-                limit?: number;
-                model: "user";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  banExpires?: number;
-                  banReason?: string;
-                  banned?: boolean;
-                  createdAt?: number;
-                  displayUsername?: string;
-                  email?: string;
-                  emailVerified?: boolean;
-                  image?: string;
-                  isAnonymous?: boolean;
-                  name?: string;
-                  phoneNumber?: string;
-                  phoneNumberVerified?: boolean;
-                  role?: string;
-                  stripeCustomerId?: string;
-                  twoFactorEnabled?: boolean;
-                  updatedAt?: number;
-                  userId?: string;
-                  username?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
+                table: "account";
+                value: Record<string, any>;
+                where: {
                   field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
                   value:
                     | string
                     | number
@@ -946,48 +299,13 @@ export declare const components: {
                     | Array<string>
                     | Array<number>
                     | null;
-                }>;
+                };
               }
             | {
-                limit?: number;
-                model: "session";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  activeOrganizationId?: string;
-                  createdAt?: number;
-                  expiresAt?: number;
-                  impersonatedBy?: string;
-                  ipAddress?: string;
-                  token?: string;
-                  updatedAt?: number;
-                  userAgent?: string;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
+                table: "session";
+                value: Record<string, any>;
+                where: {
                   field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
                   value:
                     | string
                     | number
@@ -995,51 +313,13 @@ export declare const components: {
                     | Array<string>
                     | Array<number>
                     | null;
-                }>;
+                };
               }
             | {
-                limit?: number;
-                model: "account";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  accessToken?: string;
-                  accessTokenExpiresAt?: number;
-                  accountId?: string;
-                  createdAt?: number;
-                  idToken?: string;
-                  password?: string;
-                  providerId?: string;
-                  refreshToken?: string;
-                  refreshTokenExpiresAt?: number;
-                  scope?: string;
-                  updatedAt?: number;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
+                table: "verification";
+                value: Record<string, any>;
+                where: {
                   field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
                   value:
                     | string
                     | number
@@ -1047,44 +327,13 @@ export declare const components: {
                     | Array<string>
                     | Array<number>
                     | null;
-                }>;
+                };
               }
             | {
-                limit?: number;
-                model: "verification";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  createdAt?: number;
-                  expiresAt?: number;
-                  identifier?: string;
-                  updatedAt?: number;
-                  value?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
+                table: "user";
+                value: Record<string, any>;
+                where: {
                   field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
                   value:
                     | string
                     | number
@@ -1092,1302 +341,40 @@ export declare const components: {
                     | Array<string>
                     | Array<number>
                     | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "twoFactor";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
                 };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  backupCodes?: string;
-                  secret?: string;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "passkey";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  aaguid?: string;
-                  backedUp?: boolean;
-                  counter?: number;
-                  createdAt?: number;
-                  credentialID?: string;
-                  deviceType?: string;
-                  name?: string;
-                  publicKey?: string;
-                  transports?: string;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "apikey";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  createdAt?: number;
-                  enabled?: boolean;
-                  expiresAt?: number;
-                  key?: string;
-                  lastRefillAt?: number;
-                  lastRequest?: number;
-                  metadata?: string;
-                  name?: string;
-                  permissions?: string;
-                  prefix?: string;
-                  rateLimitEnabled?: boolean;
-                  rateLimitMax?: number;
-                  rateLimitTimeWindow?: number;
-                  refillAmount?: number;
-                  refillInterval?: number;
-                  remaining?: number;
-                  requestCount?: number;
-                  start?: string;
-                  updatedAt?: number;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "oauthApplication";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  clientId?: string;
-                  clientSecret?: string;
-                  createdAt?: number;
-                  disabled?: boolean;
-                  icon?: string;
-                  metadata?: string;
-                  name?: string;
-                  redirectURLs?: string;
-                  type?: string;
-                  updatedAt?: number;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "oauthAccessToken";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  accessToken?: string;
-                  accessTokenExpiresAt?: number;
-                  clientId?: string;
-                  createdAt?: number;
-                  refreshToken?: string;
-                  refreshTokenExpiresAt?: number;
-                  scopes?: string;
-                  updatedAt?: number;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "oauthConsent";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  clientId?: string;
-                  consentGiven?: boolean;
-                  createdAt?: number;
-                  scopes?: string;
-                  updatedAt?: number;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "organization";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  createdAt?: number;
-                  logo?: string;
-                  metadata?: string;
-                  name?: string;
-                  slug?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "member";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  createdAt?: number;
-                  organizationId?: string;
-                  role?: string;
-                  teamId?: string;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "invitation";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  email?: string;
-                  expiresAt?: number;
-                  inviterId?: string;
-                  organizationId?: string;
-                  role?: string;
-                  status?: string;
-                  teamId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "team";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  createdAt?: number;
-                  name?: string;
-                  organizationId?: string;
-                  updatedAt?: number;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "ssoProvider";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  domain?: string;
-                  issuer?: string;
-                  oidcConfig?: string;
-                  organizationId?: string;
-                  providerId?: string;
-                  samlConfig?: string;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "jwks";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  createdAt?: number;
-                  privateKey?: string;
-                  publicKey?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "subscription";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: {
-                  cancelAtPeriodEnd?: boolean;
-                  periodEnd?: number;
-                  periodStart?: number;
-                  plan?: string;
-                  referenceId?: string;
-                  seats?: number;
-                  status?: string;
-                  stripeCustomerId?: string;
-                  stripeSubscriptionId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                limit?: number;
-                model: "rateLimit";
-                offset?: number;
-                paginationOpts: {
-                  cursor: string | null;
-                  endCursor?: string | null;
-                  id?: number;
-                  maximumBytesRead?: number;
-                  maximumRowsRead?: number;
-                  numItems: number;
-                };
-                select?: Array<string>;
-                sortBy?: { direction: "asc" | "desc"; field: string };
-                unique?: boolean;
-                update: { count?: number; key?: string; lastRequest?: number };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
               };
         },
         any
       >;
-      updateOne: FunctionReference<
+      updateTwoFactor: FunctionReference<
         "mutation",
         "internal",
         {
-          input:
-            | {
-                model: "user";
-                update: {
-                  banExpires?: number;
-                  banReason?: string;
-                  banned?: boolean;
-                  createdAt?: number;
-                  displayUsername?: string;
-                  email?: string;
-                  emailVerified?: boolean;
-                  image?: string;
-                  isAnonymous?: boolean;
-                  name?: string;
-                  phoneNumber?: string;
-                  phoneNumberVerified?: boolean;
-                  role?: string;
-                  stripeCustomerId?: string;
-                  twoFactorEnabled?: boolean;
-                  updatedAt?: number;
-                  userId?: string;
-                  username?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "session";
-                update: {
-                  activeOrganizationId?: string;
-                  createdAt?: number;
-                  expiresAt?: number;
-                  impersonatedBy?: string;
-                  ipAddress?: string;
-                  token?: string;
-                  updatedAt?: number;
-                  userAgent?: string;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "account";
-                update: {
-                  accessToken?: string;
-                  accessTokenExpiresAt?: number;
-                  accountId?: string;
-                  createdAt?: number;
-                  idToken?: string;
-                  password?: string;
-                  providerId?: string;
-                  refreshToken?: string;
-                  refreshTokenExpiresAt?: number;
-                  scope?: string;
-                  updatedAt?: number;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "verification";
-                update: {
-                  createdAt?: number;
-                  expiresAt?: number;
-                  identifier?: string;
-                  updatedAt?: number;
-                  value?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "twoFactor";
-                update: {
-                  backupCodes?: string;
-                  secret?: string;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "passkey";
-                update: {
-                  aaguid?: string;
-                  backedUp?: boolean;
-                  counter?: number;
-                  createdAt?: number;
-                  credentialID?: string;
-                  deviceType?: string;
-                  name?: string;
-                  publicKey?: string;
-                  transports?: string;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "apikey";
-                update: {
-                  createdAt?: number;
-                  enabled?: boolean;
-                  expiresAt?: number;
-                  key?: string;
-                  lastRefillAt?: number;
-                  lastRequest?: number;
-                  metadata?: string;
-                  name?: string;
-                  permissions?: string;
-                  prefix?: string;
-                  rateLimitEnabled?: boolean;
-                  rateLimitMax?: number;
-                  rateLimitTimeWindow?: number;
-                  refillAmount?: number;
-                  refillInterval?: number;
-                  remaining?: number;
-                  requestCount?: number;
-                  start?: string;
-                  updatedAt?: number;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "oauthApplication";
-                update: {
-                  clientId?: string;
-                  clientSecret?: string;
-                  createdAt?: number;
-                  disabled?: boolean;
-                  icon?: string;
-                  metadata?: string;
-                  name?: string;
-                  redirectURLs?: string;
-                  type?: string;
-                  updatedAt?: number;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "oauthAccessToken";
-                update: {
-                  accessToken?: string;
-                  accessTokenExpiresAt?: number;
-                  clientId?: string;
-                  createdAt?: number;
-                  refreshToken?: string;
-                  refreshTokenExpiresAt?: number;
-                  scopes?: string;
-                  updatedAt?: number;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "oauthConsent";
-                update: {
-                  clientId?: string;
-                  consentGiven?: boolean;
-                  createdAt?: number;
-                  scopes?: string;
-                  updatedAt?: number;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "organization";
-                update: {
-                  createdAt?: number;
-                  logo?: string;
-                  metadata?: string;
-                  name?: string;
-                  slug?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "member";
-                update: {
-                  createdAt?: number;
-                  organizationId?: string;
-                  role?: string;
-                  teamId?: string;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "invitation";
-                update: {
-                  email?: string;
-                  expiresAt?: number;
-                  inviterId?: string;
-                  organizationId?: string;
-                  role?: string;
-                  status?: string;
-                  teamId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "team";
-                update: {
-                  createdAt?: number;
-                  name?: string;
-                  organizationId?: string;
-                  updatedAt?: number;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "ssoProvider";
-                update: {
-                  domain?: string;
-                  issuer?: string;
-                  oidcConfig?: string;
-                  organizationId?: string;
-                  providerId?: string;
-                  samlConfig?: string;
-                  userId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "jwks";
-                update: {
-                  createdAt?: number;
-                  privateKey?: string;
-                  publicKey?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "subscription";
-                update: {
-                  cancelAtPeriodEnd?: boolean;
-                  periodEnd?: number;
-                  periodStart?: number;
-                  plan?: string;
-                  referenceId?: string;
-                  seats?: number;
-                  status?: string;
-                  stripeCustomerId?: string;
-                  stripeSubscriptionId?: string;
-                };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              }
-            | {
-                model: "rateLimit";
-                update: { count?: number; key?: string; lastRequest?: number };
-                where?: Array<{
-                  connector?: "AND" | "OR";
-                  field: string;
-                  operator?:
-                    | "lt"
-                    | "lte"
-                    | "gt"
-                    | "gte"
-                    | "eq"
-                    | "in"
-                    | "ne"
-                    | "contains"
-                    | "starts_with"
-                    | "ends_with";
-                  value:
-                    | string
-                    | number
-                    | boolean
-                    | Array<string>
-                    | Array<number>
-                    | null;
-                }>;
-              };
+          update: { backupCodes?: string; secret?: string; userId?: string };
+          userId: string;
+        },
+        any
+      >;
+      updateUserProviderAccounts: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          providerId: string;
+          update: {
+            accessToken?: string;
+            accessTokenExpiresAt?: number;
+            accountId?: string;
+            createdAt?: number;
+            idToken?: string;
+            password?: string;
+            providerId?: string;
+            refreshToken?: string;
+            refreshTokenExpiresAt?: number;
+            scope?: string;
+            updatedAt?: number;
+            userId?: string;
+          };
+          userId: string;
         },
         any
       >;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -84,6 +84,17 @@ export declare const internal: FilterApi<
 
 export declare const components: {
   betterAuth: {
+    adapterTest: {
+      count: FunctionReference<"query", "internal", any, any>;
+      create: FunctionReference<"mutation", "internal", any, any>;
+      delete: FunctionReference<"mutation", "internal", any, any>;
+      deleteMany: FunctionReference<"mutation", "internal", any, any>;
+      findMany: FunctionReference<"query", "internal", any, any>;
+      findOne: FunctionReference<"query", "internal", any, any>;
+      isAuthenticated: FunctionReference<"query", "internal", {}, any>;
+      update: FunctionReference<"mutation", "internal", any, any>;
+      updateMany: FunctionReference<"mutation", "internal", any, any>;
+    };
     lib: {
       create: FunctionReference<
         "mutation",
@@ -91,76 +102,640 @@ export declare const components: {
         {
           input:
             | {
-                createdAt: number;
-                email: string;
-                emailVerified: boolean;
-                image?: string;
-                name: string;
-                table: string;
-                twoFactorEnabled?: boolean;
-                updatedAt: number;
-                userId: string;
+                data: {
+                  banExpires?: number;
+                  banReason?: string;
+                  banned?: boolean;
+                  createdAt: number;
+                  displayUsername?: string;
+                  email: string;
+                  emailVerified: boolean;
+                  image?: string;
+                  isAnonymous?: boolean;
+                  name: string;
+                  phoneNumber?: string;
+                  phoneNumberVerified?: boolean;
+                  role?: string;
+                  stripeCustomerId?: string;
+                  twoFactorEnabled?: boolean;
+                  updatedAt: number;
+                  userId?: string;
+                  username?: string;
+                };
+                model: "user";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
               }
             | {
-                createdAt: number;
-                expiresAt: number;
-                ipAddress?: string;
-                table: string;
-                token: string;
-                updatedAt: number;
-                userAgent?: string;
-                userId: string;
+                data: {
+                  activeOrganizationId?: string;
+                  createdAt: number;
+                  expiresAt: number;
+                  impersonatedBy?: string;
+                  ipAddress?: string;
+                  token: string;
+                  updatedAt: number;
+                  userAgent?: string;
+                  userId: string;
+                };
+                model: "session";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
               }
             | {
-                accessToken?: string;
-                accessTokenExpiresAt?: number;
-                accountId: string;
-                createdAt: number;
-                idToken?: string;
-                password?: string;
-                providerId: string;
-                refreshToken?: string;
-                refreshTokenExpiresAt?: number;
-                scope?: string;
-                table: string;
-                updatedAt: number;
-                userId: string;
+                data: {
+                  accessToken?: string;
+                  accessTokenExpiresAt?: number;
+                  accountId: string;
+                  createdAt: number;
+                  idToken?: string;
+                  password?: string;
+                  providerId: string;
+                  refreshToken?: string;
+                  refreshTokenExpiresAt?: number;
+                  scope?: string;
+                  updatedAt: number;
+                  userId: string;
+                };
+                model: "account";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
               }
             | {
-                backupCodes: string;
-                secret: string;
-                table: string;
-                userId: string;
+                data: {
+                  createdAt?: number;
+                  expiresAt: number;
+                  identifier: string;
+                  updatedAt?: number;
+                  value: string;
+                };
+                model: "verification";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
               }
             | {
-                createdAt?: number;
-                expiresAt: number;
-                identifier: string;
-                table: string;
-                updatedAt?: number;
-                value: string;
+                data: { backupCodes: string; secret: string; userId: string };
+                model: "twoFactor";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
               }
             | {
-                createdAt: number;
-                id?: string;
-                privateKey: string;
-                publicKey: string;
-                table: string;
+                data: {
+                  aaguid?: string;
+                  backedUp: boolean;
+                  counter: number;
+                  createdAt?: number;
+                  credentialID: string;
+                  deviceType: string;
+                  name?: string;
+                  publicKey: string;
+                  transports?: string;
+                  userId: string;
+                };
+                model: "passkey";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                data: {
+                  createdAt: number;
+                  enabled?: boolean;
+                  expiresAt?: number;
+                  key: string;
+                  lastRefillAt?: number;
+                  lastRequest?: number;
+                  metadata?: string;
+                  name?: string;
+                  permissions?: string;
+                  prefix?: string;
+                  rateLimitEnabled?: boolean;
+                  rateLimitMax?: number;
+                  rateLimitTimeWindow?: number;
+                  refillAmount?: number;
+                  refillInterval?: number;
+                  remaining?: number;
+                  requestCount?: number;
+                  start?: string;
+                  updatedAt: number;
+                  userId: string;
+                };
+                model: "apikey";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                data: {
+                  clientId?: string;
+                  clientSecret?: string;
+                  createdAt?: number;
+                  disabled?: boolean;
+                  icon?: string;
+                  metadata?: string;
+                  name?: string;
+                  redirectURLs?: string;
+                  type?: string;
+                  updatedAt?: number;
+                  userId?: string;
+                };
+                model: "oauthApplication";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                data: {
+                  accessToken?: string;
+                  accessTokenExpiresAt?: number;
+                  clientId?: string;
+                  createdAt?: number;
+                  refreshToken?: string;
+                  refreshTokenExpiresAt?: number;
+                  scopes?: string;
+                  updatedAt?: number;
+                  userId?: string;
+                };
+                model: "oauthAccessToken";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                data: {
+                  clientId?: string;
+                  consentGiven?: boolean;
+                  createdAt?: number;
+                  scopes?: string;
+                  updatedAt?: number;
+                  userId?: string;
+                };
+                model: "oauthConsent";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                data: {
+                  createdAt: number;
+                  logo?: string;
+                  metadata?: string;
+                  name: string;
+                  slug?: string;
+                };
+                model: "organization";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                data: {
+                  createdAt: number;
+                  organizationId: string;
+                  role: string;
+                  teamId?: string;
+                  userId: string;
+                };
+                model: "member";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                data: {
+                  email: string;
+                  expiresAt: number;
+                  inviterId: string;
+                  organizationId: string;
+                  role?: string;
+                  status: string;
+                  teamId?: string;
+                };
+                model: "invitation";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                data: {
+                  createdAt: number;
+                  name: string;
+                  organizationId: string;
+                  updatedAt?: number;
+                };
+                model: "team";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                data: {
+                  domain: string;
+                  issuer: string;
+                  oidcConfig?: string;
+                  organizationId?: string;
+                  providerId: string;
+                  samlConfig?: string;
+                  userId?: string;
+                };
+                model: "ssoProvider";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                data: {
+                  createdAt: number;
+                  privateKey: string;
+                  publicKey: string;
+                };
+                model: "jwks";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                data: {
+                  cancelAtPeriodEnd?: boolean;
+                  periodEnd?: number;
+                  periodStart?: number;
+                  plan: string;
+                  referenceId: string;
+                  seats?: number;
+                  status?: string;
+                  stripeCustomerId?: string;
+                  stripeSubscriptionId?: string;
+                };
+                model: "subscription";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                data: { count?: number; key?: string; lastRequest?: number };
+                model: "rateLimit";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
               };
         },
         any
       >;
-      deleteAllForUser: FunctionReference<
-        "action",
-        "internal",
-        { table: string; userId: string },
-        any
-      >;
-      deleteAllForUserPage: FunctionReference<
+      deleteMany: FunctionReference<
         "mutation",
         "internal",
         {
-          paginationOpts?: {
+          limit?: number;
+          model: string;
+          offset?: number;
+          paginationOpts: {
             cursor: string | null;
             endCursor?: string | null;
             id?: number;
@@ -168,46 +743,77 @@ export declare const components: {
             maximumRowsRead?: number;
             numItems: number;
           };
-          table: string;
-          userId: string;
-        },
-        any
-      >;
-      deleteBy: FunctionReference<
-        "mutation",
-        "internal",
-        {
-          field: string;
-          table: string;
+          select?: Array<string>;
+          sortBy?: { direction: "asc" | "desc"; field: string };
           unique?: boolean;
-          value:
-            | string
-            | number
-            | boolean
-            | Array<string>
-            | Array<number>
-            | null;
+          where?: Array<{
+            connector?: "AND" | "OR";
+            field: string;
+            operator?:
+              | "lt"
+              | "lte"
+              | "gt"
+              | "gte"
+              | "eq"
+              | "in"
+              | "ne"
+              | "contains"
+              | "starts_with"
+              | "ends_with";
+            value:
+              | string
+              | number
+              | boolean
+              | Array<string>
+              | Array<number>
+              | null;
+          }>;
         },
         any
       >;
-      deleteExpiredSessions: FunctionReference<
-        "mutation",
-        "internal",
-        { expiresAt: number; userId: string },
-        any
-      >;
-      deleteOldVerifications: FunctionReference<
-        "action",
-        "internal",
-        { currentTimestamp: number },
-        any
-      >;
-      deleteOldVerificationsPage: FunctionReference<
+      deleteOne: FunctionReference<
         "mutation",
         "internal",
         {
-          currentTimestamp: number;
-          paginationOpts?: {
+          limit?: number;
+          model: string;
+          offset?: number;
+          select?: Array<string>;
+          sortBy?: { direction: "asc" | "desc"; field: string };
+          unique?: boolean;
+          where?: Array<{
+            connector?: "AND" | "OR";
+            field: string;
+            operator?:
+              | "lt"
+              | "lte"
+              | "gt"
+              | "gte"
+              | "eq"
+              | "in"
+              | "ne"
+              | "contains"
+              | "starts_with"
+              | "ends_with";
+            value:
+              | string
+              | number
+              | boolean
+              | Array<string>
+              | Array<number>
+              | null;
+          }>;
+        },
+        any
+      >;
+      findMany: FunctionReference<
+        "query",
+        "internal",
+        {
+          limit?: number;
+          model: string;
+          offset?: number;
+          paginationOpts: {
             cursor: string | null;
             endCursor?: string | null;
             id?: number;
@@ -215,83 +821,124 @@ export declare const components: {
             maximumRowsRead?: number;
             numItems: number;
           };
+          select?: Array<string>;
+          sortBy?: { direction: "asc" | "desc"; field: string };
+          unique?: boolean;
+          where?: Array<{
+            connector?: "AND" | "OR";
+            field: string;
+            operator?:
+              | "lt"
+              | "lte"
+              | "gt"
+              | "gte"
+              | "eq"
+              | "in"
+              | "ne"
+              | "contains"
+              | "starts_with"
+              | "ends_with";
+            value:
+              | string
+              | number
+              | boolean
+              | Array<string>
+              | Array<number>
+              | null;
+          }>;
         },
         any
       >;
-      getAccountByAccountIdAndProviderId: FunctionReference<
-        "query",
-        "internal",
-        { accountId: string; providerId: string },
-        any
-      >;
-      getAccountsByUserId: FunctionReference<
-        "query",
-        "internal",
-        { limit?: number; userId: string },
-        any
-      >;
-      getBy: FunctionReference<
+      findOne: FunctionReference<
         "query",
         "internal",
         {
-          field: string;
-          table: string;
+          limit?: number;
+          model: string;
+          offset?: number;
+          select?: Array<string>;
+          sortBy?: { direction: "asc" | "desc"; field: string };
           unique?: boolean;
-          value:
-            | string
-            | number
-            | boolean
-            | Array<string>
-            | Array<number>
-            | null;
-        },
-        any
-      >;
-      getByQuery: FunctionReference<
-        "query",
-        "internal",
-        {
-          field: string;
-          table: string;
-          unique?: boolean;
-          value:
-            | string
-            | number
-            | boolean
-            | Array<string>
-            | Array<number>
-            | null;
+          where?: Array<{
+            connector?: "AND" | "OR";
+            field: string;
+            operator?:
+              | "lt"
+              | "lte"
+              | "gt"
+              | "gte"
+              | "eq"
+              | "in"
+              | "ne"
+              | "contains"
+              | "starts_with"
+              | "ends_with";
+            value:
+              | string
+              | number
+              | boolean
+              | Array<string>
+              | Array<number>
+              | null;
+          }>;
         },
         any
       >;
       getCurrentSession: FunctionReference<"query", "internal", {}, any>;
-      getJwks: FunctionReference<"query", "internal", { limit?: number }, any>;
-      getSessionsByUserId: FunctionReference<
-        "query",
-        "internal",
-        { limit?: number; userId: string },
-        any
-      >;
-      listVerificationsByIdentifier: FunctionReference<
-        "query",
-        "internal",
-        {
-          identifier: string;
-          limit?: number;
-          sortBy?: { direction: "asc" | "desc"; field: string };
-        },
-        any
-      >;
-      update: FunctionReference<
+      updateMany: FunctionReference<
         "mutation",
         "internal",
         {
           input:
             | {
-                table: "account";
-                value: Record<string, any>;
-                where: {
+                limit?: number;
+                model: "user";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  banExpires?: number;
+                  banReason?: string;
+                  banned?: boolean;
+                  createdAt?: number;
+                  displayUsername?: string;
+                  email?: string;
+                  emailVerified?: boolean;
+                  image?: string;
+                  isAnonymous?: boolean;
+                  name?: string;
+                  phoneNumber?: string;
+                  phoneNumberVerified?: boolean;
+                  role?: string;
+                  stripeCustomerId?: string;
+                  twoFactorEnabled?: boolean;
+                  updatedAt?: number;
+                  userId?: string;
+                  username?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
                   field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
                   value:
                     | string
                     | number
@@ -299,13 +946,48 @@ export declare const components: {
                     | Array<string>
                     | Array<number>
                     | null;
-                };
+                }>;
               }
             | {
-                table: "session";
-                value: Record<string, any>;
-                where: {
+                limit?: number;
+                model: "session";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  activeOrganizationId?: string;
+                  createdAt?: number;
+                  expiresAt?: number;
+                  impersonatedBy?: string;
+                  ipAddress?: string;
+                  token?: string;
+                  updatedAt?: number;
+                  userAgent?: string;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
                   field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
                   value:
                     | string
                     | number
@@ -313,13 +995,51 @@ export declare const components: {
                     | Array<string>
                     | Array<number>
                     | null;
-                };
+                }>;
               }
             | {
-                table: "verification";
-                value: Record<string, any>;
-                where: {
+                limit?: number;
+                model: "account";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  accessToken?: string;
+                  accessTokenExpiresAt?: number;
+                  accountId?: string;
+                  createdAt?: number;
+                  idToken?: string;
+                  password?: string;
+                  providerId?: string;
+                  refreshToken?: string;
+                  refreshTokenExpiresAt?: number;
+                  scope?: string;
+                  updatedAt?: number;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
                   field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
                   value:
                     | string
                     | number
@@ -327,13 +1047,44 @@ export declare const components: {
                     | Array<string>
                     | Array<number>
                     | null;
-                };
+                }>;
               }
             | {
-                table: "user";
-                value: Record<string, any>;
-                where: {
+                limit?: number;
+                model: "verification";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  createdAt?: number;
+                  expiresAt?: number;
+                  identifier?: string;
+                  updatedAt?: number;
+                  value?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
                   field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
                   value:
                     | string
                     | number
@@ -341,40 +1092,1302 @@ export declare const components: {
                     | Array<string>
                     | Array<number>
                     | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "twoFactor";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
                 };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  backupCodes?: string;
+                  secret?: string;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "passkey";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  aaguid?: string;
+                  backedUp?: boolean;
+                  counter?: number;
+                  createdAt?: number;
+                  credentialID?: string;
+                  deviceType?: string;
+                  name?: string;
+                  publicKey?: string;
+                  transports?: string;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "apikey";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  createdAt?: number;
+                  enabled?: boolean;
+                  expiresAt?: number;
+                  key?: string;
+                  lastRefillAt?: number;
+                  lastRequest?: number;
+                  metadata?: string;
+                  name?: string;
+                  permissions?: string;
+                  prefix?: string;
+                  rateLimitEnabled?: boolean;
+                  rateLimitMax?: number;
+                  rateLimitTimeWindow?: number;
+                  refillAmount?: number;
+                  refillInterval?: number;
+                  remaining?: number;
+                  requestCount?: number;
+                  start?: string;
+                  updatedAt?: number;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "oauthApplication";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  clientId?: string;
+                  clientSecret?: string;
+                  createdAt?: number;
+                  disabled?: boolean;
+                  icon?: string;
+                  metadata?: string;
+                  name?: string;
+                  redirectURLs?: string;
+                  type?: string;
+                  updatedAt?: number;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "oauthAccessToken";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  accessToken?: string;
+                  accessTokenExpiresAt?: number;
+                  clientId?: string;
+                  createdAt?: number;
+                  refreshToken?: string;
+                  refreshTokenExpiresAt?: number;
+                  scopes?: string;
+                  updatedAt?: number;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "oauthConsent";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  clientId?: string;
+                  consentGiven?: boolean;
+                  createdAt?: number;
+                  scopes?: string;
+                  updatedAt?: number;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "organization";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  createdAt?: number;
+                  logo?: string;
+                  metadata?: string;
+                  name?: string;
+                  slug?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "member";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  createdAt?: number;
+                  organizationId?: string;
+                  role?: string;
+                  teamId?: string;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "invitation";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  email?: string;
+                  expiresAt?: number;
+                  inviterId?: string;
+                  organizationId?: string;
+                  role?: string;
+                  status?: string;
+                  teamId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "team";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  createdAt?: number;
+                  name?: string;
+                  organizationId?: string;
+                  updatedAt?: number;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "ssoProvider";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  domain?: string;
+                  issuer?: string;
+                  oidcConfig?: string;
+                  organizationId?: string;
+                  providerId?: string;
+                  samlConfig?: string;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "jwks";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  createdAt?: number;
+                  privateKey?: string;
+                  publicKey?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "subscription";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: {
+                  cancelAtPeriodEnd?: boolean;
+                  periodEnd?: number;
+                  periodStart?: number;
+                  plan?: string;
+                  referenceId?: string;
+                  seats?: number;
+                  status?: string;
+                  stripeCustomerId?: string;
+                  stripeSubscriptionId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                limit?: number;
+                model: "rateLimit";
+                offset?: number;
+                paginationOpts: {
+                  cursor: string | null;
+                  endCursor?: string | null;
+                  id?: number;
+                  maximumBytesRead?: number;
+                  maximumRowsRead?: number;
+                  numItems: number;
+                };
+                select?: Array<string>;
+                sortBy?: { direction: "asc" | "desc"; field: string };
+                unique?: boolean;
+                update: { count?: number; key?: string; lastRequest?: number };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
               };
         },
         any
       >;
-      updateTwoFactor: FunctionReference<
+      updateOne: FunctionReference<
         "mutation",
         "internal",
         {
-          update: { backupCodes?: string; secret?: string; userId?: string };
-          userId: string;
-        },
-        any
-      >;
-      updateUserProviderAccounts: FunctionReference<
-        "mutation",
-        "internal",
-        {
-          providerId: string;
-          update: {
-            accessToken?: string;
-            accessTokenExpiresAt?: number;
-            accountId?: string;
-            createdAt?: number;
-            idToken?: string;
-            password?: string;
-            providerId?: string;
-            refreshToken?: string;
-            refreshTokenExpiresAt?: number;
-            scope?: string;
-            updatedAt?: number;
-            userId?: string;
-          };
-          userId: string;
+          input:
+            | {
+                model: "user";
+                update: {
+                  banExpires?: number;
+                  banReason?: string;
+                  banned?: boolean;
+                  createdAt?: number;
+                  displayUsername?: string;
+                  email?: string;
+                  emailVerified?: boolean;
+                  image?: string;
+                  isAnonymous?: boolean;
+                  name?: string;
+                  phoneNumber?: string;
+                  phoneNumberVerified?: boolean;
+                  role?: string;
+                  stripeCustomerId?: string;
+                  twoFactorEnabled?: boolean;
+                  updatedAt?: number;
+                  userId?: string;
+                  username?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "session";
+                update: {
+                  activeOrganizationId?: string;
+                  createdAt?: number;
+                  expiresAt?: number;
+                  impersonatedBy?: string;
+                  ipAddress?: string;
+                  token?: string;
+                  updatedAt?: number;
+                  userAgent?: string;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "account";
+                update: {
+                  accessToken?: string;
+                  accessTokenExpiresAt?: number;
+                  accountId?: string;
+                  createdAt?: number;
+                  idToken?: string;
+                  password?: string;
+                  providerId?: string;
+                  refreshToken?: string;
+                  refreshTokenExpiresAt?: number;
+                  scope?: string;
+                  updatedAt?: number;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "verification";
+                update: {
+                  createdAt?: number;
+                  expiresAt?: number;
+                  identifier?: string;
+                  updatedAt?: number;
+                  value?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "twoFactor";
+                update: {
+                  backupCodes?: string;
+                  secret?: string;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "passkey";
+                update: {
+                  aaguid?: string;
+                  backedUp?: boolean;
+                  counter?: number;
+                  createdAt?: number;
+                  credentialID?: string;
+                  deviceType?: string;
+                  name?: string;
+                  publicKey?: string;
+                  transports?: string;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "apikey";
+                update: {
+                  createdAt?: number;
+                  enabled?: boolean;
+                  expiresAt?: number;
+                  key?: string;
+                  lastRefillAt?: number;
+                  lastRequest?: number;
+                  metadata?: string;
+                  name?: string;
+                  permissions?: string;
+                  prefix?: string;
+                  rateLimitEnabled?: boolean;
+                  rateLimitMax?: number;
+                  rateLimitTimeWindow?: number;
+                  refillAmount?: number;
+                  refillInterval?: number;
+                  remaining?: number;
+                  requestCount?: number;
+                  start?: string;
+                  updatedAt?: number;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "oauthApplication";
+                update: {
+                  clientId?: string;
+                  clientSecret?: string;
+                  createdAt?: number;
+                  disabled?: boolean;
+                  icon?: string;
+                  metadata?: string;
+                  name?: string;
+                  redirectURLs?: string;
+                  type?: string;
+                  updatedAt?: number;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "oauthAccessToken";
+                update: {
+                  accessToken?: string;
+                  accessTokenExpiresAt?: number;
+                  clientId?: string;
+                  createdAt?: number;
+                  refreshToken?: string;
+                  refreshTokenExpiresAt?: number;
+                  scopes?: string;
+                  updatedAt?: number;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "oauthConsent";
+                update: {
+                  clientId?: string;
+                  consentGiven?: boolean;
+                  createdAt?: number;
+                  scopes?: string;
+                  updatedAt?: number;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "organization";
+                update: {
+                  createdAt?: number;
+                  logo?: string;
+                  metadata?: string;
+                  name?: string;
+                  slug?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "member";
+                update: {
+                  createdAt?: number;
+                  organizationId?: string;
+                  role?: string;
+                  teamId?: string;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "invitation";
+                update: {
+                  email?: string;
+                  expiresAt?: number;
+                  inviterId?: string;
+                  organizationId?: string;
+                  role?: string;
+                  status?: string;
+                  teamId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "team";
+                update: {
+                  createdAt?: number;
+                  name?: string;
+                  organizationId?: string;
+                  updatedAt?: number;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "ssoProvider";
+                update: {
+                  domain?: string;
+                  issuer?: string;
+                  oidcConfig?: string;
+                  organizationId?: string;
+                  providerId?: string;
+                  samlConfig?: string;
+                  userId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "jwks";
+                update: {
+                  createdAt?: number;
+                  privateKey?: string;
+                  publicKey?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "subscription";
+                update: {
+                  cancelAtPeriodEnd?: boolean;
+                  periodEnd?: number;
+                  periodStart?: number;
+                  plan?: string;
+                  referenceId?: string;
+                  seats?: number;
+                  status?: string;
+                  stripeCustomerId?: string;
+                  stripeSubscriptionId?: string;
+                };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "rateLimit";
+                update: { count?: number; key?: string; lastRequest?: number };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: string;
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              };
         },
         any
       >;

--- a/src/components/app/PageHeader/PageHeader.tsx
+++ b/src/components/app/PageHeader/PageHeader.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 import { tv } from "tailwind-variants";
+import { PageTitle } from "@/components/app";
 import { Link, type LinkProps } from "@/components/common";
 import { useIsMobile } from "@/hooks/useIsMobile";
 
@@ -51,6 +52,7 @@ export const PageHeader = ({
         className,
       )}
     >
+      <PageTitle title={title} />
       <div className={containerStyles({ fullWidth })}>
         <div className="flex flex-col gap-1 min-w-0">
           <div className="flex gap-2 items-center">

--- a/src/components/app/PageTitle/PageTitle.test.tsx
+++ b/src/components/app/PageTitle/PageTitle.test.tsx
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PageTitle } from "./PageTitle";
+
+describe("PageTitle", () => {
+  it("renders the title correctly with default values", () => {
+    render(<PageTitle title="Court Order" />);
+    expect(document.title).toEqual("Court Order · Namesake");
+  });
+
+  it("renders the title with custom divider", () => {
+    render(<PageTitle title="Court Order" divider=" - " />);
+    expect(document.title).toEqual("Court Order - Namesake");
+  });
+
+  it("renders the title with custom site title", () => {
+    render(<PageTitle title="Test Page" siteTitle="Namesake Beta" />);
+    expect(document.title).toEqual("Test Page · Namesake Beta");
+  });
+
+  it("hides the divider when site title is not provided", () => {
+    render(<PageTitle title="Test Page" siteTitle={null} />);
+    expect(document.title).toEqual("Test Page");
+  });
+
+  it("trims whitespace from title and site title", () => {
+    render(<PageTitle title="  Whitespace  " siteTitle="  Namesake  " />);
+    expect(document.title).toEqual("Whitespace · Namesake");
+  });
+});

--- a/src/components/app/PageTitle/PageTitle.tsx
+++ b/src/components/app/PageTitle/PageTitle.tsx
@@ -1,0 +1,26 @@
+export interface PageTitleProps {
+  /** The title of the page. */
+  title: string;
+  /** The divider between the title and the site title.
+   * @default " · "
+   */
+  divider?: string;
+  /** The site title.
+   * @default "Namesake"
+   */
+  siteTitle?: string | null;
+}
+
+function constructPageTitle({
+  title,
+  divider = " · ",
+  siteTitle = "Namesake",
+}: PageTitleProps) {
+  const suffix = siteTitle ? `${divider}${siteTitle}` : "";
+
+  return `${title.trim()}${suffix}`;
+}
+
+export function PageTitle(props: PageTitleProps) {
+  return <title>{constructPageTitle(props)}</title>;
+}

--- a/src/components/app/index.ts
+++ b/src/components/app/index.ts
@@ -6,6 +6,7 @@ export * from "./ForgotPasswordForm/ForgotPasswordForm";
 export * from "./Logo/Logo";
 export * from "./NamesakeHeader/NamesakeHeader";
 export * from "./PageHeader/PageHeader";
+export * from "./PageTitle/PageTitle";
 export * from "./PasswordStrength/PasswordStrength";
 export * from "./RegistrationForm/RegistrationForm";
 export * from "./ResetPasswordForm/ResetPasswordForm";

--- a/src/components/forms/FormContainer/FormContainer.tsx
+++ b/src/components/forms/FormContainer/FormContainer.tsx
@@ -2,6 +2,7 @@ import { ShieldCheck } from "lucide-react";
 import { Children, isValidElement, useMemo } from "react";
 import { Heading } from "react-aria-components";
 import { FormProvider, type UseFormReturn } from "react-hook-form";
+import { PageTitle } from "@/components/app";
 import { Badge, Banner, Container, Form } from "@/components/common";
 import { FormNavigation, FormSection } from "@/components/forms";
 import { JURISDICTIONS, type Jurisdiction } from "@/constants";
@@ -64,6 +65,7 @@ export function FormContainer({
 
   return (
     <FormProvider {...form}>
+      <PageTitle title={title} />
       <FormSectionContext value={{ sections }}>
         <FormNavigation title={title} jurisdiction={jurisdiction} />
         <Container className="w-full max-w-[720px] flex-1 py-16 px-6">


### PR DESCRIPTION
## What changed?
Display the page name within the tab title for all pages in the app. Resolves #704 

| Before | After |
|--------|--------|
| <img width="486" height="84" alt="CleanShot 2025-07-18 at 08 47 25@2x" src="https://github.com/user-attachments/assets/23c463a1-6a16-4694-ac03-de507fe93e7a" /> | <img width="490" height="88" alt="CleanShot 2025-07-18 at 08 47 16@2x" src="https://github.com/user-attachments/assets/cc45a9fb-611f-4341-a180-f02250712210" /> | 

## Why?
Make it easier to navigate and keep places in the app, especially if there are multiple Namesake tabs open.

## How was this change made?
Created a new `PageTitle` component which accepts a `title`, `divider`, and `siteTitle`. Divider and site title have defaults of " · " and "Namesake".

Added `PageTitle` to the `PageHeader` component and the `FormContainer` component for use across all pages.

## How was this tested?
Wrote unit tests, verified manually on pages.

## Anything else?
Yay React 19 document metadata hoisting!

There are other additions we could make to page metadata on a per-route basis but they aren't really important until more of the app is public-facing and does not require login.