### PR TITLE
fix: Resolve all console warnings during tests

### DIFF
--- a/src/components/app/ResetPasswordForm/ResetPasswordForm.test.tsx
+++ b/src/components/app/ResetPasswordForm/ResetPasswordForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ZxcvbnResult } from "@zxcvbn-ts/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -102,7 +102,7 @@ describe("ResetPasswordForm", () => {
       },
     });
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(router.navigate).toHaveBeenCalledWith({ to: "/signin" });
     });
   });

--- a/src/components/app/SignInForm/SignInForm.test.tsx
+++ b/src/components/app/SignInForm/SignInForm.test.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { authClient } from "@/main";
@@ -48,7 +48,7 @@ describe("SignInForm", () => {
     await user.click(screen.getByRole("button", { name: "Sign in" }));
 
     // Wait for the navigation to occur
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({ to: "/" });
     });
 

--- a/src/components/common/HiddenText/HiddenText.test.tsx
+++ b/src/components/common/HiddenText/HiddenText.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { HiddenText } from "./HiddenText";
@@ -55,8 +55,10 @@ describe("HiddenText", () => {
     render(<HiddenText>Secret text</HiddenText>);
 
     const checkbox = screen.getByRole("checkbox");
-    checkbox.focus();
-    await user.keyboard(" ");
+    await act(async () => {
+      checkbox.focus();
+      await user.keyboard(" ");
+    });
 
     const text = screen.getByText("Secret text");
     expect(text).toHaveAttribute("aria-hidden", "false");

--- a/src/components/common/Menu/Menu.test.tsx
+++ b/src/components/common/Menu/Menu.test.tsx
@@ -8,7 +8,7 @@ describe("Menu", () => {
     render(
       <DialogTrigger>
         <Button>Open Menu</Button>
-        <Menu>
+        <Menu aria-label="Menu">
           <MenuItem id="item1">Item 1</MenuItem>
           <MenuItem id="item2">Item 2</MenuItem>
         </Menu>

--- a/src/components/forms/RadioGroupField/RadioGroupField.tsx
+++ b/src/components/forms/RadioGroupField/RadioGroupField.tsx
@@ -39,6 +39,7 @@ export function RadioGroupField({
         control={control}
         name={name}
         shouldUnregister={true}
+        defaultValue={[]}
         render={({ field, fieldState: { invalid, error } }) => (
           <RadioGroup
             {...field}

--- a/src/components/settings/DeleteAccountSetting/DeleteAccountSetting.test.tsx
+++ b/src/components/settings/DeleteAccountSetting/DeleteAccountSetting.test.tsx
@@ -90,7 +90,7 @@ describe("DeleteAccountSetting", () => {
     await user.click(submitButton);
 
     // Wait for error message to appear and button to be re-enabled
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(screen.getByText(errorMessage)).toBeInTheDocument();
       expect(submitButton).not.toBeDisabled();
     });

--- a/src/components/settings/EditNameSetting/EditNameSetting.test.tsx
+++ b/src/components/settings/EditNameSetting/EditNameSetting.test.tsx
@@ -1,9 +1,10 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useMutation } from "convex/react";
 import { toast } from "sonner";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_DISPLAY_NAME_LENGTH } from "@/constants";
 import { EditNameSetting } from "./EditNameSetting";
 
 describe("EditNameSetting", () => {
@@ -16,6 +17,11 @@ describe("EditNameSetting", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    cleanup();
   });
 
   it("renders correct username if exists", () => {
@@ -67,7 +73,7 @@ describe("EditNameSetting", () => {
     const input = screen.getByRole("textbox", { name: "Name" });
 
     await user.clear(input);
-    await user.type(input, "a".repeat(101));
+    await user.type(input, "a".repeat(MAX_DISPLAY_NAME_LENGTH + 1));
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(screen.getByRole("alert")).toBeInTheDocument();

--- a/src/hooks/__tests__/useDecrypt.test.ts
+++ b/src/hooks/__tests__/useDecrypt.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import {
   mockDEK,
   setupEncryptionMocks,
@@ -41,9 +41,9 @@ describe("useDecrypt", () => {
 
     const { result } = renderHook(() => useDecrypt(encryptedValue));
 
-    await vi.waitFor(() => {
-      expect(result.current.decryptedValue).toBe("decrypted");
-    });
+    await waitFor(() =>
+      expect(result.current.decryptedValue).toBe("decrypted"),
+    );
     expect(result.current.error).toBe(false);
   });
 
@@ -53,19 +53,22 @@ describe("useDecrypt", () => {
 
     const { result } = renderHook(() => useDecrypt(encryptedValues));
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(result.current.decryptedValues).toEqual([
         "decrypted",
         "decrypted",
       ]);
     });
+
     expect(result.current.error).toBe(false);
   });
 
-  it("should handle undefined input", () => {
+  it("should handle undefined input", async () => {
     const { result } = renderHook(() => useDecrypt(undefined));
-    expect(result.current.decryptedValue).toBeUndefined();
-    expect(result.current.error).toBe(false);
+    await waitFor(() => {
+      expect(result.current.decryptedValue).toBeUndefined();
+      expect(result.current.error).toBe(false);
+    });
   });
 
   it("should handle decryption errors", async () => {
@@ -78,10 +81,10 @@ describe("useDecrypt", () => {
 
     const { result } = renderHook(() => useDecrypt(encryptedValue));
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(result.current.error).toBe(true);
+      expect(mockPosthog.captureException).toHaveBeenCalled();
     });
-    expect(mockPosthog.captureException).toHaveBeenCalled();
   });
 
   it("should handle missing encryption key", async () => {
@@ -102,14 +105,14 @@ describe("useDecrypt", () => {
       initialProps: initialValue,
     });
 
-    await vi.waitFor(() => {
-      expect(result.current.decryptedValue).toBe("decrypted");
-    });
+    await waitFor(() =>
+      expect(result.current.decryptedValue).toBe("decrypted"),
+    );
 
     rerender(updatedValue);
 
-    await vi.waitFor(() => {
-      expect(result.current.decryptedValue).toBe("decrypted");
-    });
+    await waitFor(() =>
+      expect(result.current.decryptedValue).toBe("decrypted"),
+    );
   });
 });

--- a/src/hooks/__tests__/useForm.test.ts
+++ b/src/hooks/__tests__/useForm.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { useMutation, useQuery } from "convex/react";
 import { usePostHog } from "posthog-js/react";
 import { toast } from "sonner";
@@ -90,7 +90,9 @@ describe("useForm", () => {
       email: "jane@example.com",
     };
 
-    await submitForm(result.current, testData);
+    await act(async () => {
+      await submitForm(result.current, testData);
+    });
 
     expect(encryptData).toHaveBeenCalledTimes(3);
     expect(mockSave).toHaveBeenCalledTimes(3);
@@ -103,7 +105,9 @@ describe("useForm", () => {
     const { result } = renderHook(() => useForm(mockFields));
     const testData = { newFirstName: "Jane" };
 
-    await submitForm(result.current, testData);
+    await act(async () => {
+      await submitForm(result.current, testData);
+    });
 
     expect(toast.error).toHaveBeenCalled();
     expect(mockPosthog.captureException).toHaveBeenCalled();
@@ -115,7 +119,9 @@ describe("useForm", () => {
     const { result } = renderHook(() => useForm(mockFields));
     const testData = { firstName: "Jane" };
 
-    await submitForm(result.current, testData);
+    await act(async () => {
+      await submitForm(result.current, testData);
+    });
 
     expect(toast.error).toHaveBeenCalledWith("No encryption key available.");
     expect(mockPosthog.captureException).toHaveBeenCalledWith(

--- a/src/hooks/__tests__/usePDFDetails.test.ts
+++ b/src/hooks/__tests__/usePDFDetails.test.ts
@@ -24,13 +24,15 @@ describe("usePDFDetails", () => {
     vi.clearAllMocks();
   });
 
-  it("returns null and no errors initially", () => {
+  it("returns null and no errors initially", async () => {
     (getPdfDefinition as ReturnType<typeof vi.fn>).mockResolvedValue(mockPDF);
     const { result } = renderHook(() =>
       usePDFDetails("cjp27-petition-to-change-name-of-adult" as PDFId),
     );
-    expect(result.current.data).toBeNull();
-    expect(result.current.errors).toEqual([]);
+    await waitFor(() => {
+      expect(result.current.data).toBeNull();
+      expect(result.current.errors).toEqual([]);
+    });
   });
 
   it("fetches and returns PDF details for a single PDFId", async () => {


### PR DESCRIPTION
## What changed?
Resolve all console warnings during testing. Fixes #694.

## Why?
There were several noisy warnings emitted when running `pnpm test`. No more.

## How was this change made?
Added `act()`, `waitFor()`, and uncontrolled/controlled fixes where necessary.

## How was this tested?
Ran tests, no more warnings!

## Anything else?
N/A